### PR TITLE
Stabilize packaged Mac application smoke

### DIFF
--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -357,6 +357,7 @@ function runApplicationSmoke(smokeApp, stage) {
       "--args",
       "--mgt-mac-package-smoke=alpha-ci-v1",
       `--mgt-mac-package-smoke-stage=${stage}`,
+      "--disable-gpu",
       "--enable-logging=stderr",
       "--v=1",
     ],
@@ -394,7 +395,7 @@ function waitForSmokeMarker(marker, expectedStage, timeoutMs) {
       if (parsed?.stage === expectedStage) {
         return parsed;
       }
-      lastState = `marker stage ${String(parsed?.stage || "unknown")}`;
+      lastState = `marker stage ${String(parsed?.stage || "unknown")} phase ${String(parsed?.phase || "unknown")}`;
     }
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
   }
@@ -412,6 +413,11 @@ function collectApplicationSmokeDiagnostics(dataRoot, marker) {
     diagnostics,
     "application log",
     join(dataRoot, "logs", "app.log"),
+  );
+  appendDiagnosticFile(
+    diagnostics,
+    "bootstrap log",
+    join(dataRoot, "logs", "bootstrap.log"),
   );
 
   const reportsDir = join(homedir(), "Library", "Logs", "DiagnosticReports");
@@ -449,8 +455,13 @@ function appendDiagnosticFile(diagnostics, label, filePath) {
   }
   try {
     const contents = readFileSync(filePath, "utf8");
+    const diagnosticLimit = 32 * 1024;
+    const excerpt =
+      contents.length <= diagnosticLimit
+        ? contents
+        : `${contents.slice(0, 20 * 1024)}\n[mac-smoke diagnostics] ... middle omitted ...\n${contents.slice(-12 * 1024)}`;
     diagnostics.push(
-      `[mac-smoke diagnostics] ${label}: ${filePath}\n${contents.slice(-32 * 1024)}`,
+      `[mac-smoke diagnostics] ${label}: ${filePath}\n${excerpt}`,
     );
   } catch (error) {
     diagnostics.push(

--- a/src/main/macPackageSmoke.ts
+++ b/src/main/macPackageSmoke.ts
@@ -1,6 +1,6 @@
-import { app, nativeImage } from "electron";
+import { app } from "electron";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { AppPaths } from "./appPaths";
 import {
@@ -17,6 +17,13 @@ const MAC_PACKAGE_SMOKE_MARKER = "mac-package-smoke.json";
 const MAC_PACKAGE_SMOKE_DIR = "mac-package-smoke";
 const MAC_PACKAGE_SMOKE_CLI_TOKEN = "--mgt-mac-package-smoke=alpha-ci-v1";
 const MAC_PACKAGE_SMOKE_STAGE_PREFIX = "--mgt-mac-package-smoke-stage=";
+const SMOKE_SOURCE_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
 
 type PreparedSmoke = {
   ok: true;
@@ -54,11 +61,12 @@ export async function runMacPackageSmokeExit(
   } catch (error) {
     const message =
       error instanceof Error ? error.stack || error.message : String(error);
-    await writeFile(
-      markerPath,
-      `${JSON.stringify({ ok: false, stage, dataRoot: appPaths.dataRoot, error: message }, null, 2)}\n`,
-      "utf8",
-    );
+    await writeSmokeMarker(markerPath, {
+      ok: false,
+      stage,
+      dataRoot: appPaths.dataRoot,
+      error: message,
+    });
     console.error("Mac package application smoke failed", error);
     app.exit(1);
   }
@@ -89,14 +97,23 @@ async function preparePackageSmoke(
   markerPath: string,
 ): Promise<void> {
   const smokeRoot = join(appPaths.dataRoot, MAC_PACKAGE_SMOKE_DIR);
+  await writeSmokeProgress(
+    markerPath,
+    "preparing",
+    "reset-workspace",
+    appPaths,
+  );
   await rm(smokeRoot, { recursive: true, force: true });
   await mkdir(smokeRoot, { recursive: true });
   const sourcePath = join(smokeRoot, "import-source.png");
+  await writeSmokeProgress(markerPath, "preparing", "write-source", appPaths);
   await writeSmokeSourcePng(sourcePath);
 
+  await writeSmokeProgress(markerPath, "preparing", "preview-import", appPaths);
   const preview = await previewImages([sourcePath]);
   const draft = preview.chapters[0];
   if (!draft) throw new Error("Mac package smoke import preview was empty.");
+  await writeSmokeProgress(markerPath, "preparing", "create-import", appPaths);
   const imported = await createImport({
     preview,
     target: { mode: "new", title: "Mac Alpha Package Smoke" },
@@ -108,6 +125,7 @@ async function preparePackageSmoke(
     throw new Error("Mac package smoke did not import a page.");
   }
 
+  await writeSmokeProgress(markerPath, "preparing", "save-page", appPaths);
   const saved = await savePageBlocks({
     chapterId: chapter.id,
     pageId: page.id,
@@ -120,6 +138,7 @@ async function preparePackageSmoke(
     throw new Error("Mac package smoke page save was not persisted.");
 
   const firstExportPath = join(smokeRoot, "first-export.png");
+  await writeSmokeProgress(markerPath, "preparing", "export-page", appPaths);
   await writeRenderedPage(firstExportPath, savedPage, appPaths.dataRoot);
   const prepared: PreparedSmoke = {
     ok: true,
@@ -133,7 +152,7 @@ async function preparePackageSmoke(
     saved: true,
     exported: true,
   };
-  await writeFile(markerPath, `${JSON.stringify(prepared, null, 2)}\n`, "utf8");
+  await writeSmokeMarker(markerPath, prepared);
 }
 
 async function verifyRestartedPackageSmoke(
@@ -141,6 +160,7 @@ async function verifyRestartedPackageSmoke(
   markerPath: string,
 ): Promise<void> {
   const prepared = parsePreparedSmoke(await readFile(markerPath, "utf8"));
+  await writeSmokeProgress(markerPath, "verifying", "reload-library", appPaths);
   if (prepared.dataRoot !== appPaths.dataRoot) {
     throw new Error("Mac package smoke data root changed after restart.");
   }
@@ -164,41 +184,32 @@ async function verifyRestartedPackageSmoke(
     MAC_PACKAGE_SMOKE_DIR,
     "restart-export.png",
   );
+  await writeSmokeProgress(markerPath, "verifying", "export-page", appPaths);
   await writeRenderedPage(restartedExportPath, page, appPaths.dataRoot);
+  await writeSmokeProgress(markerPath, "verifying", "cleanup", appPaths);
   await deleteWork(prepared.workId);
   await rm(join(appPaths.dataRoot, MAC_PACKAGE_SMOKE_DIR), {
     recursive: true,
     force: true,
   });
-  await writeFile(
-    markerPath,
-    `${JSON.stringify(
-      {
-        ok: true,
-        stage: "verified",
-        platform: process.platform,
-        arch: process.arch,
-        dataRoot: appPaths.dataRoot,
-        imported: true,
-        saved: true,
-        restarted: true,
-        exported: true,
-      },
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
+  await writeSmokeMarker(markerPath, {
+    ok: true,
+    stage: "verified",
+    platform: process.platform,
+    arch: process.arch,
+    dataRoot: appPaths.dataRoot,
+    imported: true,
+    saved: true,
+    restarted: true,
+    exported: true,
+  });
 }
 
 async function writeSmokeSourcePng(filePath: string): Promise<void> {
-  const width = 256;
-  const height = 192;
-  const bitmap = Buffer.alloc(width * height * 4, 255);
-  const image = nativeImage.createFromBitmap(bitmap, { width, height });
-  if (image.isEmpty())
-    throw new Error("Mac package smoke source image is empty.");
-  await writeFile(filePath, image.toPNG());
+  if (!isPng(SMOKE_SOURCE_PNG)) {
+    throw new Error("Mac package smoke source fixture is not a PNG.");
+  }
+  await writeFile(filePath, SMOKE_SOURCE_PNG);
 }
 
 async function writeRenderedPage(
@@ -212,9 +223,39 @@ async function writeRenderedPage(
   });
   if (!png.length) throw new Error("Mac package smoke export was empty.");
   await writeFile(filePath, png);
-  const image = nativeImage.createFromBuffer(png);
-  if (image.isEmpty())
-    throw new Error("Mac package smoke export is not a PNG.");
+  if (!isPng(png)) throw new Error("Mac package smoke export is not a PNG.");
+}
+
+async function writeSmokeProgress(
+  markerPath: string,
+  stage: "preparing" | "verifying",
+  phase: string,
+  appPaths: AppPaths,
+): Promise<void> {
+  await writeSmokeMarker(markerPath, {
+    ok: true,
+    stage,
+    phase,
+    platform: process.platform,
+    arch: process.arch,
+    dataRoot: appPaths.dataRoot,
+  });
+}
+
+async function writeSmokeMarker(
+  markerPath: string,
+  value: Record<string, unknown>,
+): Promise<void> {
+  const temporaryPath = `${markerPath}.tmp-${process.pid}`;
+  await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(temporaryPath, markerPath);
+}
+
+function isPng(value: Buffer): boolean {
+  return (
+    value.length >= PNG_SIGNATURE.length &&
+    value.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)
+  );
 }
 
 function parsePreparedSmoke(value: string): PreparedSmoke {

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -302,8 +302,11 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(verifier).toContain('"-W",');
     expect(verifier).toContain('"--args",');
     expect(verifier).toContain('"--mgt-mac-package-smoke=alpha-ci-v1"');
+    expect(verifier).toContain('"--disable-gpu"');
     expect(verifier).toContain("waitForSmokeMarker");
     expect(verifier).toContain("collectApplicationSmokeDiagnostics");
+    expect(verifier).toContain('"bootstrap log"');
+    expect(verifier).toContain("contents.slice(0, 20 * 1024)");
     expect(verifier).toContain("result.signal");
     expect(verifier).toContain('"--entitlements",');
     const appSmoke = readFileSync(
@@ -317,6 +320,10 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(appSmoke).toContain("await savePageBlocks({");
     expect(appSmoke).toContain("await openChapter(prepared.chapterId)");
     expect(appSmoke).toContain("renderPageWithTranslationBlocksForExport");
+    expect(appSmoke).toContain("SMOKE_SOURCE_PNG");
+    expect(appSmoke).not.toContain("createFromBitmap");
+    expect(appSmoke).toContain('"export-page"');
+    expect(appSmoke).toContain("writeSmokeMarker");
   });
 
   it("pins the release workflow to the standard M1 runner and both signing modes", () => {


### PR DESCRIPTION
## What changed

- disable GPU only for the packaged macOS CI lifecycle smoke
- replace platform-dependent raw bitmap smoke input with a fixed valid PNG
- persist atomic phase markers and retain crash-report head/tail diagnostics

## Why

The Apple Silicon release run reached the packaged app smoke but Electron crashed natively on CrBrowserMain before writing the prepared marker. The launch was the only offscreen QA path that did not disable GPU, and its generated raw bitmap was platform-dependent.

## Validation

- npm test -- tests/macPackaging.test.ts
- npm run typecheck
- npm run typecheck:js
- npx eslint src/main/macPackageSmoke.ts tests/macPackaging.test.ts
- npx prettier --check src/main/macPackageSmoke.ts scripts/verify-mac-package.cjs tests/macPackaging.test.ts