### PR TITLE
Pass Mac package smoke through app arguments

### DIFF
--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -298,12 +298,7 @@ function verifyApplicationDirectorySmoke(appPath) {
   try {
     run("ditto", [appPath, smokeApp]);
     runApplicationSmoke(smokeApp, "prepare");
-    if (!existsSync(marker)) {
-      throw new Error(
-        `Packaged app did not create its external data marker: ${marker}`,
-      );
-    }
-    const prepared = JSON.parse(readFileSync(marker, "utf8"));
+    const prepared = waitForSmokeMarker(marker, "prepared", 120_000);
     if (
       prepared.ok !== true ||
       prepared.stage !== "prepared" ||
@@ -316,7 +311,7 @@ function verifyApplicationDirectorySmoke(appPath) {
       );
     }
     runApplicationSmoke(smokeApp, "verify");
-    const smoke = JSON.parse(readFileSync(marker, "utf8"));
+    const smoke = waitForSmokeMarker(marker, "verified", 120_000);
     if (
       smoke.ok !== true ||
       smoke.stage !== "verified" ||
@@ -358,17 +353,53 @@ function runApplicationSmoke(smokeApp, stage) {
       "-n",
       "-F",
       "-g",
-      "--env",
-      "MGT_MAC_PACKAGE_SMOKE_EXIT=1",
-      "--env",
-      `MGT_MAC_PACKAGE_SMOKE_STAGE=${stage}`,
-      "--env",
-      "ELECTRON_ENABLE_LOGGING=1",
-      "--env",
-      "ELECTRON_ENABLE_STACK_DUMPING=1",
       smokeApp,
+      "--args",
+      "--mgt-mac-package-smoke=alpha-ci-v1",
+      `--mgt-mac-package-smoke-stage=${stage}`,
+      "--enable-logging=stderr",
+      "--v=1",
     ],
     { timeout: 120_000 },
+  );
+}
+
+/**
+ * LaunchServices can return before the new process has flushed its marker on
+ * hosted runners. Wait for the exact stage instead of racing the app startup.
+ *
+ * @param {string} marker
+ * @param {"prepared" | "verified"} expectedStage
+ * @param {number} timeoutMs
+ * @returns {Record<string, unknown>}
+ */
+function waitForSmokeMarker(marker, expectedStage, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastState = "marker missing";
+  while (Date.now() < deadline) {
+    if (existsSync(marker)) {
+      let parsed;
+      try {
+        parsed = JSON.parse(readFileSync(marker, "utf8"));
+      } catch (error) {
+        lastState = `marker unreadable: ${error instanceof Error ? error.message : String(error)}`;
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+        continue;
+      }
+      if (parsed?.ok === false) {
+        throw new Error(
+          `Packaged app smoke reported failure: ${JSON.stringify(parsed)}`,
+        );
+      }
+      if (parsed?.stage === expectedStage) {
+        return parsed;
+      }
+      lastState = `marker stage ${String(parsed?.stage || "unknown")}`;
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  }
+  throw new Error(
+    `Timed out waiting for packaged app smoke stage ${expectedStage}: ${lastState}: ${marker}`,
   );
 }
 

--- a/src/main/macPackageSmoke.ts
+++ b/src/main/macPackageSmoke.ts
@@ -15,6 +15,8 @@ import { renderPageWithTranslationBlocksForExport } from "./pageExport";
 
 const MAC_PACKAGE_SMOKE_MARKER = "mac-package-smoke.json";
 const MAC_PACKAGE_SMOKE_DIR = "mac-package-smoke";
+const MAC_PACKAGE_SMOKE_CLI_TOKEN = "--mgt-mac-package-smoke=alpha-ci-v1";
+const MAC_PACKAGE_SMOKE_STAGE_PREFIX = "--mgt-mac-package-smoke-stage=";
 
 type PreparedSmoke = {
   ok: true;
@@ -33,16 +35,12 @@ type PreparedSmoke = {
 export async function runMacPackageSmokeExit(
   appPaths: AppPaths,
 ): Promise<boolean> {
-  if (
-    process.env.MGT_MAC_PACKAGE_SMOKE_EXIT !== "1" ||
-    !app.isPackaged ||
-    process.platform !== "darwin" ||
-    process.arch !== "arm64"
-  ) {
+  if (!shouldRunMacPackageSmoke()) {
     return false;
   }
 
-  const stage = process.env.MGT_MAC_PACKAGE_SMOKE_STAGE;
+  const stage =
+    process.env.MGT_MAC_PACKAGE_SMOKE_STAGE || readPackageSmokeStageArgument();
   const markerPath = join(appPaths.dataRoot, MAC_PACKAGE_SMOKE_MARKER);
   try {
     if (stage === "prepare") {
@@ -65,6 +63,25 @@ export async function runMacPackageSmokeExit(
     app.exit(1);
   }
   return true;
+}
+
+function shouldRunMacPackageSmoke(): boolean {
+  const requested =
+    process.env.MGT_MAC_PACKAGE_SMOKE_EXIT === "1" ||
+    process.argv.includes(MAC_PACKAGE_SMOKE_CLI_TOKEN);
+  return (
+    requested &&
+    app.isPackaged &&
+    process.platform === "darwin" &&
+    process.arch === "arm64"
+  );
+}
+
+function readPackageSmokeStageArgument(): string | undefined {
+  const argument = process.argv.find((value) =>
+    value.startsWith(MAC_PACKAGE_SMOKE_STAGE_PREFIX),
+  );
+  return argument?.slice(MAC_PACKAGE_SMOKE_STAGE_PREFIX.length);
 }
 
 async function preparePackageSmoke(

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -295,12 +295,14 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(smokes).toContain('"lama-manga"');
     expect(smokes).toContain('"metal-native"');
     expect(smokes).toContain("128 * 128");
-    expect(verifier).toContain("MGT_MAC_PACKAGE_SMOKE_STAGE=${stage}");
+    expect(verifier).toContain("--mgt-mac-package-smoke-stage=${stage}");
     expect(verifier).toContain('runApplicationSmoke(smokeApp, "prepare")');
     expect(verifier).toContain('runApplicationSmoke(smokeApp, "verify")');
     expect(verifier).toContain('"open",');
     expect(verifier).toContain('"-W",');
-    expect(verifier).toContain('"--env",');
+    expect(verifier).toContain('"--args",');
+    expect(verifier).toContain('"--mgt-mac-package-smoke=alpha-ci-v1"');
+    expect(verifier).toContain("waitForSmokeMarker");
     expect(verifier).toContain("collectApplicationSmokeDiagnostics");
     expect(verifier).toContain("result.signal");
     expect(verifier).toContain('"--entitlements",');
@@ -308,6 +310,8 @@ describe("Apple Silicon Alpha packaging", () => {
       join(repoRoot, "src", "main", "macPackageSmoke.ts"),
       "utf8",
     );
+    expect(appSmoke).toContain("MAC_PACKAGE_SMOKE_CLI_TOKEN");
+    expect(appSmoke).toContain("readPackageSmokeStageArgument");
     expect(appSmoke).toContain("await previewImages([sourcePath])");
     expect(appSmoke).toContain("await createImport({");
     expect(appSmoke).toContain("await savePageBlocks({");


### PR DESCRIPTION
## Summary
- pass the CI-only packaged-app smoke token and stage through LaunchServices --args
- preserve the existing environment-variable path for direct smoke launches
- wait for exact prepared and verified marker stages to avoid racing app startup

## Evidence
The previous release run showed a healthy packaged app startup and external data root, but no marker because LaunchServices did not preserve the smoke environment variables.

## Verification
- macPackaging tests passed
- ESLint passed
- typecheck passed
- Prettier passed