### PR TITLE
Fix unsigned macOS Alpha signing environment

### DIFF
--- a/scripts/dist-mac-alpha.cjs
+++ b/scripts/dist-mac-alpha.cjs
@@ -46,6 +46,23 @@ function assertSigningConfiguration() {
   }
 }
 
+/**
+ * electron-builder treats a present-but-empty CSC_LINK as a path relative to
+ * the project directory. GitHub Actions renders an unset secret as an empty
+ * environment variable, so remove certificate variables entirely for ad-hoc
+ * builds before electron-builder loads its signing configuration.
+ *
+ * @param {NodeJS.ProcessEnv} [environment]
+ */
+function configureElectronBuilderSigningEnvironment(environment = process.env) {
+  const developerId = environment.MGT_MAC_SIGNING_MODE === "developer-id";
+  environment.CSC_IDENTITY_AUTO_DISCOVERY = developerId ? "true" : "false";
+  if (!developerId) {
+    delete environment.CSC_LINK;
+    delete environment.CSC_KEY_PASSWORD;
+  }
+}
+
 /** @param {string} directory @param {string} extension @returns {string[]} */
 function findArtifacts(directory, extension) {
   const matches = [];
@@ -103,13 +120,13 @@ async function main() {
     throw new Error("The Apple Silicon Alpha must be built on macOS arm64.");
   }
   assertSigningConfiguration();
+  configureElectronBuilderSigningEnvironment();
   const buildEnv = {
     MGT_RELEASE_CHANNEL: "mac-alpha",
     MANGA_TRANSLATOR_BUILD_CHANNEL: "mac-alpha",
     MGT_TARGET_PLATFORM: "darwin",
     MGT_MAC_RUNTIME_ROOT: join(root, ".tmp", "mac-runtime"),
-    CSC_IDENTITY_AUTO_DISCOVERY:
-      process.env.MGT_MAC_SIGNING_MODE === "developer-id" ? "true" : "false",
+    CSC_IDENTITY_AUTO_DISCOVERY: process.env.CSC_IDENTITY_AUTO_DISCOVERY,
   };
 
   run(process.execPath, ["scripts/prepare-mac-icon.cjs"], buildEnv);
@@ -134,3 +151,5 @@ if (require.main === module) {
     process.exitCode = 1;
   });
 }
+
+module.exports = { configureElectronBuilderSigningEnvironment };

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -33,6 +33,12 @@ const { assertSafeArchiveEntry, removeWindowsRuntimeFiles } =
     assertSafeArchiveEntry: (entryPath: string, linkPath?: string) => void;
     removeWindowsRuntimeFiles: (currentDir: string) => Promise<string[]>;
   };
+const { configureElectronBuilderSigningEnvironment } =
+  require("../scripts/dist-mac-alpha.cjs") as {
+    configureElectronBuilderSigningEnvironment: (
+      environment: NodeJS.ProcessEnv,
+    ) => void;
+  };
 
 describe("Apple Silicon Alpha packaging", () => {
   it("pins Electron and every downloaded executable runtime", () => {
@@ -120,6 +126,34 @@ describe("Apple Silicon Alpha packaging", () => {
     } finally {
       rmSync(runtimeDir, { recursive: true, force: true });
     }
+  });
+
+  it("removes empty certificate variables before an ad-hoc build", () => {
+    const environment: NodeJS.ProcessEnv = {
+      MGT_MAC_SIGNING_MODE: "adhoc",
+      CSC_LINK: "",
+      CSC_KEY_PASSWORD: "",
+    };
+
+    configureElectronBuilderSigningEnvironment(environment);
+
+    expect(environment.CSC_LINK).toBeUndefined();
+    expect(environment.CSC_KEY_PASSWORD).toBeUndefined();
+    expect(environment.CSC_IDENTITY_AUTO_DISCOVERY).toBe("false");
+  });
+
+  it("preserves Developer ID certificate variables", () => {
+    const environment: NodeJS.ProcessEnv = {
+      MGT_MAC_SIGNING_MODE: "developer-id",
+      CSC_LINK: "developer-id-certificate",
+      CSC_KEY_PASSWORD: "certificate-password",
+    };
+
+    configureElectronBuilderSigningEnvironment(environment);
+
+    expect(environment.CSC_LINK).toBe("developer-id-certificate");
+    expect(environment.CSC_KEY_PASSWORD).toBe("certificate-password");
+    expect(environment.CSC_IDENTITY_AUTO_DISCOVERY).toBe("true");
   });
 
   it("keeps Windows resources out of the arm64 app configuration", () => {


### PR DESCRIPTION
## 원인

GitHub Actions가 설정되지 않은 MAC_CSC_LINK secret을 빈 CSC_LINK 환경변수로 만들었고, electron-builder가 이를 저장소 디렉터리의 인증서 경로로 해석했습니다.

## 수정

- ad-hoc 빌드에서는 CSC_LINK와 CSC_KEY_PASSWORD를 electron-builder 로드 전에 완전히 제거
- Developer ID 모드에서는 인증서 값을 보존
- 두 서명 모드에 대한 회귀 테스트 추가

## 로컬 검증

- macPackaging.test.ts: 8 passed
- npm run typecheck:js
- Prettier / git diff --check