### PR TITLE
Materialize macOS llama dylibs before signing

### DIFF
--- a/scripts/prepare-mac-runtime.cjs
+++ b/scripts/prepare-mac-runtime.cjs
@@ -269,11 +269,7 @@ async function stageLlamaRuntime(asset) {
   }
   const runtimeSource = path.dirname(serverPath);
   const runtimeTarget = path.join(stagingTools, asset.id);
-  await cp(runtimeSource, runtimeTarget, {
-    recursive: true,
-    dereference: false,
-    preserveTimestamps: true,
-  });
+  await copyLlamaRuntimePayload(runtimeSource, runtimeTarget);
   const stagedServer = path.join(runtimeTarget, "llama-server");
   await chmod(stagedServer, 0o755);
   assertArm64MachO(stagedServer);
@@ -284,6 +280,41 @@ async function stageLlamaRuntime(asset) {
     throw new Error(`${asset.id} is missing its required Metal dylibs`);
   }
   console.log(`[mac-runtime] staged ${asset.id}`);
+}
+
+/**
+ * The official llama.cpp archives may keep a dylib target outside the folder
+ * containing llama-server. Copying that folder while preserving symlinks can
+ * therefore leave a broken link in the app bundle. Archive links have already
+ * passed the extraction-root escape checks, so materialize them as regular
+ * files before electron-builder and codesign see the staged runtime.
+ *
+ * @param {string} runtimeSource
+ * @param {string} runtimeTarget
+ */
+async function copyLlamaRuntimePayload(runtimeSource, runtimeTarget) {
+  await cp(runtimeSource, runtimeTarget, {
+    recursive: true,
+    dereference: true,
+    preserveTimestamps: true,
+  });
+  await assertNoSymlinks(runtimeTarget);
+}
+
+/** @param {string} currentDir */
+async function assertNoSymlinks(currentDir) {
+  for (const entry of await readdir(currentDir, { withFileTypes: true })) {
+    const entryPath = path.join(currentDir, entry.name);
+    const metadata = await lstat(entryPath);
+    if (metadata.isSymbolicLink()) {
+      throw new Error(
+        `Staged llama runtime still contains symlink: ${entryPath}`,
+      );
+    }
+    if (metadata.isDirectory()) {
+      await assertNoSymlinks(entryPath);
+    }
+  }
 }
 
 /** @param {string} currentDir @param {string} suffix @returns {Promise<string | null>} */
@@ -486,6 +517,7 @@ async function main() {
 
 module.exports = {
   assertSafeArchiveEntry,
+  copyLlamaRuntimePayload,
   extractTarSafely,
   isSameOrDescendant,
   removeWindowsRuntimeFiles,

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -1,10 +1,12 @@
 import { createRequire } from "node:module";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -28,11 +30,18 @@ const { MAC_RUNTIME_MANIFEST } =
       }>;
     };
   };
-const { assertSafeArchiveEntry, removeWindowsRuntimeFiles } =
-  require("../scripts/prepare-mac-runtime.cjs") as {
-    assertSafeArchiveEntry: (entryPath: string, linkPath?: string) => void;
-    removeWindowsRuntimeFiles: (currentDir: string) => Promise<string[]>;
-  };
+const {
+  assertSafeArchiveEntry,
+  copyLlamaRuntimePayload,
+  removeWindowsRuntimeFiles,
+} = require("../scripts/prepare-mac-runtime.cjs") as {
+  assertSafeArchiveEntry: (entryPath: string, linkPath?: string) => void;
+  copyLlamaRuntimePayload: (
+    runtimeSource: string,
+    runtimeTarget: string,
+  ) => Promise<void>;
+  removeWindowsRuntimeFiles: (currentDir: string) => Promise<string[]>;
+};
 const { configureElectronBuilderSigningEnvironment } =
   require("../scripts/dist-mac-alpha.cjs") as {
     configureElectronBuilderSigningEnvironment: (
@@ -104,6 +113,35 @@ describe("Apple Silicon Alpha packaging", () => {
       assertSafeArchiveEntry("runtime/link", "../../outside"),
     ).toThrow("escapes extraction root");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "materializes llama dylib symlinks whose target is outside the binary folder",
+    async () => {
+      const runtimeDir = mkdtempSync(join(tmpdir(), "mgt-llama-runtime-"));
+      try {
+        const sourceDir = join(runtimeDir, "bin");
+        const libraryDir = join(runtimeDir, "lib");
+        const targetDir = join(runtimeDir, "staged");
+        mkdirSync(sourceDir, { recursive: true });
+        mkdirSync(libraryDir, { recursive: true });
+        writeFileSync(join(sourceDir, "llama-server"), "server");
+        writeFileSync(join(libraryDir, "libggml-base.0.dylib"), "metal dylib");
+        symlinkSync(
+          "../lib/libggml-base.0.dylib",
+          join(sourceDir, "libggml-base.dylib"),
+        );
+
+        await copyLlamaRuntimePayload(sourceDir, targetDir);
+
+        const stagedDylib = join(targetDir, "libggml-base.dylib");
+        expect(lstatSync(stagedDylib).isFile()).toBe(true);
+        expect(lstatSync(stagedDylib).isSymbolicLink()).toBe(false);
+        expect(readFileSync(stagedDylib, "utf8")).toBe("metal dylib");
+      } finally {
+        rmSync(runtimeDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("removes Windows-only launchers from the bundled macOS Python runtime", async () => {
     const runtimeDir = mkdtempSync(join(tmpdir(), "mgt-mac-python-runtime-"));


### PR DESCRIPTION
## 원인

공식 llama.cpp archive의 dylib symlink 대상이 llama-server 폴더 밖에 있을 수 있습니다. 실행 파일 폴더만 symlink 보존 복사하면서 최종 앱에는 깨진 링크가 남았고 codesign이 ENOENT로 중단됐습니다.

## 수정

- 안전한 archive 추출/탈출 검증 후 llama staging에서 symlink를 실파일로 역참조 복사
- staging 트리에 symlink가 남으면 즉시 실패
- 실행 파일 폴더 밖 dylib 대상을 재현하는 macOS 회귀 테스트 추가

## 검증

- macPackaging.test.ts: Windows 8 passed / macOS 전용 1 skipped
- npm run typecheck:js
- Prettier / git diff --check