### PR TITLE
fix: require complete macOS release artifacts

### DIFF
--- a/.github/workflows/mac-alpha.yml
+++ b/.github/workflows/mac-alpha.yml
@@ -93,6 +93,17 @@ jobs:
       - name: Build and verify arm64 DMG and ZIP
         run: npm run dist:mac:alpha
 
+      - name: Confirm verified release artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmg_files=(dist/*-macOS-arm64-alpha.dmg)
+          zip_files=(dist/*-macOS-arm64-alpha.zip)
+          [[ "${#dmg_files[@]}" -eq 1 ]] || { echo "Expected exactly one Alpha DMG, found ${#dmg_files[@]}" >&2; exit 1; }
+          [[ "${#zip_files[@]}" -eq 1 ]] || { echo "Expected exactly one Alpha ZIP, found ${#zip_files[@]}" >&2; exit 1; }
+          test -s dist/SHA256SUMS-mac-alpha.txt
+
       - name: Resolve Alpha release metadata
         id: release_meta
         shell: bash

--- a/scripts/dist-mac-alpha.cjs
+++ b/scripts/dist-mac-alpha.cjs
@@ -83,6 +83,21 @@ function notarizeAndStapleDiskImage() {
   run("xcrun", ["stapler", "staple", diskImages[0]]);
 }
 
+/** @param {string[]} artifactPaths */
+function assertMacReleaseArtifacts(artifactPaths) {
+  const diskImages = artifactPaths.filter((filePath) =>
+    filePath.endsWith(".dmg"),
+  );
+  const zipArchives = artifactPaths.filter((filePath) =>
+    filePath.endsWith(".zip"),
+  );
+  if (diskImages.length !== 1 || zipArchives.length !== 1) {
+    throw new Error(
+      `electron-builder returned DMG=${diskImages.length} ZIP=${zipArchives.length}: ${artifactPaths.join(", ") || "no artifacts"}`,
+    );
+  }
+}
+
 async function main() {
   if (process.platform !== "darwin" || process.arch !== "arm64") {
     throw new Error("The Apple Silicon Alpha must be built on macOS arm64.");
@@ -103,11 +118,12 @@ async function main() {
   run("npm", ["run", "build"], buildEnv);
 
   const { Arch, Platform, build } = require("electron-builder");
-  await build({
+  const artifactPaths = await build({
     targets: Platform.MAC.createTarget(["dmg", "zip"], Arch.arm64),
     config: "electron-builder.config.cjs",
     publish: "never",
   });
+  assertMacReleaseArtifacts(artifactPaths);
   notarizeAndStapleDiskImage();
   run(process.execPath, ["scripts/verify-mac-package.cjs"], buildEnv);
 }

--- a/scripts/prepare-mac-runtime.cjs
+++ b/scripts/prepare-mac-runtime.cjs
@@ -344,6 +344,10 @@ async function stagePythonAndPaddle() {
     ],
     { PYTHONNOUSERSITE: "1" },
   );
+  const removedWindowsFiles = await removeWindowsRuntimeFiles(installRoot);
+  console.log(
+    `[mac-runtime] removed ${removedWindowsFiles.length} Windows-only Python launcher/library files`,
+  );
   const pythonTarget = path.join(stagingTools, "python");
   await cp(installRoot, pythonTarget, {
     recursive: true,
@@ -354,6 +358,21 @@ async function stagePythonAndPaddle() {
   console.log(
     `[mac-runtime] staged CPython ${asset.version} with ${MAC_RUNTIME_MANIFEST.ocrPackages.join(", ")}`,
   );
+}
+
+/** @param {string} currentDir @returns {Promise<string[]>} */
+async function removeWindowsRuntimeFiles(currentDir) {
+  const removed = [];
+  for (const entry of await readdir(currentDir, { withFileTypes: true })) {
+    const entryPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      removed.push(...(await removeWindowsRuntimeFiles(entryPath)));
+    } else if (entry.isFile() && /\.(?:exe|dll)$/i.test(entry.name)) {
+      await rm(entryPath, { force: true });
+      removed.push(entryPath);
+    }
+  }
+  return removed;
 }
 
 async function stageFfmpeg() {
@@ -469,6 +488,7 @@ module.exports = {
   assertSafeArchiveEntry,
   extractTarSafely,
   isSameOrDescendant,
+  removeWindowsRuntimeFiles,
   sha256File,
 };
 

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -1,6 +1,14 @@
 import { createRequire } from "node:module";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = join(__dirname, "..");
@@ -20,9 +28,10 @@ const { MAC_RUNTIME_MANIFEST } =
       }>;
     };
   };
-const { assertSafeArchiveEntry } =
+const { assertSafeArchiveEntry, removeWindowsRuntimeFiles } =
   require("../scripts/prepare-mac-runtime.cjs") as {
     assertSafeArchiveEntry: (entryPath: string, linkPath?: string) => void;
+    removeWindowsRuntimeFiles: (currentDir: string) => Promise<string[]>;
   };
 
 describe("Apple Silicon Alpha packaging", () => {
@@ -88,6 +97,29 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(() =>
       assertSafeArchiveEntry("runtime/link", "../../outside"),
     ).toThrow("escapes extraction root");
+  });
+
+  it("removes Windows-only launchers from the bundled macOS Python runtime", async () => {
+    const runtimeDir = mkdtempSync(join(tmpdir(), "mgt-mac-python-runtime-"));
+    try {
+      const packageDir = join(runtimeDir, "lib", "site-packages", "distlib");
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(join(packageDir, "t64.exe"), "windows launcher");
+      writeFileSync(join(packageDir, "native.dll"), "windows library");
+      writeFileSync(join(packageDir, "native.so"), "mac extension");
+
+      const removed = await removeWindowsRuntimeFiles(runtimeDir);
+
+      expect(removed.map((filePath) => basename(filePath)).sort()).toEqual([
+        "native.dll",
+        "t64.exe",
+      ]);
+      expect(existsSync(join(packageDir, "native.so"))).toBe(true);
+      expect(existsSync(join(packageDir, "t64.exe"))).toBe(false);
+      expect(existsSync(join(packageDir, "native.dll"))).toBe(false);
+    } finally {
+      rmSync(runtimeDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps Windows resources out of the arm64 app configuration", () => {
@@ -158,6 +190,7 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(workflow).toContain("MGT_MAC_SIGNING_MODE=developer-id");
     expect(workflow).toContain("--prerelease");
     expect(workflow).toContain("SHA256SUMS-mac-alpha.txt");
+    expect(workflow).toContain("Confirm verified release artifacts");
     expect(workflow).toContain("MAC_ALPHA_TEST_CHECKLIST.md");
     expect(workflow).toContain("mac-alpha-ui-1440x900.png");
     expect(workflow).toContain("mac-alpha-ui-1240x760.png");


### PR DESCRIPTION
## Root cause

The bundled standalone Python acquired Windows launcher stubs from pip/setuptools (`*.exe`). The macOS `afterPack` guard correctly rejected them, but electron-builder returned no release artifacts and the workflow still reached release creation.

## Fix

- remove every `.exe` and `.dll` recursively from the staged macOS Python runtime after package installation and import verification
- require electron-builder to return exactly one DMG and one ZIP
- add a shell gate requiring the expected DMG, ZIP, and non-empty SHA256 manifest before release metadata or publication
- cover Windows-file pruning with a filesystem test

## Validation

- `npm run typecheck:js`
- `vitest run tests/macPackaging.test.ts --maxWorkers=1` (6 passed)
- workflow YAML parse
- packaging reached release publication in https://github.com/ucx0204/CarrotMangaTranslator/actions/runs/29639804949