### PR TITLE
Thin bundled Python extensions to Apple Silicon

### DIFF
--- a/scripts/prepare-mac-runtime.cjs
+++ b/scripts/prepare-mac-runtime.cjs
@@ -12,6 +12,7 @@ const {
   readlink,
   readdir,
   realpath,
+  rename,
   rm,
   symlink,
 } = require("node:fs/promises");
@@ -241,21 +242,87 @@ async function findFile(currentDir, basename) {
 
 /** @param {string} executable */
 function assertArm64MachO(executable) {
-  const result = spawnSync("file", ["-b", executable], {
-    encoding: "utf8",
-    shell: false,
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `file failed for ${executable}: ${result.stderr || "unknown error"}`,
-    );
-  }
-  const description = String(result.stdout).trim();
+  const description = describeFile(executable);
   if (!/Mach-O.*arm64/i.test(description) || /x86_64/i.test(description)) {
     throw new Error(
       `Expected arm64-only Mach-O at ${executable}, got: ${description}`,
     );
   }
+}
+
+/** @param {string} filePath */
+function describeFile(filePath) {
+  const result = spawnSync("file", ["-b", filePath], {
+    encoding: "utf8",
+    shell: false,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `file failed for ${filePath}: ${result.stderr || "unknown error"}`,
+    );
+  }
+  return String(result.stdout).trim();
+}
+
+/** @param {string} description */
+function classifyMachODescription(description) {
+  if (!/Mach-O/i.test(description)) {
+    return "other";
+  }
+  const arm64 = /\barm64\b/i.test(description);
+  const x86_64 = /\bx86_64\b/i.test(description);
+  if (arm64 && x86_64) {
+    return "universal-arm64";
+  }
+  return arm64 ? "arm64" : "unsupported";
+}
+
+/** @param {string} currentDir @returns {Promise<number>} */
+async function thinUniversalMachOFiles(currentDir) {
+  let thinned = 0;
+  for (const entry of await readdir(currentDir, { withFileTypes: true })) {
+    const entryPath = path.join(currentDir, entry.name);
+    const metadata = await lstat(entryPath);
+    if (metadata.isSymbolicLink()) {
+      continue;
+    }
+    if (metadata.isDirectory()) {
+      thinned += await thinUniversalMachOFiles(entryPath);
+      continue;
+    }
+    if (
+      !metadata.isFile() ||
+      ((metadata.mode & 0o111) === 0 &&
+        !/\.(?:bundle|dylib|node|so)$/i.test(entry.name))
+    ) {
+      continue;
+    }
+    const description = describeFile(entryPath);
+    const classification = classifyMachODescription(description);
+    if (classification === "other") {
+      continue;
+    }
+    if (classification === "unsupported") {
+      throw new Error(
+        `Python runtime contains non-arm64 Mach-O: ${entryPath}: ${description}`,
+      );
+    }
+    if (classification !== "universal-arm64") {
+      continue;
+    }
+    const thinPath = `${entryPath}.mgt-arm64-thin`;
+    await rm(thinPath, { force: true });
+    try {
+      run("lipo", ["-thin", "arm64", entryPath, "-output", thinPath]);
+      await chmod(thinPath, metadata.mode & 0o777);
+      await rename(thinPath, entryPath);
+    } finally {
+      await rm(thinPath, { force: true });
+    }
+    assertArm64MachO(entryPath);
+    thinned += 1;
+  }
+  return thinned;
 }
 
 /** @param {ArchiveAsset & { id: string }} asset */
@@ -367,21 +434,26 @@ async function stagePythonAndPaddle() {
       PIP_NO_CACHE_DIR: "1",
     },
   );
-  run(
-    extractedPython,
-    [
-      "-c",
-      "import importlib.metadata, platform, paddle; assert platform.machine() == 'arm64'; print(paddle.__version__, importlib.metadata.version('paddleocr'))",
-    ],
-    { PYTHONNOUSERSITE: "1" },
-  );
   const removedWindowsFiles = await removeWindowsRuntimeFiles(installRoot);
   console.log(
     `[mac-runtime] removed ${removedWindowsFiles.length} Windows-only Python launcher/library files`,
   );
   const pythonTarget = path.join(stagingTools, "python");
   await copyMacRuntimePayload(installRoot, pythonTarget);
-  await chmod(path.join(pythonTarget, "bin", "python3"), 0o755);
+  const stagedPython = path.join(pythonTarget, "bin", "python3");
+  await chmod(stagedPython, 0o755);
+  const thinnedMachOFiles = await thinUniversalMachOFiles(pythonTarget);
+  console.log(
+    `[mac-runtime] thinned ${thinnedMachOFiles} universal Python Mach-O files to arm64`,
+  );
+  run(
+    stagedPython,
+    [
+      "-c",
+      "import importlib.metadata, platform, paddle; assert platform.machine() == 'arm64'; print(paddle.__version__, importlib.metadata.version('paddleocr'))",
+    ],
+    { PYTHONNOUSERSITE: "1" },
+  );
   console.log(
     `[mac-runtime] staged CPython ${asset.version} with ${MAC_RUNTIME_MANIFEST.ocrPackages.join(", ")}`,
   );
@@ -514,11 +586,13 @@ async function main() {
 
 module.exports = {
   assertSafeArchiveEntry,
+  classifyMachODescription,
   copyMacRuntimePayload,
   extractTarSafely,
   isSameOrDescendant,
   removeWindowsRuntimeFiles,
   sha256File,
+  thinUniversalMachOFiles,
 };
 
 if (require.main === module) {

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -32,10 +32,14 @@ const { MAC_RUNTIME_MANIFEST } =
   };
 const {
   assertSafeArchiveEntry,
+  classifyMachODescription,
   copyMacRuntimePayload,
   removeWindowsRuntimeFiles,
 } = require("../scripts/prepare-mac-runtime.cjs") as {
   assertSafeArchiveEntry: (entryPath: string, linkPath?: string) => void;
+  classifyMachODescription: (
+    description: string,
+  ) => "other" | "arm64" | "universal-arm64" | "unsupported";
   copyMacRuntimePayload: (
     runtimeSource: string,
     runtimeTarget: string,
@@ -107,6 +111,9 @@ describe("Apple Silicon Alpha packaging", () => {
       "await copyMacRuntimePayload(installRoot, pythonTarget)",
     );
     expect(runtimePreparer).toContain("await assertNoSymlinks(stagingTools)");
+    expect(runtimePreparer).toContain(
+      "await thinUniversalMachOFiles(pythonTarget)",
+    );
   });
 
   it("rejects archive traversal and escaping symlinks", () => {
@@ -175,6 +182,25 @@ describe("Apple Silicon Alpha packaging", () => {
     } finally {
       rmSync(runtimeDir, { recursive: true, force: true });
     }
+  });
+
+  it("classifies universal Python extensions for arm64 thinning", () => {
+    expect(
+      classifyMachODescription(
+        "Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit bundle x86_64] [arm64:Mach-O 64-bit bundle arm64]",
+      ),
+    ).toBe("universal-arm64");
+    expect(
+      classifyMachODescription(
+        "Mach-O 64-bit dynamically linked shared library arm64",
+      ),
+    ).toBe("arm64");
+    expect(classifyMachODescription("Mach-O 64-bit bundle x86_64")).toBe(
+      "unsupported",
+    );
+    expect(classifyMachODescription("POSIX shell script text executable")).toBe(
+      "other",
+    );
   });
 
   it("removes empty certificate variables before an ad-hoc build", () => {


### PR DESCRIPTION
## 원인

Paddle OCR 의존성 중 pycryptodome 등이 universal2 Mach-O를 포함해 arm64와 x86_64 슬라이스가 함께 번들됐고, Intel 제외 패키지 검증에서 거부됐습니다.

## 수정

- 최종 Python staging의 실행 파일·so·dylib·node·bundle을 file로 분류
- arm64+x86_64 universal Mach-O는 lipo -thin arm64로 원자적으로 교체
- x86_64-only Mach-O는 즉시 실패
- thinning 후 최종 staged Python으로 Paddle 3.3.1 / PaddleOCR 3.7.0 import 재검증
- Mach-O 분류 회귀 테스트 추가

## 검증

- macPackaging.test.ts: 10 passed / macOS 전용 1 skipped
- npm run typecheck:js
- ESLint / Prettier / git diff --check