### PR TITLE
fix: extract verified macOS runtime symlinks safely

### DIFF
--- a/scripts/prepare-mac-runtime.cjs
+++ b/scripts/prepare-mac-runtime.cjs
@@ -11,7 +11,9 @@ const {
   mkdir,
   readlink,
   readdir,
+  realpath,
   rm,
+  symlink,
 } = require("node:fs/promises");
 const https = require("node:https");
 const path = require("node:path");
@@ -142,11 +144,19 @@ function assertSafeArchiveEntry(entryPath, linkPath = "") {
 async function extractTarSafely(archivePath, outputDir) {
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
+  /** @type {Array<{ entryPath: string; linkPath: string }>} */
+  const symbolicLinks = [];
   await tar.t({
     file: archivePath,
     strict: true,
     onentry(entry) {
       assertSafeArchiveEntry(entry.path, entry.linkpath);
+      if (entry.type === "SymbolicLink") {
+        symbolicLinks.push({
+          entryPath: String(entry.path),
+          linkPath: String(entry.linkpath),
+        });
+      }
     },
   });
   await tar.x({
@@ -154,7 +164,21 @@ async function extractTarSafely(archivePath, outputDir) {
     cwd: outputDir,
     strict: true,
     preservePaths: false,
+    filter(_entryPath, entry) {
+      const tarEntry = /** @type {{ type?: string }} */ (entry);
+      return tarEntry.type !== "SymbolicLink";
+    },
   });
+  for (const link of symbolicLinks) {
+    const linkPath = path.resolve(outputDir, link.entryPath);
+    if (!isSameOrDescendant(outputDir, linkPath)) {
+      throw new Error(
+        `Refusing to create archive symlink outside root: ${linkPath}`,
+      );
+    }
+    await mkdir(path.dirname(linkPath), { recursive: true });
+    await symlink(link.linkPath, linkPath);
+  }
   await assertSymlinksStayInside(outputDir, outputDir);
 }
 
@@ -166,7 +190,16 @@ async function assertSymlinksStayInside(rootDir, currentDir) {
     if (metadata.isSymbolicLink()) {
       const target = await readlink(entryPath);
       const resolvedTarget = path.resolve(path.dirname(entryPath), target);
-      if (!isSameOrDescendant(rootDir, resolvedTarget)) {
+      let realTarget;
+      try {
+        realTarget = await realpath(entryPath);
+      } catch (cause) {
+        throw new Error(`Extracted symlink is broken: ${entryPath}`, { cause });
+      }
+      if (
+        !isSameOrDescendant(rootDir, resolvedTarget) ||
+        !isSameOrDescendant(rootDir, realTarget)
+      ) {
         throw new Error(
           `Extracted symlink escapes root: ${entryPath} -> ${target}`,
         );


### PR DESCRIPTION
## Root cause

The official llama.cpp b9547 macOS arm64 archive contains an in-root dylib symlink chain. Node tar's extraction guard rejects creating a symlink whose target is itself a symlink, even after the archive metadata passed the existing traversal checks.

## Fix

- validate every archive path and link target before writing
- extract regular entries with all symbolic links filtered out
- create only prevalidated relative symlinks afterward
- verify both lexical and real symlink targets stay inside the extraction root and reject broken links

## Validation

- `npm run typecheck:js`
- `vitest run tests/macPackaging.test.ts --maxWorkers=1` (5 passed)
- failed packaging run: https://github.com/ucx0204/CarrotMangaTranslator/actions/runs/29639156509