### PR TITLE
Materialize every bundled macOS runtime symlink

### DIFF
--- a/scripts/prepare-mac-runtime.cjs
+++ b/scripts/prepare-mac-runtime.cjs
@@ -269,7 +269,7 @@ async function stageLlamaRuntime(asset) {
   }
   const runtimeSource = path.dirname(serverPath);
   const runtimeTarget = path.join(stagingTools, asset.id);
-  await copyLlamaRuntimePayload(runtimeSource, runtimeTarget);
+  await copyMacRuntimePayload(runtimeSource, runtimeTarget);
   const stagedServer = path.join(runtimeTarget, "llama-server");
   await chmod(stagedServer, 0o755);
   assertArm64MachO(stagedServer);
@@ -283,16 +283,16 @@ async function stageLlamaRuntime(asset) {
 }
 
 /**
- * The official llama.cpp archives may keep a dylib target outside the folder
- * containing llama-server. Copying that folder while preserving symlinks can
- * therefore leave a broken link in the app bundle. Archive links have already
- * passed the extraction-root escape checks, so materialize them as regular
- * files before electron-builder and codesign see the staged runtime.
+ * Runtime archives may keep a symlink target outside the subtree selected for
+ * staging. Copying that subtree while preserving symlinks can therefore leave
+ * a broken link in the app bundle. Archive links have already passed the
+ * extraction-root escape checks, so materialize them before electron-builder
+ * and codesign see the staged runtime.
  *
  * @param {string} runtimeSource
  * @param {string} runtimeTarget
  */
-async function copyLlamaRuntimePayload(runtimeSource, runtimeTarget) {
+async function copyMacRuntimePayload(runtimeSource, runtimeTarget) {
   await cp(runtimeSource, runtimeTarget, {
     recursive: true,
     dereference: true,
@@ -308,7 +308,7 @@ async function assertNoSymlinks(currentDir) {
     const metadata = await lstat(entryPath);
     if (metadata.isSymbolicLink()) {
       throw new Error(
-        `Staged llama runtime still contains symlink: ${entryPath}`,
+        `Staged macOS runtime still contains symlink: ${entryPath}`,
       );
     }
     if (metadata.isDirectory()) {
@@ -380,11 +380,7 @@ async function stagePythonAndPaddle() {
     `[mac-runtime] removed ${removedWindowsFiles.length} Windows-only Python launcher/library files`,
   );
   const pythonTarget = path.join(stagingTools, "python");
-  await cp(installRoot, pythonTarget, {
-    recursive: true,
-    dereference: false,
-    preserveTimestamps: true,
-  });
+  await copyMacRuntimePayload(installRoot, pythonTarget);
   await chmod(path.join(pythonTarget, "bin", "python3"), 0o755);
   console.log(
     `[mac-runtime] staged CPython ${asset.version} with ${MAC_RUNTIME_MANIFEST.ocrPackages.join(", ")}`,
@@ -511,13 +507,14 @@ async function main() {
     path.join(root, "scripts", "mac-runtime-manifest.cjs"),
     path.join(stagingTools, "mac-runtime-manifest.cjs"),
   );
+  await assertNoSymlinks(stagingTools);
   await rm(extractionRoot, { recursive: true, force: true });
   console.log(`[mac-runtime] complete: ${stagingRoot}`);
 }
 
 module.exports = {
   assertSafeArchiveEntry,
-  copyLlamaRuntimePayload,
+  copyMacRuntimePayload,
   extractTarSafely,
   isSameOrDescendant,
   removeWindowsRuntimeFiles,

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -32,11 +32,11 @@ const { MAC_RUNTIME_MANIFEST } =
   };
 const {
   assertSafeArchiveEntry,
-  copyLlamaRuntimePayload,
+  copyMacRuntimePayload,
   removeWindowsRuntimeFiles,
 } = require("../scripts/prepare-mac-runtime.cjs") as {
   assertSafeArchiveEntry: (entryPath: string, linkPath?: string) => void;
-  copyLlamaRuntimePayload: (
+  copyMacRuntimePayload: (
     runtimeSource: string,
     runtimeTarget: string,
   ) => Promise<void>;
@@ -96,6 +96,14 @@ describe("Apple Silicon Alpha packaging", () => {
         'rev = "0d640615d435a399bc195c892de8f5d17efb68f8"',
       );
     }
+    const runtimePreparer = readFileSync(
+      join(repoRoot, "scripts", "prepare-mac-runtime.cjs"),
+      "utf8",
+    );
+    expect(runtimePreparer).toContain(
+      "await copyMacRuntimePayload(installRoot, pythonTarget)",
+    );
+    expect(runtimePreparer).toContain("await assertNoSymlinks(stagingTools)");
   });
 
   it("rejects archive traversal and escaping symlinks", () => {
@@ -131,7 +139,7 @@ describe("Apple Silicon Alpha packaging", () => {
           join(sourceDir, "libggml-base.dylib"),
         );
 
-        await copyLlamaRuntimePayload(sourceDir, targetDir);
+        await copyMacRuntimePayload(sourceDir, targetDir);
 
         const stagedDylib = join(targetDir, "libggml-base.dylib");
         expect(lstatSync(stagedDylib).isFile()).toBe(true);


### PR DESCRIPTION
## 원인

llama dylib 링크를 고친 뒤 codesign이 Python runtime의 bin/2to3 깨진 symlink에서 다시 중단됐습니다. electron-builder의 extraResources 경로에서는 보존된 archive symlink를 안정적으로 처리하지 못했습니다.

## 수정

- 검증된 Python runtime도 symlink를 실파일/실디렉터리로 역참조해 staging
- llama와 Python에 공통 staging helper 사용
- 최종 macOS tools 트리 전체에 symlink가 0개인지 패키징 전에 강제 검사
- Python staging 연결과 전체 검사를 회귀 테스트로 고정

## 검증

- macPackaging.test.ts: Windows 8 passed / macOS 전용 1 skipped
- npm run typecheck:js
- Prettier / git diff --check