### PR TITLE
[codex] Enable DFlash on AMD ROCm with BeeLlama HIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Codex를 선택할 예정이라면 위의 `OpenAI Codex 엔진 준비` 섹션에
 
 처음 번역하거나 처음 인페인팅을 실행하면 필요한 파일을 다운로드하고 검증합니다. 이 과정은 PC 성능과 인터넷 속도에 따라 꽤 오래 걸릴 수 있습니다.
 
-- Gemma 4: GGUF 모델, mmproj, llama.cpp/beellama/Lemonade ROCm 런타임
+- Gemma 4: GGUF 모델, mmproj, llama.cpp/beellama/BeeLlama HIP/Lemonade ROCm 런타임
 - Paddle OCR: Python 런타임, PaddleOCR/PaddleOCR-VL 또는 AMD ROCm OCR 패키지, OCR 모델 캐시
 - Flux 인페인팅: Flux Klein 모델, VAE, Flux 실행기, GPU 백엔드 준비
 - OpenAI Codex: 로컬 Codex 로그인 토큰을 사용하는 openai-oauth 연결
@@ -237,7 +237,7 @@ Codex를 선택할 예정이라면 위의 `OpenAI Codex 엔진 준비` 섹션에
 
 ![OCR 진행 상태](docs/images/12-translation-ocr-progress.png)
 
-Gemma를 처음 쓰는 경우에는 모델 파일과 실행 런타임을 준비합니다. AMD 환경에서는 Lemonade ROCm 런타임을 내려받는 화면이 보일 수 있습니다.
+Gemma를 처음 쓰는 경우에는 모델 파일과 실행 런타임을 준비합니다. AMD 환경에서는 31B DFlash preset에 BeeLlama HIP 런타임을, 12B/26B mainline preset에 Lemonade ROCm 런타임을 내려받는 화면이 보일 수 있습니다.
 
 ![Gemma 실행 런타임 설치](docs/images/13-gemma-runtime-install.png)
 
@@ -355,7 +355,7 @@ AMD 지원은 번역, OCR, 인페인팅이 각각 다른 경로로 준비됩니�
 
 ### Gemma 4 on AMD
 
-지원되는 AMD GPU에서는 `AMD ROCm` Gemma 런타임을 우선 사용합니다. 앱은 GPU 이름, `rocm-smi`, Windows 장치 정보를 보고 ROCm target을 추정합니다.
+지원되는 AMD GPU에서는 `AMD ROCm` Gemma 런타임을 우선 사용합니다. 31B DFlash preset은 BeeLlama HIP/Radeon 런타임을 사용하고, 12B/26B mainline preset은 ROCm target별 Lemonade 런타임을 사용합니다. 앱은 GPU 이름, `rocm-smi`, Windows 장치 정보를 보고 ROCm target을 추정합니다.
 
 지원 target 그룹은 다음과 같습니다.
 
@@ -603,4 +603,4 @@ README의 만화 예시 화면은 [IDPF EPUB 3 Samples Project](https://github.c
 
 이 프로젝트의 앱 소스코드는 `GPL-3.0-only` 라이선스로 배포합니다. 자세한 내용은 [LICENSE](LICENSE)를 확인하세요.
 
-앱 안에서 내려받거나 함께 쓰는 모델, Python 런타임, OCR 패키지, ffmpeg, llama.cpp/beellama/Lemonade ROCm, Flux 관련 런타임은 각각 별도 라이선스와 배포 조건을 가질 수 있습니다. 릴리즈 빌드와 런타임을 재배포하거나 수정 배포할 때는 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)와 해당 구성요소의 라이선스도 함께 확인해야 합니다.
+앱 안에서 내려받거나 함께 쓰는 모델, Python 런타임, OCR 패키지, ffmpeg, llama.cpp/beellama/BeeLlama HIP/Lemonade ROCm, Flux 관련 런타임은 각각 별도 라이선스와 배포 조건을 가질 수 있습니다. 릴리즈 빌드와 런타임을 재배포하거나 수정 배포할 때는 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)와 해당 구성요소의 라이선스도 함께 확인해야 합니다.

--- a/src/main/appPaths.ts
+++ b/src/main/appPaths.ts
@@ -159,6 +159,7 @@ function llamaServerBinaryName(): string {
 function bundledLlamaServerCandidates(toolsDir: string): string[] {
   const serverBinary = llamaServerBinaryName();
   const knownRuntimeDirs = [
+    "beellama-v0.3.1-hip-radeon",
     "beellama-v0.2.0-cuda13.1",
     "beellama-v0.2.0-cuda12.4",
     "llama-b9547-cuda13.3",

--- a/src/main/runtime/resolve-llama-runtime.cjs
+++ b/src/main/runtime/resolve-llama-runtime.cjs
@@ -13,6 +13,7 @@ function binaryName() {
 function bundledServerCandidates(toolsDir) {
   const serverBinary = binaryName();
   const knownRuntimeDirs = [
+    "beellama-v0.3.1-hip-radeon",
     "beellama-v0.2.0-cuda13.1",
     "beellama-v0.2.0-cuda12.4",
     "lemonade-llama-b1291-rocm-gfx120X",

--- a/src/main/runtime/simple-page-launch-args.cjs
+++ b/src/main/runtime/simple-page-launch-args.cjs
@@ -268,12 +268,14 @@ function shouldUseBeellamaGemmaLaunch(options = {}) {
   )
     .trim()
     .toLowerCase();
-  if (
-    ["rocm", "hip", "amd", "amd-rocm", "vulkan", "vk", "amd-vulkan"].includes(
-      profile,
-    )
-  ) {
+  if (["vulkan", "vk", "amd-vulkan"].includes(profile)) {
     return false;
+  }
+  if (resolveConfiguredModelSource(options) === "local") {
+    const localModelPath = resolveConfiguredLocalModelPath(options);
+    if (!/gemma[-_]?4/i.test(path.basename(localModelPath || ""))) {
+      return false;
+    }
   }
   if (isMainlineGemmaModel(options)) {
     return false;
@@ -284,13 +286,16 @@ function shouldUseBeellamaGemmaLaunch(options = {}) {
       defaultServerPath(options) ||
       "",
   );
-  if (/rocm|hip|vulkan/i.test(serverPath)) {
-    return false;
-  }
   const isBeellamaRuntime = /beellama/i.test(serverPath);
   const isGemma4Model = looksLikeGemma4Model(options);
   if (isBeellamaRuntime && isGemma4Model) {
     return true;
+  }
+  if (
+    ["rocm", "hip", "amd", "amd-rocm"].includes(profile) ||
+    /rocm|hip|vulkan/i.test(serverPath)
+  ) {
+    return false;
   }
   if (resolveConfiguredModelSource(options) === "local") {
     const localModelPath = resolveConfiguredLocalModelPath(options);
@@ -307,13 +312,15 @@ function shouldUseBeellamaGemmaLaunch(options = {}) {
  * @returns {boolean}
  */
 function looksLikeGemma4Model(options = {}) {
-  const parts = [
-    resolveConfiguredModelRepo(options),
-    resolveConfiguredModelFile(options),
-    resolveConfiguredLocalModelPath(options),
-    resolveConfiguredMmprojRepo(options),
-    resolveConfiguredMmprojFile(options),
-  ];
+  const parts =
+    resolveConfiguredModelSource(options) === "local"
+      ? [resolveConfiguredLocalModelPath(options)]
+      : [
+          resolveConfiguredModelRepo(options),
+          resolveConfiguredModelFile(options),
+          resolveConfiguredMmprojRepo(options),
+          resolveConfiguredMmprojFile(options),
+        ];
   return parts.some((part) => /gemma[-_]?4/i.test(String(part || "")));
 }
 

--- a/src/main/runtime/simple-page-llama-runtimes.cjs
+++ b/src/main/runtime/simple-page-llama-runtimes.cjs
@@ -51,6 +51,30 @@ const BEELLAMA_LLAMA_RUNTIME_CUDA13 = {
   ],
 };
 
+const BEELLAMA_LLAMA_RUNTIME_HIP_RADEON = {
+  id: "beellama-v0.3.1-hip-radeon",
+  kind: "beellama-hip",
+  backend: "rocm",
+  dir: "beellama-v0.3.1-hip-radeon",
+  archive: "beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+  url: "https://github.com/Anbeeld/beellama.cpp/releases/download/v0.3.1/beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+  archives: [
+    {
+      archive: "beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+      url: "https://github.com/Anbeeld/beellama.cpp/releases/download/v0.3.1/beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+    },
+  ],
+  requiredFiles: [
+    "llama-server.exe",
+    "llama-server-impl.dll",
+    "llama.dll",
+    "ggml-hip.dll",
+    "rocblas.dll",
+    ["libhipblas.dll", "hipblas.dll"],
+    "libhipblaslt.dll",
+  ],
+};
+
 const MAINLINE_LLAMA_RUNTIME_CUDA12 = {
   id: "llama-b9547-cuda12.4",
   kind: "mainline",
@@ -203,6 +227,8 @@ const LLAMA_RUNTIME_FILES = new Set([
   "ggml-vulkan.so",
   "ggml.dll",
   "hipblas.dll",
+  "libhipblas.dll",
+  "libhipblaslt.dll",
   "hiprtc0506.dll",
   "hiprtc-builtins.dll",
   "amdhip64.dll",
@@ -252,6 +278,7 @@ function shouldExtractLlamaRuntimeFile(fileName, relativePath = fileName) {
 module.exports = {
   BEELLAMA_LLAMA_RUNTIME_CUDA12,
   BEELLAMA_LLAMA_RUNTIME_CUDA13,
+  BEELLAMA_LLAMA_RUNTIME_HIP_RADEON,
   LLAMA_RUNTIME_FILES,
   LLAMA_RUNTIME_MARKER_FILE,
   MAINLINE_LLAMA_RUNTIME_CUDA12,

--- a/src/main/runtime/simple-page-runtime-paths.cjs
+++ b/src/main/runtime/simple-page-runtime-paths.cjs
@@ -18,6 +18,7 @@ const {
 const {
   BEELLAMA_LLAMA_RUNTIME_CUDA12,
   BEELLAMA_LLAMA_RUNTIME_CUDA13,
+  BEELLAMA_LLAMA_RUNTIME_HIP_RADEON,
   MAINLINE_LLAMA_RUNTIME_CUDA12,
   MAINLINE_LLAMA_RUNTIME_CUDA13,
   MAINLINE_LLAMA_RUNTIME_VULKAN,
@@ -28,10 +29,10 @@ const {
 } = require("./simple-page-amd-rocm-target.cjs");
 const {
   resolveConfiguredLocalModelPath,
+  resolveConfiguredLocalMmprojPath,
   resolveConfiguredModelFile,
   resolveConfiguredModelRepo,
-  resolveConfiguredMmprojFile,
-  resolveConfiguredMmprojRepo,
+  resolveConfiguredModelSource,
 } = require("./simple-page-model-config.cjs");
 const {
   isLikelyPackagedToolsDir,
@@ -318,38 +319,34 @@ function resolveLlamaRuntimeProfile(options = {}) {
 }
 
 /** @param {RuntimePathOptions} [options] */
-function isGemma26BModel(options = {}) {
-  const parts = [
+function configuredGemmaModelParts(options = {}) {
+  if (resolveConfiguredModelSource(options) === "local") {
+    return [
+      resolveConfiguredLocalModelPath(options),
+      resolveConfiguredLocalMmprojPath(options),
+    ];
+  }
+  return [
     resolveConfiguredModelRepo(options),
     resolveConfiguredModelFile(options),
-    resolveConfiguredLocalModelPath(options),
-    resolveConfiguredMmprojRepo(options),
-    resolveConfiguredMmprojFile(options),
   ];
+}
+
+/** @param {RuntimePathOptions} [options] */
+function isGemma26BModel(options = {}) {
+  const parts = configuredGemmaModelParts(options);
   return parts.some((part) => /gemma[-_]?4[-_]?26b/i.test(String(part || "")));
 }
 
 /** @param {RuntimePathOptions} [options] */
 function isGemma12BModel(options = {}) {
-  const parts = [
-    resolveConfiguredModelRepo(options),
-    resolveConfiguredModelFile(options),
-    resolveConfiguredLocalModelPath(options),
-    resolveConfiguredMmprojRepo(options),
-    resolveConfiguredMmprojFile(options),
-  ];
+  const parts = configuredGemmaModelParts(options);
   return parts.some((part) => /gemma[-_]?4[-_]?12b/i.test(String(part || "")));
 }
 
 /** @param {RuntimePathOptions} [options] */
 function isGemma31BModel(options = {}) {
-  const parts = [
-    resolveConfiguredModelRepo(options),
-    resolveConfiguredModelFile(options),
-    resolveConfiguredLocalModelPath(options),
-    resolveConfiguredMmprojRepo(options),
-    resolveConfiguredMmprojFile(options),
-  ];
+  const parts = configuredGemmaModelParts(options);
   return parts.some((part) => /gemma[-_]?4[-_]?31b/i.test(String(part || "")));
 }
 
@@ -370,6 +367,9 @@ function isBuiltInGemmaRuntimeModel(options = {}) {
 function resolvePreferredLlamaRuntime(options = {}) {
   const profile = resolveLlamaRuntimeProfile(options);
   if (profile === "rocm") {
+    if (isGemma31BModel(options)) {
+      return BEELLAMA_LLAMA_RUNTIME_HIP_RADEON;
+    }
     const rocmTarget = resolveAmdRocmTargetFromOptions(options);
     if (!rocmTarget) {
       throw createDetailedError(

--- a/src/main/runtime/simple-page-server-lifecycle.cjs
+++ b/src/main/runtime/simple-page-server-lifecycle.cjs
@@ -433,7 +433,7 @@ async function verifyLlamaRuntimePreflight(serverPath, options = {}) {
     serverPath,
     options,
     ["--list-devices"],
-    20000,
+    resolveLlamaRuntimePreflightTimeoutMs(preferredRuntime, options),
   );
   const output = `${result.stdout}\n${result.stderr}`;
   if (result.code !== 0) {
@@ -465,6 +465,30 @@ async function verifyLlamaRuntimePreflight(serverPath, options = {}) {
       },
     );
   }
+}
+
+/**
+ * @param {Partial<LlamaRuntimeDescriptor>} [runtime]
+ * @param {RuntimeOptions & { llamaRuntimePreflightTimeoutMs?: unknown }} [options]
+ * @returns {number}
+ */
+function resolveLlamaRuntimePreflightTimeoutMs(runtime = {}, options = {}) {
+  const configured = Number(
+    options.llamaRuntimePreflightTimeoutMs ??
+      runtimeOverrideEnv("MGT_LLAMA_RUNTIME_PREFLIGHT_TIMEOUT_MS", options) ??
+      runtimeOverrideEnv(
+        "MANGA_TRANSLATOR_LLAMA_RUNTIME_PREFLIGHT_TIMEOUT_MS",
+        options,
+      ),
+  );
+  if (Number.isFinite(configured) && configured > 0) {
+    return Math.max(1000, Math.round(configured));
+  }
+  const backend = String(runtime.backend || "cuda").toLowerCase();
+  if (backend === "rocm" || backend === "hip") {
+    return 120000;
+  }
+  return 20000;
 }
 
 /** @param {unknown} [backend] */
@@ -621,6 +645,7 @@ async function stopServer(server) {
 module.exports = {
   buildLaunchArgs,
   buildLlamaServerEnv,
+  resolveLlamaRuntimePreflightTimeoutMs,
   startServer,
   stopServer,
 };

--- a/src/main/settings/gemmaModelPresets.ts
+++ b/src/main/settings/gemmaModelPresets.ts
@@ -107,7 +107,7 @@ function is12BGemmaModel(
   );
 }
 
-function is31BGemmaModel(
+export function is31BGemmaModel(
   model: Pick<AppSettings["gemma"], "modelRepo" | "modelFile">,
 ): boolean {
   return (

--- a/src/main/settings/translationLlamaServerPath.ts
+++ b/src/main/settings/translationLlamaServerPath.ts
@@ -2,7 +2,11 @@ import { join } from "node:path";
 import type { AppSettings } from "../../shared/settingsTypes";
 import { normalizeAmdRocmTarget } from "../gpuInfo";
 import type { TranslationOptionPaths } from "./appSettingsTypes";
-import { isBuiltInGemmaModel, isMainlineGemmaModel } from "./gemmaModelPresets";
+import {
+  is31BGemmaModel,
+  isBuiltInGemmaModel,
+  isMainlineGemmaModel,
+} from "./gemmaModelPresets";
 import {
   isRocmLlamaRuntimeProfile,
   isRtx50LlamaRuntimeProfile,
@@ -11,6 +15,7 @@ import {
 
 const BEELLAMA_LLAMA_RUNTIME_DIR_CUDA12 = "beellama-v0.2.0-cuda12.4";
 const BEELLAMA_LLAMA_RUNTIME_DIR_CUDA13 = "beellama-v0.2.0-cuda13.1";
+const BEELLAMA_LLAMA_RUNTIME_DIR_HIP_RADEON = "beellama-v0.3.1-hip-radeon";
 const MAINLINE_LLAMA_RUNTIME_DIR_CUDA12 = "llama-b9547-cuda12.4";
 const MAINLINE_LLAMA_RUNTIME_DIR_CUDA13 = "llama-b9547-cuda13.3";
 const LEMONADE_LLAMA_RUNTIME_ROCM_RELEASE = "b1291";
@@ -28,7 +33,12 @@ export function resolveDefaultLlamaServerPathForGemma(
   const binaryName =
     process.platform === "win32" ? "llama-server.exe" : "llama-server";
   if (isRocmLlamaRuntimeProfile(llamaRuntimeProfile)) {
-    return resolveRocmLlamaServerPath(paths, binaryName, llamaRocmTarget);
+    return resolveRocmLlamaServerPath(
+      paths,
+      binaryName,
+      gemma,
+      llamaRocmTarget,
+    );
   }
   if (isVulkanLlamaRuntimeProfile(llamaRuntimeProfile)) {
     return join(
@@ -59,8 +69,17 @@ function shouldUseBundledLlamaServer(gemma: AppSettings["gemma"]): boolean {
 function resolveRocmLlamaServerPath(
   paths: TranslationOptionPaths,
   binaryName: string,
+  gemma: AppSettings["gemma"],
   llamaRocmTarget?: string,
 ): string {
+  if (is31BGemmaModel(gemma)) {
+    return join(
+      paths.dataRoot,
+      "tools",
+      BEELLAMA_LLAMA_RUNTIME_DIR_HIP_RADEON,
+      binaryName,
+    );
+  }
   const rocmTarget = normalizeAmdRocmTarget(llamaRocmTarget) ?? "unknown";
   return join(
     paths.dataRoot,

--- a/tests/appSettings.test.ts
+++ b/tests/appSettings.test.ts
@@ -511,7 +511,7 @@ describe("app settings helpers", () => {
     );
   });
 
-  it("routes known AMD GPUs to Lemonade ROCm runtime targets", () => {
+  it("routes known AMD GPUs with the full DFlash preset to BeeLlama HIP", () => {
     const amdDefaults = resolveDefaultAppSettings(
       {},
       {
@@ -548,7 +548,7 @@ describe("app settings helpers", () => {
       join(
         "C:/app-data",
         "tools",
-        "lemonade-llama-b1291-rocm-gfx110X",
+        "beellama-v0.3.1-hip-radeon",
         "llama-server.exe",
       ),
     );

--- a/tests/llamaRuntimePaths.test.ts
+++ b/tests/llamaRuntimePaths.test.ts
@@ -3,6 +3,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_GEMMA_MODEL_FILE,
+  DEFAULT_GEMMA_MODEL_REPO,
+  GEMMA_26B_MODEL_FILE_IQ3_S,
+  GEMMA_26B_MODEL_REPO,
+} from "../src/shared/modelPresets";
 
 const require = createRequire(import.meta.url);
 const { inferAmdRocmTargetFromText } =
@@ -37,6 +43,13 @@ const {
     backend: string;
   };
 };
+const { resolveLlamaRuntimePreflightTimeoutMs } =
+  require("../src/main/runtime/simple-page-server-lifecycle.cjs") as {
+    resolveLlamaRuntimePreflightTimeoutMs: (
+      runtime?: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => number;
+  };
 
 describe("llama runtime path selection", () => {
   it("infers Azure AMD Radeon PRO V710 style hardware text as gfx110X", () => {
@@ -52,6 +65,8 @@ describe("llama runtime path selection", () => {
     const runtime = resolvePreferredLlamaRuntime({
       llamaRuntimeProfile: "rocm",
       llamaRocmTarget: "gfx1201",
+      modelRepo: GEMMA_26B_MODEL_REPO,
+      modelFile: GEMMA_26B_MODEL_FILE_IQ3_S,
     });
 
     expect(runtime.backend).toBe("rocm");
@@ -63,10 +78,75 @@ describe("llama runtime path selection", () => {
     );
   });
 
+  it("selects BeeLlama HIP Radeon for the 31B ROCm DFlash preset", () => {
+    const runtime = resolvePreferredLlamaRuntime({
+      llamaRuntimeProfile: "rocm",
+      llamaRocmTarget: "gfx110X",
+      modelRepo: DEFAULT_GEMMA_MODEL_REPO,
+      modelFile: DEFAULT_GEMMA_MODEL_FILE,
+    });
+
+    expect(runtime.backend).toBe("rocm");
+    expect(runtime.id).toBe("beellama-v0.3.1-hip-radeon");
+    expect(runtime.dir).toBe("beellama-v0.3.1-hip-radeon");
+    expect(runtime.archive).toBe("beellama-v0.3.1-bin-win-hip-radeon-x64.zip");
+    expect(runtime.url).toBe(
+      "https://github.com/Anbeeld/beellama.cpp/releases/download/v0.3.1/beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+    );
+  });
+
+  it("does not require a target-specific Lemonade archive for 31B ROCm DFlash", () => {
+    const runtime = resolvePreferredLlamaRuntime({
+      llamaRuntimeProfile: "rocm",
+      modelRepo: DEFAULT_GEMMA_MODEL_REPO,
+      modelFile: DEFAULT_GEMMA_MODEL_FILE,
+      disableHostRocmTargetDetection: true,
+    });
+
+    expect(runtime.id).toBe("beellama-v0.3.1-hip-radeon");
+    expect(runtime.archive).toBe("beellama-v0.3.1-bin-win-hip-radeon-x64.zip");
+  });
+
+  it("accepts BeeLlama HIP Radeon runtime files for DFlash", () => {
+    const runtime = resolvePreferredLlamaRuntime({
+      llamaRuntimeProfile: "rocm",
+      llamaRocmTarget: "gfx110X",
+      modelRepo: DEFAULT_GEMMA_MODEL_REPO,
+      modelFile: DEFAULT_GEMMA_MODEL_FILE,
+    });
+    const runtimeDir = mkdtempSync(join(tmpdir(), "mgt-beellama-hip-"));
+    try {
+      const rocblasDir = join(runtimeDir, "rocblas", "library");
+      const hipblasltDir = join(runtimeDir, "hipblaslt", "library");
+      mkdirSync(rocblasDir, { recursive: true });
+      mkdirSync(hipblasltDir, { recursive: true });
+      for (const fileName of [
+        "llama-server.exe",
+        "llama-server-impl.dll",
+        "llama.dll",
+        "ggml-hip.dll",
+        "rocblas.dll",
+        "libhipblas.dll",
+        "libhipblaslt.dll",
+      ]) {
+        writeFileSync(join(runtimeDir, fileName), "");
+      }
+      writeFileSync(join(rocblasDir, "TensileLibrary_Type_HH_gfx1101.dat"), "");
+      writeFileSync(join(hipblasltDir, "Kernels.so-000-gfx1101.hsaco"), "");
+
+      expect(missingRequiredLlamaRuntimeFiles(runtimeDir, runtime)).toEqual([]);
+      expect(hasRequiredLlamaRuntimeFiles(runtimeDir, runtime)).toBe(true);
+    } finally {
+      rmSync(runtimeDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts ROCm 7 HIP runtime DLL names from Lemonade archives", () => {
     const runtime = resolvePreferredLlamaRuntime({
       llamaRuntimeProfile: "rocm",
       llamaRocmTarget: "gfx110X",
+      modelRepo: GEMMA_26B_MODEL_REPO,
+      modelFile: GEMMA_26B_MODEL_FILE_IQ3_S,
     });
     const runtimeDir = mkdtempSync(join(tmpdir(), "mgt-rocm-runtime-"));
     try {
@@ -96,6 +176,8 @@ describe("llama runtime path selection", () => {
     const runtime = resolvePreferredLlamaRuntime({
       llamaRuntimeProfile: "rocm",
       llamaRocmTarget: "gfx110X",
+      modelRepo: GEMMA_26B_MODEL_REPO,
+      modelFile: GEMMA_26B_MODEL_FILE_IQ3_S,
     });
     const runtimeDir = mkdtempSync(
       join(tmpdir(), "mgt-rocm-runtime-missing-kernels-"),
@@ -163,7 +245,30 @@ describe("llama runtime path selection", () => {
 
   it("does not guess an AMD ROCm runtime when the GPU target is unknown", () => {
     expect(() =>
-      resolvePreferredLlamaRuntime({ llamaRuntimeProfile: "rocm" }),
+      resolvePreferredLlamaRuntime({
+        llamaRuntimeProfile: "rocm",
+        modelRepo: GEMMA_26B_MODEL_REPO,
+        modelFile: GEMMA_26B_MODEL_FILE_IQ3_S,
+        disableHostRocmTargetDetection: true,
+      }),
     ).toThrow(/AMD GPU/);
+  });
+
+  it("gives ROCm/HIP runtime probes enough time for first-load initialization", () => {
+    expect(
+      resolveLlamaRuntimePreflightTimeoutMs({ backend: "rocm" }),
+    ).toBeGreaterThanOrEqual(120000);
+    expect(
+      resolveLlamaRuntimePreflightTimeoutMs({ backend: "hip" }),
+    ).toBeGreaterThanOrEqual(120000);
+    expect(resolveLlamaRuntimePreflightTimeoutMs({ backend: "vulkan" })).toBe(
+      20000,
+    );
+    expect(
+      resolveLlamaRuntimePreflightTimeoutMs(
+        { backend: "rocm" },
+        { llamaRuntimePreflightTimeoutMs: 45000 },
+      ),
+    ).toBe(45000);
   });
 });

--- a/tests/runtimeLaunchArgs.test.ts
+++ b/tests/runtimeLaunchArgs.test.ts
@@ -375,6 +375,47 @@ describe("runtime launch argument contracts", () => {
     expect(args).not.toContain("--chat-template-kwargs");
   });
 
+  it("keeps BeeLlama DFlash launch flags for the ROCm HIP runtime", () => {
+    const args = buildLaunchArgs({
+      port: 18180,
+      fitTargetMb: 4096,
+      ctx: 16384,
+      batch: 2048,
+      ubatch: 1536,
+      cacheTypeK: "q4_0",
+      cacheTypeV: "q4_0",
+      ctxCheckpoints: 0,
+      mmprojOffload: false,
+      enableMetrics: true,
+      enablePerf: true,
+      llamaRuntimeProfile: "rocm",
+      serverPath:
+        "C:/app-data/tools/beellama-v0.3.1-hip-radeon/llama-server.exe",
+      useDraft: true,
+      draftModelRepo: DEFAULT_DRAFT_REPO,
+      draftModelFile: DEFAULT_DRAFT_FILE,
+      imageMinTokens: 1024,
+      imageMaxTokens: 1024,
+      modelRepo: DEFAULT_31B_REPO,
+      modelFile: DEFAULT_31B_FILE,
+      mmprojRepo: DEFAULT_MMPROJ_REPO,
+      mmprojFile: DEFAULT_MMPROJ_FILE,
+    });
+
+    expect(args).toContain("--spec-type");
+    expect(args).toContain("dflash");
+    expect(args).toContain("--spec-dflash-cross-ctx");
+    expect(args).toContain("--spec-branch-budget");
+    expect(args).toContain("--kv-unified");
+    expect(args).toContain("--jinja");
+    expect(args).toContain("--no-mmap");
+    expect(args).toContain("--mlock");
+    expect(args).toContain("--no-host");
+    expect(args).not.toContain("--fit");
+    expect(args).not.toContain("--no-cache-prompt");
+    expect(args).not.toContain("--no-warmup");
+  });
+
   it("launches from app-managed HF cache files after direct download", () => {
     const hubCacheDir = createTempDir("hf-managed-cache-");
     const options = {


### PR DESCRIPTION
## Summary
- add the BeeLlama v0.3.1 HIP/Radeon runtime descriptor and route the 31B AMD ROCm DFlash preset to it
- keep 12B/26B mainline ROCm presets on the existing Lemonade target-specific runtimes
- preserve DFlash and BeeLlama launch flags for HIP/Radeon paths, while avoiding Lemonade receiving unsupported `--spec-type dflash`
- document the AMD runtime split and cover the selection/launch behavior with tests

## Root cause
The full 31B ROCm preset enabled the DFlash draft model, but the bundled Lemonade ROCm llama-server only accepts mainline speculative types such as draft-simple, draft-mtp, and ngram variants. Passing `--spec-type dflash` to Lemonade makes llama-server exit before readiness.

## Validation
- `npm test -- tests/llamaRuntimePaths.test.ts tests/runtimeLaunchArgs.test.ts tests/appSettings.test.ts tests/runtimeModelLaunch.test.ts`
- `npm run lint`
- `npx prettier --check README.md src/main/appPaths.ts src/main/runtime/resolve-llama-runtime.cjs src/main/runtime/simple-page-launch-args.cjs src/main/runtime/simple-page-llama-runtimes.cjs src/main/runtime/simple-page-runtime-paths.cjs src/main/settings/gemmaModelPresets.ts src/main/settings/translationLlamaServerPath.ts tests/appSettings.test.ts tests/llamaRuntimePaths.test.ts tests/runtimeLaunchArgs.test.ts`
- `git diff --check`

## Notes
Full `npm run typecheck`, `npm run typecheck:js`, and full `npm test` are currently blocked by existing repository issues unrelated to this change, primarily missing `src/main/library/*Facade` modules referenced by `src/main/library.ts`.