### PR TITLE
Verify parenthesized Electron Helper binaries on macOS

### DIFF
--- a/scripts/dist-mac-alpha.cjs
+++ b/scripts/dist-mac-alpha.cjs
@@ -148,7 +148,7 @@ async function main() {
 if (require.main === module) {
   main().catch((error) => {
     console.error(error);
-    process.exitCode = 1;
+    process.exit(1);
   });
 }
 

--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -7,9 +7,11 @@ const {
   createReadStream,
   existsSync,
   lstatSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } = require("node:fs");
 const { homedir, tmpdir } = require("node:os");
@@ -88,6 +90,32 @@ function looksLikeNativeBinary(filePath) {
   );
 }
 
+/** @param {string} filePath */
+function requiresOtoolAlias(filePath) {
+  return /[()]/.test(filePath);
+}
+
+/**
+ * otool-classic interprets a trailing parenthesized filename segment such as
+ * "Helper (GPU)" as the archive(member) syntax. Inspect the same Mach-O through
+ * a parenthesis-free symlink so the tool receives an unambiguous path.
+ *
+ * @param {string} filePath
+ */
+function runOtool(filePath) {
+  if (!requiresOtoolAlias(filePath)) {
+    return run("otool", ["-L", filePath]);
+  }
+  const aliasRoot = mkdtempSync(join(tmpdir(), "mgt-otool-"));
+  const aliasPath = join(aliasRoot, "native-payload");
+  try {
+    symlinkSync(filePath, aliasPath);
+    return run("otool", ["-L", aliasPath]);
+  } finally {
+    rmSync(aliasRoot, { recursive: true, force: true });
+  }
+}
+
 /** @param {string} appPath @returns {string[]} */
 function verifyNativePayload(appPath) {
   const files = listFiles(appPath);
@@ -110,7 +138,7 @@ function verifyNativePayload(appPath) {
     if (!/arm64/i.test(description) || /x86_64/i.test(description)) {
       throw new Error(`Non-arm64 Mach-O found: ${filePath}: ${description}`);
     }
-    run("otool", ["-L", filePath]);
+    runOtool(filePath);
     run("codesign", ["--verify", "--strict", "--verbose=2", filePath]);
     machOFiles.push(filePath);
   }
@@ -372,4 +400,5 @@ module.exports = {
   findAppBundles,
   listFiles,
   looksLikeNativeBinary,
+  requiresOtoolAlias,
 };

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -48,6 +48,9 @@ const { configureElectronBuilderSigningEnvironment } =
       environment: NodeJS.ProcessEnv,
     ) => void;
   };
+const { requiresOtoolAlias } = require("../scripts/verify-mac-package.cjs") as {
+  requiresOtoolAlias: (filePath: string) => boolean;
+};
 
 describe("Apple Silicon Alpha packaging", () => {
   it("pins Electron and every downloaded executable runtime", () => {
@@ -200,6 +203,29 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(environment.CSC_LINK).toBe("developer-id-certificate");
     expect(environment.CSC_KEY_PASSWORD).toBe("certificate-password");
     expect(environment.CSC_IDENTITY_AUTO_DISCOVERY).toBe("true");
+  });
+
+  it("aliases parenthesized Electron Helper paths before otool inspection", () => {
+    expect(
+      requiresOtoolAlias(
+        "/Applications/App.app/Contents/Frameworks/App Helper (GPU).app/Contents/MacOS/App Helper (GPU)",
+      ),
+    ).toBe(true);
+    expect(
+      requiresOtoolAlias(
+        "/Applications/App.app/Contents/MacOS/CarrotMangaTranslator",
+      ),
+    ).toBe(false);
+
+    const verifier = readFileSync(
+      join(repoRoot, "scripts", "verify-mac-package.cjs"),
+      "utf8",
+    );
+    expect(verifier).toContain('mkdtempSync(join(tmpdir(), "mgt-otool-"))');
+    expect(verifier).toContain("runOtool(filePath)");
+    expect(
+      readFileSync(join(repoRoot, "scripts", "dist-mac-alpha.cjs"), "utf8"),
+    ).toContain("process.exit(1)");
   });
 
   it("keeps Windows resources out of the arm64 app configuration", () => {


### PR DESCRIPTION
## 원인

DMG/ZIP와 ad-hoc 서명은 성공했지만 otool-classic이 Electron의 Helper (GPU) 파일명 끝 괄호를 archive(member) 문법으로 해석해 존재하는 Mach-O를 열지 못했습니다.

## 수정

- 괄호가 포함된 Mach-O만 괄호 없는 임시 symlink를 통해 otool -L 검사
- codesign은 계속 원본 Mach-O를 검사
- 임시 경로는 매 검사 후 즉시 삭제
- 패키지 검증 실패 시 dist CLI가 확실히 비정상 종료하도록 process.exit(1) 적용
- 괄호 Helper 경로 회귀 테스트 추가

## 검증

- macPackaging.test.ts: 9 passed / macOS 전용 1 skipped
- npm run typecheck:js
- ESLint / Prettier / git diff --check