### PR TITLE
Scope hosted Mac smoke waiver to known trap

### DIFF
--- a/.github/workflows/mac-alpha.yml
+++ b/.github/workflows/mac-alpha.yml
@@ -91,9 +91,12 @@ jobs:
           fi
 
       - name: Build and verify arm64 DMG and ZIP
+        env:
+          MGT_MAC_ALPHA_ALLOW_HOSTED_APP_SMOKE_TRAP: macos15-electron43-crbrowsermain-v1
+          MGT_MAC_ALPHA_RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: npm run dist:mac:alpha
 
-      - name: Confirm verified release artifacts
+      - name: Confirm release artifacts
         shell: bash
         run: |
           set -euo pipefail
@@ -137,7 +140,7 @@ jobs:
           MGT_MAC_RELEASE_NOTES_PATH: ${{ runner.temp }}/mac-alpha-release-notes.md
         run: node scripts/generate-mac-alpha-release-notes.cjs
 
-      - name: Upload verified build artifact
+      - name: Upload Alpha build artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.release_meta.outputs.tag }}
@@ -147,6 +150,7 @@ jobs:
             dist/*-macOS-arm64-alpha.dmg
             dist/*-macOS-arm64-alpha.zip
             dist/SHA256SUMS-mac-alpha.txt
+            dist/mac-alpha-hosted-app-smoke-waiver.json
             docs/MAC_ALPHA_TEST_CHECKLIST.md
             ${{ runner.temp }}/mac-alpha-release-notes.md
             ${{ runner.temp }}/mac-alpha-ui-1440x900.png
@@ -181,5 +185,10 @@ jobs:
             echo "### ${{ steps.release_meta.outputs.title }}"
             echo "- Runner: $(uname -m), $(sw_vers -productVersion)"
             echo "- Signing: $SIGNING_LABEL"
+            if [[ -f dist/mac-alpha-hosted-app-smoke-waiver.json ]]; then
+              echo "- Packaged GUI lifecycle: WAIVED on GitHub-hosted runner; real-Mac verification requested"
+            else
+              echo "- Packaged GUI lifecycle: passed"
+            fi
             echo "- Gemma memory tiers remain unverified until tester checklists are received."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/MAC_ALPHA_TEST_CHECKLIST.md
+++ b/docs/MAC_ALPHA_TEST_CHECKLIST.md
@@ -12,6 +12,7 @@
 
 ## 공통 흐름
 
+- [ ] `/Applications`에서 실행 → 작은 PNG 가져오기 → 저장 → 완전 종료 → 재실행 복원 → PNG/TXT 내보내기 전체 수명주기
 - [ ] `/Applications`에서 앱이 열리고 `Apple Silicon Alpha` 표시가 보임
 - [ ] 최초 Alpha 안내와 GitHub Issue 링크가 동작함
 - [ ] 이미지·폴더·ZIP/CBZ 가져오기

--- a/scripts/generate-mac-alpha-release-notes.cjs
+++ b/scripts/generate-mac-alpha-release-notes.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
 
-const { mkdirSync, writeFileSync } = require("node:fs");
+const { existsSync, mkdirSync, writeFileSync } = require("node:fs");
 const { dirname, join } = require("node:path");
 
 const root = join(__dirname, "..");
@@ -21,6 +21,9 @@ function main() {
   const issueUrl =
     "https://github.com/ucx0204/CarrotMangaTranslator/issues/new?template=mac_alpha.yml&title=%5BmacOS%20Alpha%5D%20";
   const unsigned = signingMode === "adhoc";
+  const hostedGuiSmokeWaived = existsSync(
+    join(root, "dist", "mac-alpha-hosted-app-smoke-waiver.json"),
+  );
   const title = unsigned
     ? `Unsigned Apple Silicon Alpha ${tag}`
     : `Apple Silicon Alpha ${tag}`;
@@ -74,6 +77,7 @@ ${installation.join("\n")}
 ## 알려진 제한
 
 - GitHub의 7GB M1 빌드 러너는 대형 모델 품질·장시간 메모리 시험을 대신하지 못합니다.
+${hostedGuiSmokeWaived ? "- GitHub 호스티드 macOS 15 러너에서 패키지 GUI 앱의 LaunchServices prepare 스모크가 Electron native EXC_BREAKPOINT/SIGTRAP(CrBrowserMain)으로 종료되어 이 수명주기는 CI에서 미검증입니다. arm64·서명·번들 런타임·OCR·Metal 검증은 통과했으며, 실제 Mac에서 앱 실행·가져오기·저장·재실행·내보내기 확인을 요청합니다." : "- 패키지 GUI 앱의 LaunchServices 가져오기·저장·재실행·내보내기 수명주기 스모크를 통과했습니다."}
 - 인증서가 없는 빌드는 ad-hoc 서명이므로 Gatekeeper에서 수동 승인이 필요합니다.
 - Intel Mac과 macOS 13 이하는 지원하지 않습니다.
 

--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -22,6 +22,12 @@ const { verifyMacRuntimeSmokes } = require("./verify-mac-runtime-smokes.cjs");
 
 const root = join(__dirname, "..");
 const distDir = join(root, "dist");
+const HOSTED_APP_SMOKE_WAIVER_TOKEN = "macos15-electron43-crbrowsermain-v1";
+const HOSTED_APP_SMOKE_WAIVER_PATH = join(
+  distDir,
+  "mac-alpha-hosted-app-smoke-waiver.json",
+);
+const SMOKE_APP_PATH = "/Applications/CarrotMangaTranslatorAlphaSmoke.app";
 
 /** @typedef {{ status: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string; error?: Error }} CommandResult */
 
@@ -280,10 +286,8 @@ function verifySigning(appPath) {
 
 /** @param {string} appPath */
 function verifyApplicationDirectorySmoke(appPath) {
-  const smokeApp = "/Applications/CarrotMangaTranslatorAlphaSmoke.app";
-  if (
-    resolve(smokeApp) !== "/Applications/CarrotMangaTranslatorAlphaSmoke.app"
-  ) {
+  const smokeApp = SMOKE_APP_PATH;
+  if (resolve(smokeApp) !== SMOKE_APP_PATH) {
     throw new Error(`Unsafe smoke app path: ${smokeApp}`);
   }
   rmSync(smokeApp, { recursive: true, force: true });
@@ -294,9 +298,15 @@ function verifyApplicationDirectorySmoke(appPath) {
     "manga-gemma-translator",
   );
   const marker = join(dataRoot, "mac-package-smoke.json");
+  /** @type {"copy" | "prepare" | "verify"} */
+  let smokeStage = "copy";
+  let smokeStartedAtMs = 0;
   rmSync(marker, { force: true });
   try {
     run("ditto", [appPath, smokeApp]);
+    run("codesign", ["--verify", "--deep", "--strict", smokeApp]);
+    smokeStage = "prepare";
+    smokeStartedAtMs = Date.now();
     runApplicationSmoke(smokeApp, "prepare");
     const prepared = waitForSmokeMarker(marker, "prepared", 120_000);
     if (
@@ -310,6 +320,7 @@ function verifyApplicationDirectorySmoke(appPath) {
         `Invalid packaged prepare smoke result: ${JSON.stringify(prepared)}`,
       );
     }
+    smokeStage = "verify";
     runApplicationSmoke(smokeApp, "verify");
     const smoke = waitForSmokeMarker(marker, "verified", 120_000);
     if (
@@ -334,14 +345,157 @@ function verifyApplicationDirectorySmoke(appPath) {
   } catch (error) {
     const message =
       error instanceof Error ? error.stack || error.message : String(error);
-    throw new Error(
-      `${message}\n${collectApplicationSmokeDiagnostics(dataRoot, marker)}`,
-      { cause: error },
-    );
+    const diagnostics = collectApplicationSmokeDiagnostics(dataRoot, marker);
+    const crashReport = findFreshApplicationCrashReport(smokeStartedAtMs);
+    if (
+      shouldAllowHostedGuiSmokeFailure({
+        stage: smokeStage,
+        markerExists: existsSync(marker),
+        message,
+        smokeStartedAtMs,
+        crashReport,
+      })
+    ) {
+      writeHostedAppSmokeWaiver(crashReport);
+      console.warn(
+        `[mac-verify] Hosted runner packaged GUI lifecycle smoke hit the known pre-ready Electron SIGTRAP. Continuing this explicitly opted-in Alpha build; real-Mac launch remains unverified.\n${message}\n${diagnostics}`,
+      );
+      return;
+    }
+    throw new Error(`${message}\n${diagnostics}`, { cause: error });
   } finally {
     rmSync(smokeApp, { recursive: true, force: true });
     rmSync(marker, { force: true });
   }
+}
+
+/**
+ * @typedef {{
+ *   path: string;
+ *   mtimeMs: number;
+ *   procPath: string;
+ *   exceptionType: string;
+ *   signal: string;
+ *   faultingThread: number;
+ *   triggered: boolean;
+ *   threadName: string;
+ * }} ApplicationCrashReport
+ */
+
+/**
+ * @param {number} smokeStartedAtMs
+ * @returns {ApplicationCrashReport | null}
+ */
+function findFreshApplicationCrashReport(smokeStartedAtMs) {
+  if (!Number.isFinite(smokeStartedAtMs) || smokeStartedAtMs <= 0) {
+    return null;
+  }
+  const reportsDir = join(homedir(), "Library", "Logs", "DiagnosticReports");
+  try {
+    const reportPaths = readdirSync(reportsDir)
+      .filter(
+        (name) =>
+          /CarrotMangaTranslator|당근망가번역기/i.test(name) &&
+          name.endsWith(".ips"),
+      )
+      .map((name) => join(reportsDir, name))
+      .filter(
+        (reportPath) =>
+          statSync(reportPath).mtimeMs >= smokeStartedAtMs - 5_000,
+      )
+      .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs);
+    for (const reportPath of reportPaths) {
+      const contents = readFileSync(reportPath, "utf8").replace(/^\uFEFF/, "");
+      const firstLineEnd = contents.indexOf("\n");
+      if (firstLineEnd < 0) continue;
+      /** @type {Record<string, any>} */
+      const report = JSON.parse(contents.slice(firstLineEnd + 1));
+      const faultingThread = Number(report.faultingThread);
+      const thread = Array.isArray(report.threads)
+        ? report.threads[faultingThread]
+        : undefined;
+      return {
+        path: reportPath,
+        mtimeMs: statSync(reportPath).mtimeMs,
+        procPath: String(report.procPath || ""),
+        exceptionType: String(report.exception?.type || ""),
+        signal: String(report.exception?.signal || ""),
+        faultingThread,
+        triggered: thread?.triggered === true,
+        threadName: String(thread?.name || ""),
+      };
+    }
+  } catch (_error) {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Alpha CI may downgrade only the exact, fresh pre-marker native crash observed
+ * on GitHub-hosted macOS 15 arm64 with Electron 43. Every other smoke failure
+ * remains release-blocking.
+ *
+ * @param {{
+ *   stage: "copy" | "prepare" | "verify";
+ *   markerExists: boolean;
+ *   message: string;
+ *   smokeStartedAtMs: number;
+ *   crashReport: ApplicationCrashReport | null;
+ * }} input
+ * @param {NodeJS.ProcessEnv} [environment]
+ */
+function shouldAllowHostedGuiSmokeFailure(input, environment = process.env) {
+  const report = input.crashReport;
+  return (
+    environment.MGT_MAC_ALPHA_ALLOW_HOSTED_APP_SMOKE_TRAP ===
+      HOSTED_APP_SMOKE_WAIVER_TOKEN &&
+    environment.MGT_MAC_ALPHA_RUNNER_ENVIRONMENT === "github-hosted" &&
+    environment.GITHUB_ACTIONS === "true" &&
+    environment.RUNNER_OS === "macOS" &&
+    environment.RUNNER_ARCH === "ARM64" &&
+    environment.GITHUB_REF === "refs/heads/master" &&
+    /\.github\/workflows\/mac-alpha\.yml@refs\/heads\/master$/.test(
+      String(environment.GITHUB_WORKFLOW_REF || ""),
+    ) &&
+    input.stage === "prepare" &&
+    input.markerExists === false &&
+    /Timed out waiting for packaged app smoke stage prepared/.test(
+      input.message,
+    ) &&
+    report !== null &&
+    report.mtimeMs >= input.smokeStartedAtMs - 5_000 &&
+    report.procPath ===
+      `${SMOKE_APP_PATH}/Contents/MacOS/CarrotMangaTranslator` &&
+    report.exceptionType === "EXC_BREAKPOINT" &&
+    report.signal === "SIGTRAP" &&
+    report.faultingThread === 0 &&
+    report.triggered === true &&
+    report.threadName === "CrBrowserMain"
+  );
+}
+
+/** @param {ApplicationCrashReport | null} report */
+function writeHostedAppSmokeWaiver(report) {
+  if (!report) throw new Error("Hosted app smoke waiver report is missing.");
+  writeFileSync(
+    HOSTED_APP_SMOKE_WAIVER_PATH,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        stage: "prepare",
+        reason: HOSTED_APP_SMOKE_WAIVER_TOKEN,
+        exception: report.exceptionType,
+        signal: report.signal,
+        thread: report.threadName,
+        runner: "github-hosted-macos-arm64",
+        runId: process.env.GITHUB_RUN_ID || "unknown",
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
 }
 
 /** @param {string} smokeApp @param {"prepare" | "verify"} stage */
@@ -483,6 +637,7 @@ async function main() {
   if (process.platform !== "darwin" || process.arch !== "arm64") {
     throw new Error("macOS package verification requires macOS arm64.");
   }
+  rmSync(HOSTED_APP_SMOKE_WAIVER_PATH, { force: true });
   const apps = findAppBundles(distDir);
   if (apps.length !== 1) {
     throw new Error(`Expected one unpacked .app in dist, found ${apps.length}`);
@@ -543,4 +698,5 @@ module.exports = {
   listFiles,
   looksLikeNativeBinary,
   requiresOtoolAlias,
+  shouldAllowHostedGuiSmokeFailure,
 };

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -52,9 +52,29 @@ const { configureElectronBuilderSigningEnvironment } =
       environment: NodeJS.ProcessEnv,
     ) => void;
   };
-const { requiresOtoolAlias } = require("../scripts/verify-mac-package.cjs") as {
-  requiresOtoolAlias: (filePath: string) => boolean;
-};
+const { requiresOtoolAlias, shouldAllowHostedGuiSmokeFailure } =
+  require("../scripts/verify-mac-package.cjs") as {
+    requiresOtoolAlias: (filePath: string) => boolean;
+    shouldAllowHostedGuiSmokeFailure: (
+      input: {
+        stage: "copy" | "prepare" | "verify";
+        markerExists: boolean;
+        message: string;
+        smokeStartedAtMs: number;
+        crashReport: {
+          path: string;
+          mtimeMs: number;
+          procPath: string;
+          exceptionType: string;
+          signal: string;
+          faultingThread: number;
+          triggered: boolean;
+          threadName: string;
+        } | null;
+      },
+      environment: NodeJS.ProcessEnv,
+    ) => boolean;
+  };
 
 describe("Apple Silicon Alpha packaging", () => {
   it("pins Electron and every downloaded executable runtime", () => {
@@ -254,6 +274,82 @@ describe("Apple Silicon Alpha packaging", () => {
     ).toContain("process.exit(1)");
   });
 
+  it("waives only the exact fresh GitHub-hosted pre-ready Electron trap", () => {
+    const environment: NodeJS.ProcessEnv = {
+      MGT_MAC_ALPHA_ALLOW_HOSTED_APP_SMOKE_TRAP:
+        "macos15-electron43-crbrowsermain-v1",
+      MGT_MAC_ALPHA_RUNNER_ENVIRONMENT: "github-hosted",
+      GITHUB_ACTIONS: "true",
+      RUNNER_OS: "macOS",
+      RUNNER_ARCH: "ARM64",
+      GITHUB_REF: "refs/heads/master",
+      GITHUB_WORKFLOW_REF:
+        "ucx0204/CarrotMangaTranslator/.github/workflows/mac-alpha.yml@refs/heads/master",
+    };
+    const input = {
+      stage: "prepare" as const,
+      markerExists: false,
+      message: "Timed out waiting for packaged app smoke stage prepared",
+      smokeStartedAtMs: 10_000,
+      crashReport: {
+        path: "/Users/runner/Library/Logs/DiagnosticReports/smoke.ips",
+        mtimeMs: 12_000,
+        procPath:
+          "/Applications/CarrotMangaTranslatorAlphaSmoke.app/Contents/MacOS/CarrotMangaTranslator",
+        exceptionType: "EXC_BREAKPOINT",
+        signal: "SIGTRAP",
+        faultingThread: 0,
+        triggered: true,
+        threadName: "CrBrowserMain",
+      },
+    };
+
+    expect(shouldAllowHostedGuiSmokeFailure(input, environment)).toBe(true);
+    expect(
+      shouldAllowHostedGuiSmokeFailure(
+        { ...input, stage: "verify" },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldAllowHostedGuiSmokeFailure(
+        { ...input, markerExists: true },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldAllowHostedGuiSmokeFailure(
+        {
+          ...input,
+          crashReport: { ...input.crashReport, signal: "SIGABRT" },
+        },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldAllowHostedGuiSmokeFailure(input, {
+        ...environment,
+        MGT_MAC_ALPHA_RUNNER_ENVIRONMENT: "self-hosted",
+      }),
+    ).toBe(false);
+    expect(
+      shouldAllowHostedGuiSmokeFailure(
+        {
+          ...input,
+          crashReport: { ...input.crashReport, mtimeMs: 1_000 },
+        },
+        environment,
+      ),
+    ).toBe(false);
+    expect(
+      shouldAllowHostedGuiSmokeFailure(input, {
+        ...environment,
+        GITHUB_WORKFLOW_REF:
+          "ucx0204/CarrotMangaTranslator/.github/workflows/check.yml@refs/heads/master",
+      }),
+    ).toBe(false);
+  });
+
   it("keeps Windows resources out of the arm64 app configuration", () => {
     const config = readFileSync(
       join(repoRoot, "electron-builder.config.cjs"),
@@ -305,6 +401,11 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(verifier).toContain('"--disable-gpu"');
     expect(verifier).toContain("waitForSmokeMarker");
     expect(verifier).toContain("collectApplicationSmokeDiagnostics");
+    expect(verifier).toContain("shouldAllowHostedGuiSmokeFailure");
+    expect(verifier).toContain("findFreshApplicationCrashReport");
+    expect(verifier).toContain("mac-alpha-hosted-app-smoke-waiver.json");
+    expect(verifier).toContain("EXC_BREAKPOINT");
+    expect(verifier).toContain("CrBrowserMain");
     expect(verifier).toContain('"bootstrap log"');
     expect(verifier).toContain("contents.slice(0, 20 * 1024)");
     expect(verifier).toContain("result.signal");
@@ -342,9 +443,15 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(workflow).toContain("APPLE_API_KEY_P8_B64");
     expect(workflow).toContain("MGT_MAC_SIGNING_MODE=adhoc");
     expect(workflow).toContain("MGT_MAC_SIGNING_MODE=developer-id");
+    expect(workflow).toContain(
+      "MGT_MAC_ALPHA_ALLOW_HOSTED_APP_SMOKE_TRAP: macos15-electron43-crbrowsermain-v1",
+    );
+    expect(workflow).toContain(
+      "MGT_MAC_ALPHA_RUNNER_ENVIRONMENT: ${{ runner.environment }}",
+    );
     expect(workflow).toContain("--prerelease");
     expect(workflow).toContain("SHA256SUMS-mac-alpha.txt");
-    expect(workflow).toContain("Confirm verified release artifacts");
+    expect(workflow).toContain("Confirm release artifacts");
     expect(workflow).toContain("MAC_ALPHA_TEST_CHECKLIST.md");
     expect(workflow).toContain("mac-alpha-ui-1440x900.png");
     expect(workflow).toContain("mac-alpha-ui-1240x760.png");


### PR DESCRIPTION
## What changed

- downgrade only the exact fresh GitHub-hosted macOS 15 Electron 43 pre-ready SIGTRAP during the first packaged LaunchServices probe
- require master workflow identity, arm64 hosted runner identity, exact versioned opt-in token, no marker, exact app path, and structured .ips fields
- keep signing, arm64 payload, OCR, Metal runtime, DMG, and checksum checks release-blocking
- record a sanitized waiver sentinel and disclose the unverified GUI lifecycle in release notes and tester checklist

## Why

The packaged app exits in the GitHub-hosted non-interactive session before app.whenReady with EXC_BREAKPOINT/SIGTRAP on CrBrowserMain. The user explicitly requested an honest real-Mac-unverified Alpha release so volunteers can test it.

## Validation

- npm test -- tests/macPackaging.test.ts (11 passed, 1 skipped)
- npm run typecheck
- npm run typecheck:js
- targeted ESLint and Prettier checks
- generated unsigned release notes with a waiver sentinel and verified the warning text