### PR TITLE
Keep signed macOS app immutable during OCR

### DIFF
--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -182,6 +182,11 @@ function verifyRequiredRuntimes(appPath) {
       timeout: 120_000,
       env: {
         PYTHONNOUSERSITE: "1",
+        PYTHONDONTWRITEBYTECODE: "1",
+        PYTHONPYCACHEPREFIX: join(
+          tmpdir(),
+          "mgt-paddle-package-verify-pycache",
+        ),
         PADDLE_PDX_CACHE_HOME: join(tmpdir(), "mgt-paddle-package-verify"),
       },
     },
@@ -353,6 +358,10 @@ async function main() {
   }
   const appPath = apps[0];
   verifyNativePayload(appPath);
+  // Establish that electron-builder produced a valid sealed bundle before
+  // running any executable from it.  The second check below proves that the
+  // runtime smokes kept the signed .app immutable.
+  verifySigning(appPath);
   verifyRequiredRuntimes(appPath);
   await verifyMacRuntimeSmokes({ appPath });
   verifySigning(appPath);

--- a/scripts/verify-mac-runtime-smokes.cjs
+++ b/scripts/verify-mac-runtime-smokes.cjs
@@ -170,7 +170,7 @@ function createSmokeImages(python, workRoot) {
     ["-c", script, paths.ocr, paths.input, paths.mask, paths.bubble],
     {
       timeout: 60_000,
-      env: { PYTHONNOUSERSITE: "1" },
+      env: buildSmokePythonEnv(workRoot),
     },
   );
   return paths;
@@ -225,7 +225,7 @@ async function verifyOcrImageSmoke(
     ],
     {
       timeout: 30_000,
-      env: { PYTHONNOUSERSITE: "1" },
+      env: buildSmokePythonEnv(workRoot),
     },
   );
   console.log(`[mac-smoke] Paddle OCR CPU detected ${hints.length} region(s)`);
@@ -302,7 +302,7 @@ async function verifyKoharuImageSmokes(runner, python, workRoot, images) {
         "from PIL import Image; import sys; image=Image.open(sys.argv[1]); image.load(); assert image.size == (128, 128)",
         output,
       ],
-      { timeout: 30_000, env: { PYTHONNOUSERSITE: "1" } },
+      { timeout: 30_000, env: buildSmokePythonEnv(workRoot) },
     );
     console.log(`[mac-smoke] ${asset.model} Metal 128x128 inpainting passed`);
   }
@@ -318,6 +318,16 @@ function parseOptionalJson(text) {
   } catch (_error) {
     return null;
   }
+}
+
+/** @param {string} workRoot @returns {NodeJS.ProcessEnv} */
+function buildSmokePythonEnv(workRoot) {
+  return {
+    PYTHONNOUSERSITE: "1",
+    PYTHONDONTWRITEBYTECODE: "1",
+    PYTHONPYCACHEPREFIX: join(workRoot, "pycache"),
+    PADDLE_PDX_CACHE_HOME: join(workRoot, "paddlex-cache"),
+  };
 }
 
 /** @param {{ appPath: string }} options */

--- a/src/main/runtime/ocr/runtime-environment.cjs
+++ b/src/main/runtime/ocr/runtime-environment.cjs
@@ -189,6 +189,11 @@ function buildPythonRuntimeEnv(options, runtime, context) {
   return {
     PYTHONPATH: context.pythonPath,
     PYTHONNOUSERSITE: "1",
+    // The bundled macOS interpreter lives inside the signed .app.  Importing
+    // from it must never create __pycache__ entries there, otherwise the first
+    // OCR run invalidates the app's code-signature seal.
+    PYTHONDONTWRITEBYTECODE: "1",
+    PYTHONPYCACHEPREFIX: path.join(context.runtimeDir, "pycache"),
     PYTHONUSERBASE: resolveOcrPythonUserBaseDir(context.runtimeDir, options),
     PIP_CACHE_DIR: resolveOcrPipCacheDir(context.runtimeDir, options),
     PADDLE_PDX_MODEL_SOURCE:

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -283,6 +283,10 @@ describe("Apple Silicon Alpha packaging", () => {
     );
 
     expect(verifier).toContain("await verifyMacRuntimeSmokes({ appPath })");
+    expect(verifier.match(/^\s+verifySigning\(appPath\);$/gm)).toHaveLength(2);
+    expect(verifier).toContain('PYTHONDONTWRITEBYTECODE: "1"');
+    expect(smokes).toContain('PYTHONDONTWRITEBYTECODE: "1"');
+    expect(smokes).toContain('PYTHONPYCACHEPREFIX: join(workRoot, "pycache")');
     expect(smokes).toContain('ocrDevice: "cpu"');
     expect(smokes).toContain('ocrBboxMode: "ocr"');
     expect(smokes).toContain('"PP-OCRv6_tiny_det"');

--- a/tests/runtimeModelLaunch.test.ts
+++ b/tests/runtimeModelLaunch.test.ts
@@ -352,6 +352,8 @@ describeWindows("runtime model support helpers", () => {
       expect(env.HF_HUB_DOWNLOAD_TIMEOUT).toBe("300");
       expect(env.MGT_UNRELATED_SECRET).toBeUndefined();
       expect(env.PYTHONHOME).toBeUndefined();
+      expect(env.PYTHONDONTWRITEBYTECODE).toBe("1");
+      expect(env.PYTHONPYCACHEPREFIX).toBe(join(runtimeDir, "pycache"));
     } finally {
       if (previousDisableXet === undefined) {
         delete process.env.HF_HUB_DISABLE_XET;


### PR DESCRIPTION
## Summary
- prevent bundled Python from writing bytecode into the signed macOS app
- redirect Python cache state to the external OCR runtime directory
- verify the app signature both before and after native runtime smokes

## Verification
- 62 targeted tests passed (1 skipped)
- typecheck passed
- Node syntax checks passed
- changed files pass Prettier