### PR TITLE
Stabilize macOS bootstrap and Flux Metal inpainting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
+.DS_Store
+.mac-alpha-onboarding-v1
 out/
 dist/
 .tmp/
@@ -21,6 +23,8 @@ tools/llama-b8833-cuda13.1/
 tools/beellama*/
 tools/mgt-flux-cuda12.*/
 tools/mgt-flux-klein-runner/target/
+tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/Cargo.lock
+tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/target/
 tools/mgt-koharu-inpaint-runner/target/
 tools/mgt-flux-klein-sm*/
 tools/mgt-flux-klein/*.exe

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -1,9 +1,11 @@
 const http = require("node:http");
 const net = require("node:net");
 const { join } = require("node:path");
-const { existsSync } = require("node:fs");
 const { spawn, spawnSync } = require("node:child_process");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
+const {
+  resolveMissingMacInpaintingRunners,
+} = require("./mac-inpainting-runners.cjs");
 const { prepareRuntimeAssets } = require("./prepare-runtime.cjs");
 
 const root = join(__dirname, "..");
@@ -36,6 +38,19 @@ function runSync(command, args) {
   });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
+  }
+}
+
+function prepareMacInpaintingRunners() {
+  const missing = resolveMissingMacInpaintingRunners(root);
+  if (missing.length === 0) return;
+  log(`building ${missing.length} missing Metal inpainting runner(s)`);
+  runSync(process.execPath, [join(__dirname, "build-mac-runners.cjs")]);
+  const remaining = resolveMissingMacInpaintingRunners(root);
+  if (remaining.length > 0) {
+    throw new Error(
+      `Metal inpainting runner build completed without: ${remaining.join(", ")}`,
+    );
   }
 }
 
@@ -184,6 +199,7 @@ function shutdown(exitCode = 0) {
 }
 
 (async () => {
+  prepareMacInpaintingRunners();
   log("preparing runtime assets");
   prepareRuntimeAssets({ root, outputDir: join(root, "out", "app-runtime") });
   log("compiling Electron main process");
@@ -204,10 +220,7 @@ function shutdown(exitCode = 0) {
   ]);
   log(`waiting for renderer ${rendererUrl}`);
   await waitForUrl(rendererUrl);
-  const electronExe = resolveElectronExecutable(root);
-  if (!existsSync(electronExe)) {
-    throw new Error(`Electron executable is missing: ${electronExe}`);
-  }
+  const electronExe = ensureElectronExecutable(root);
   spawnChild("electron", electronExe, ["."], {
     ELECTRON_RENDERER_URL: rendererUrl,
     ELECTRON_RUN_AS_NODE: undefined,

--- a/scripts/electron-executable.cjs
+++ b/scripts/electron-executable.cjs
@@ -1,4 +1,6 @@
 // @ts-check
+const { spawnSync } = require("node:child_process");
+const { existsSync } = require("node:fs");
 const { join } = require("node:path");
 
 /**
@@ -14,4 +16,38 @@ function resolveElectronExecutable(root, platform = process.platform) {
   return join(distRoot, "electron");
 }
 
-module.exports = { resolveElectronExecutable };
+/**
+ * Electron 42+ downloads its binary on first use instead of during npm install.
+ * These scripts launch the binary directly, so mirror that first-use bootstrap
+ * before returning the executable path.
+ *
+ * @param {string} root
+ * @param {NodeJS.Platform} [platform]
+ */
+function ensureElectronExecutable(root, platform = process.platform) {
+  const executablePath = resolveElectronExecutable(root, platform);
+  if (existsSync(executablePath)) {
+    return executablePath;
+  }
+
+  const installerPath = join(root, "node_modules", "electron", "install.js");
+  const result = spawnSync(process.execPath, [installerPath], {
+    cwd: root,
+    stdio: "inherit",
+    shell: false,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Electron binary installation failed with exit code ${result.status ?? "null"}.`,
+    );
+  }
+  if (!existsSync(executablePath)) {
+    throw new Error(`Electron installer did not create: ${executablePath}`);
+  }
+  return executablePath;
+}
+
+module.exports = { ensureElectronExecutable, resolveElectronExecutable };

--- a/scripts/mac-inpainting-runners.cjs
+++ b/scripts/mac-inpainting-runners.cjs
@@ -1,0 +1,54 @@
+// @ts-check
+const { statSync } = require("node:fs");
+const { join } = require("node:path");
+
+const MAC_INPAINTING_RUNNERS = [
+  "mgt-koharu-inpaint-runner",
+  "mgt-flux-klein-runner",
+];
+
+/** @param {string} root */
+function resolveMacInpaintingRunnerPaths(root) {
+  return MAC_INPAINTING_RUNNERS.map((directory) => {
+    const executable =
+      directory === "mgt-flux-klein-runner" ? "mgt-flux-klein" : directory;
+    return join(
+      root,
+      "tools",
+      directory,
+      "target",
+      "aarch64-apple-darwin",
+      "release",
+      executable,
+    );
+  });
+}
+
+/** @param {string} filePath */
+function isUsableExecutable(filePath) {
+  try {
+    const stat = statSync(filePath);
+    return stat.isFile() && stat.size > 0 && (stat.mode & 0o111) !== 0;
+  } catch (_error) {
+    return false;
+  }
+}
+
+/**
+ * @param {string} root
+ * @param {{ platform?: NodeJS.Platform; arch?: string; isUsable?: (filePath: string) => boolean }} [options]
+ */
+function resolveMissingMacInpaintingRunners(root, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  if (platform !== "darwin" || arch !== "arm64") return [];
+  const isUsable = options.isUsable ?? isUsableExecutable;
+  return resolveMacInpaintingRunnerPaths(root).filter(
+    (filePath) => !isUsable(filePath),
+  );
+}
+
+module.exports = {
+  resolveMacInpaintingRunnerPaths,
+  resolveMissingMacInpaintingRunners,
+};

--- a/scripts/run-flux-pattern-smoke.cjs
+++ b/scripts/run-flux-pattern-smoke.cjs
@@ -1,15 +1,10 @@
 const { spawnSync } = require("node:child_process");
-const { existsSync } = require("node:fs");
 const { join } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const smokeScript = join(root, "scripts", "smoke-flux-pattern-chapter.cjs");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 /** @type {NodeJS.ProcessEnv} */
 const env = {

--- a/scripts/run-gemma-economy-benchmark.cjs
+++ b/scripts/run-gemma-economy-benchmark.cjs
@@ -1,15 +1,10 @@
 const { spawnSync } = require("node:child_process");
-const { existsSync } = require("node:fs");
 const { join } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const benchmarkScript = join(root, "scripts", "benchmark-gemma-economy.cjs");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 const env = { ...process.env };
 delete env.ELECTRON_RUN_AS_NODE;

--- a/scripts/run-image-protocol-smoke.cjs
+++ b/scripts/run-image-protocol-smoke.cjs
@@ -1,12 +1,12 @@
 // @ts-check
 const { spawn } = require("node:child_process");
-const { existsSync, mkdirSync } = require("node:fs");
+const { mkdirSync } = require("node:fs");
 const { readFile, rm } = require("node:fs/promises");
 const { isAbsolute, join, relative, resolve } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const smokeScript = join(root, "scripts", "smoke-image-protocol.cjs");
 const smokeTempRoot = join(
   root,
@@ -16,10 +16,6 @@ const smokeTempRoot = join(
 );
 const userDataDir = join(smokeTempRoot, "electron-user-data");
 const resultPath = join(smokeTempRoot, "result.json");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 assertPathInsideRoot(smokeTempRoot);
 mkdirSync(userDataDir, { recursive: true });

--- a/scripts/run-smoke-overlay.cjs
+++ b/scripts/run-smoke-overlay.cjs
@@ -1,15 +1,10 @@
 const { spawnSync } = require("node:child_process");
-const { existsSync } = require("node:fs");
 const { join } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const smokeScript = join(root, "scripts", "smoke-overlay.cjs");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 const env = { ...process.env };
 delete env.ELECTRON_RUN_AS_NODE;

--- a/scripts/smoke-flux-pattern-chapter.cjs
+++ b/scripts/smoke-flux-pattern-chapter.cjs
@@ -74,12 +74,18 @@ async function main() {
   );
 
   if (!process.env.MGT_FLUX_KLEIN_EXE) {
-    const localMgtFlux = path.join(
-      ROOT,
-      "tools",
-      "mgt-flux-klein",
-      "mgt-flux-klein.exe",
-    );
+    const localMgtFlux =
+      process.platform === "darwin" && process.arch === "arm64"
+        ? path.join(
+            ROOT,
+            "tools",
+            "mgt-flux-klein-runner",
+            "target",
+            "aarch64-apple-darwin",
+            "release",
+            "mgt-flux-klein",
+          )
+        : path.join(ROOT, "tools", "mgt-flux-klein", "mgt-flux-klein.exe");
     if (existsSync(localMgtFlux)) {
       process.env.MGT_FLUX_KLEIN_EXE = localMgtFlux;
     }
@@ -93,6 +99,10 @@ async function main() {
       "mgt-flux-klein-runtime",
     ),
     modelDir: path.join(ROOT, "models", "inpainting", "flux-klein-4b"),
+    fluxBackend:
+      process.platform === "darwin" && process.arch === "arm64"
+        ? "metal-native"
+        : undefined,
     onProgress:
       /** @param {FluxProgress} progress */
       (progress) => {

--- a/src/main/inpainting/fluxEngineRunner.ts
+++ b/src/main/inpainting/fluxEngineRunner.ts
@@ -20,6 +20,7 @@ import {
   writePngFromBitmap,
   writePngFromMask,
 } from "./imageRaster";
+import { matchFluxOutputToOriginalContext } from "./fluxToneCorrection";
 import {
   alignRectToMultiple,
   expandRect,
@@ -218,6 +219,11 @@ async function processFluxWindow({
     paths.outputPath,
     crop.paddedBounds.w,
     crop.paddedBounds.h,
+  );
+  matchFluxOutputToOriginalContext(
+    cropBitmap,
+    generated,
+    crop.validationMask,
   );
   const changeStats = measureMaskedRegionChange(
     cropBitmap,

--- a/src/main/inpainting/fluxToneCorrection.ts
+++ b/src/main/inpainting/fluxToneCorrection.ts
@@ -1,0 +1,152 @@
+import { clamp } from "../../shared/geometry";
+
+export function matchFluxOutputToOriginalContext(
+  original: Buffer,
+  generated: Buffer,
+  inpaintMask: Uint8Array,
+): boolean {
+  const pixelCount = Math.min(
+    inpaintMask.length,
+    Math.floor(original.length / 4),
+    Math.floor(generated.length / 4),
+  );
+  const stats = measureFluxContextTone(
+    original,
+    generated,
+    inpaintMask,
+    pixelCount,
+  );
+  if (!stats || !fluxContextNeedsCorrection(stats)) {
+    return false;
+  }
+  const luminanceScale = clamp(stats.originalYStd / stats.generatedYStd, 0.5, 2);
+  const cbShift = stats.originalCbMean - stats.generatedCbMean;
+  const crShift = stats.originalCrMean - stats.generatedCrMean;
+  for (let index = 0; index < pixelCount; index += 1) {
+    const offset = index * 4;
+    const tone = rgbToYCbCr(
+      generated[offset] ?? 0,
+      generated[offset + 1] ?? 0,
+      generated[offset + 2] ?? 0,
+    );
+    const corrected = yCbCrToRgb(
+      (tone.y - stats.generatedYMean) * luminanceScale +
+        stats.originalYMean,
+      tone.cb + cbShift,
+      tone.cr + crShift,
+    );
+    generated[offset] = corrected.r;
+    generated[offset + 1] = corrected.g;
+    generated[offset + 2] = corrected.b;
+  }
+  return true;
+}
+
+type FluxContextToneStats = {
+  generatedCbMean: number;
+  generatedCrMean: number;
+  generatedYMean: number;
+  generatedYStd: number;
+  originalCbMean: number;
+  originalCrMean: number;
+  originalYMean: number;
+  originalYStd: number;
+};
+
+function measureFluxContextTone(
+  original: Buffer,
+  generated: Buffer,
+  inpaintMask: Uint8Array,
+  pixelCount: number,
+): FluxContextToneStats | null {
+  let samples = 0;
+  let originalY = 0;
+  let originalYSquared = 0;
+  let originalCb = 0;
+  let originalCr = 0;
+  let generatedY = 0;
+  let generatedYSquared = 0;
+  let generatedCb = 0;
+  let generatedCr = 0;
+  for (let index = 0; index < pixelCount; index += 1) {
+    if (inpaintMask[index]) {
+      continue;
+    }
+    const offset = index * 4;
+    const originalTone = rgbToYCbCr(
+      original[offset] ?? 0,
+      original[offset + 1] ?? 0,
+      original[offset + 2] ?? 0,
+    );
+    const generatedTone = rgbToYCbCr(
+      generated[offset] ?? 0,
+      generated[offset + 1] ?? 0,
+      generated[offset + 2] ?? 0,
+    );
+    samples += 1;
+    originalY += originalTone.y;
+    originalYSquared += originalTone.y * originalTone.y;
+    originalCb += originalTone.cb;
+    originalCr += originalTone.cr;
+    generatedY += generatedTone.y;
+    generatedYSquared += generatedTone.y * generatedTone.y;
+    generatedCb += generatedTone.cb;
+    generatedCr += generatedTone.cr;
+  }
+  if (samples < 64) {
+    return null;
+  }
+  const originalYMean = originalY / samples;
+  const generatedYMean = generatedY / samples;
+  return {
+    originalYMean,
+    originalYStd: Math.sqrt(
+      Math.max(1e-6, originalYSquared / samples - originalYMean ** 2),
+    ),
+    originalCbMean: originalCb / samples,
+    originalCrMean: originalCr / samples,
+    generatedYMean,
+    generatedYStd: Math.sqrt(
+      Math.max(1e-6, generatedYSquared / samples - generatedYMean ** 2),
+    ),
+    generatedCbMean: generatedCb / samples,
+    generatedCrMean: generatedCr / samples,
+  };
+}
+
+function fluxContextNeedsCorrection(stats: FluxContextToneStats): boolean {
+  return (
+    Math.abs(stats.originalYMean - stats.generatedYMean) >= 1.3 ||
+    Math.abs(stats.originalYStd - stats.generatedYStd) >= 2 ||
+    Math.abs(stats.originalCbMean - stats.generatedCbMean) >= 1 ||
+    Math.abs(stats.originalCrMean - stats.generatedCrMean) >= 1
+  );
+}
+
+function rgbToYCbCr(
+  r: number,
+  g: number,
+  b: number,
+): { y: number; cb: number; cr: number } {
+  return {
+    y: 0.299 * r + 0.587 * g + 0.114 * b,
+    cb: 128 - 0.168736 * r - 0.331264 * g + 0.5 * b,
+    cr: 128 + 0.5 * r - 0.418688 * g - 0.081312 * b,
+  };
+}
+
+function yCbCrToRgb(
+  y: number,
+  cb: number,
+  cr: number,
+): { r: number; g: number; b: number } {
+  return {
+    r: clamp(Math.round(y + 1.402 * (cr - 128)), 0, 255),
+    g: clamp(
+      Math.round(y - 0.344136 * (cb - 128) - 0.714136 * (cr - 128)),
+      0,
+      255,
+    ),
+    b: clamp(Math.round(y + 1.772 * (cb - 128)), 0, 255),
+  };
+}

--- a/src/main/inpainting/maskGeometry.ts
+++ b/src/main/inpainting/maskGeometry.ts
@@ -192,18 +192,30 @@ export function resolveFluxProcessSize(
   maxPixels: number,
   multiple: number,
 ): { width: number; height: number } {
-  let scale = 1;
-  if (width * height > maxPixels) {
-    scale = Math.sqrt(maxPixels / Math.max(1, width * height));
+  const safeWidth = Math.max(1, width);
+  const safeHeight = Math.max(1, height);
+  const safeMaxPixels = Math.max(multiple * multiple, maxPixels);
+  const maxDimension = 2048;
+  const scale = Math.min(
+    Math.sqrt(safeMaxPixels / (safeWidth * safeHeight)),
+    maxDimension / safeWidth,
+    maxDimension / safeHeight,
+  );
+  let scaledWidth = Math.max(
+    multiple,
+    Math.round((safeWidth * scale) / multiple) * multiple,
+  );
+  let scaledHeight = Math.max(
+    multiple,
+    Math.round((safeHeight * scale) / multiple) * multiple,
+  );
+  while (scaledWidth * scaledHeight > safeMaxPixels) {
+    if (scaledWidth / safeWidth >= scaledHeight / safeHeight) {
+      scaledWidth = Math.max(multiple, scaledWidth - multiple);
+    } else {
+      scaledHeight = Math.max(multiple, scaledHeight - multiple);
+    }
   }
-  const scaledWidth = Math.max(
-    multiple,
-    Math.round((width * scale) / multiple) * multiple,
-  );
-  const scaledHeight = Math.max(
-    multiple,
-    Math.round((height * scale) / multiple) * multiple,
-  );
   return {
     width: scaledWidth,
     height: scaledHeight,

--- a/src/main/pipeline/overlayItems.ts
+++ b/src/main/pipeline/overlayItems.ts
@@ -66,7 +66,7 @@ export function overlayItemToBlock(
     page,
     fontSizePx,
   );
-  const rotationDeg = enforceRotationDeg(type, item.angle ?? 0);
+  const rotationDeg = resolveInitialRotationDeg(type, textRole, item.angle);
   const visualStyle = resolveBlockVisualStyle(type);
   const block: TranslationBlock = {
     id: `${page.id}-${normalizeBlockRunId(runId)}-block-${index + 1}`,
@@ -250,6 +250,18 @@ function resolveInitialRenderDirection(
   }
 
   return enforceRenderDirection(type, "horizontal");
+}
+
+function resolveInitialRotationDeg(
+  type: BlockType,
+  textRole: NormalizedTextRole,
+  angle: unknown,
+): number {
+  // Ordinary speech and captions should stay upright in the translated
+  // overlay. Vision models occasionally interpret vertical Japanese glyphs as
+  // a negative slant, which used to rotate the whole Korean block to the left.
+  // Sound effects intentionally preserve the detected source styling.
+  return enforceRotationDeg(type, textRole === "sound" ? (angle ?? 0) : 0);
 }
 
 function shouldKeepVerticalRendering(

--- a/src/main/runtime/assets/ffmpeg-path.cjs
+++ b/src/main/runtime/assets/ffmpeg-path.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const { existsSync } = require("node:fs");
+const { existsSync, statSync } = require("node:fs");
 const path = require("node:path");
 
 const {
@@ -25,7 +25,7 @@ function bundledFfmpegCandidates(toolsDir) {
 function resolveFfmpegPath(options = {}) {
   const toolsDir = resolveToolsDir(options);
   const candidates = bundledFfmpegCandidates(toolsDir);
-  const bundledPath = candidates.find((candidate) => existsSync(candidate));
+  const bundledPath = candidates.find(isExistingFilePath);
   if (bundledPath) return bundledPath;
   if (isLikelyPackagedToolsDir(toolsDir)) {
     throw createDetailedError(
@@ -40,8 +40,34 @@ function resolveFfmpegPath(options = {}) {
   const explicit = [
     options.ffmpegPath,
     runtimeOverrideEnv("MANGA_TRANSLATOR_FFMPEG_PATH", options),
-  ].find((candidate) => typeof candidate === "string" && existsSync(candidate));
-  return explicit || (process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg");
+  ].find(isExistingFilePath);
+  return (
+    explicit ||
+    resolveDevelopmentFfmpegPath() ||
+    (process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg")
+  );
 }
 
-module.exports = { resolveFfmpegPath };
+/** @returns {string | null} */
+function resolveDevelopmentFfmpegPath() {
+  try {
+    const ffmpegPath = /** @type {unknown} */ (require("ffmpeg-static"));
+    return isExistingFilePath(ffmpegPath)
+      ? /** @type {string} */ (ffmpegPath)
+      : null;
+  } catch (_error) {
+    // error-policy-allow: packaged apps use the verified bundled tools directory.
+    return null;
+  }
+}
+
+/** @param {unknown} candidate */
+function isExistingFilePath(candidate) {
+  return (
+    typeof candidate === "string" &&
+    existsSync(candidate) &&
+    statSync(candidate).isFile()
+  );
+}
+
+module.exports = { resolveDevelopmentFfmpegPath, resolveFfmpegPath };

--- a/src/main/runtime/model/server-preflight.cjs
+++ b/src/main/runtime/model/server-preflight.cjs
@@ -187,7 +187,10 @@ function llamaRuntimeProbeLooksGpuBacked(output, backend = "cuda") {
   const normalized = String(backend || "cuda").toLowerCase();
   if (normalized === "vulkan") return /(vulkan|radeon|amd|gpu)/i.test(text);
   if (normalized === "metal") {
-    return /metal/i.test(text) && /(apple|gpu|m[1-9])/i.test(text);
+    return (
+      (/metal/i.test(text) && /(apple|gpu|m[1-9])/i.test(text)) ||
+      /^\s*MTL\d+:\s*Apple\s+M\d+/im.test(text)
+    );
   }
   if (normalized === "rocm" || normalized === "hip")
     return /(rocm|hip|radeon|amd|gpu)/i.test(text);

--- a/src/main/runtime/ocr/bbox-batch-config.cjs
+++ b/src/main/runtime/ocr/bbox-batch-config.cjs
@@ -104,7 +104,8 @@ function resolveOcrCpuWorkerMinFreeRamRatio(dependencies, options = {}) {
     ),
     options.ocrCpuWorkerMinFreeRamPercent,
   ]);
-  return Math.max(0, Math.min(95, explicit ?? 20)) / 100;
+  const defaultPercent = dependencies.os.platform() === "darwin" ? 0 : 20;
+  return Math.max(0, Math.min(95, explicit ?? defaultPercent)) / 100;
 }
 
 /** @param {Dependencies} dependencies @param {OcrBboxOptions} [options] */

--- a/src/main/runtime/ocr/runtime-layout.cjs
+++ b/src/main/runtime/ocr/runtime-layout.cjs
@@ -262,7 +262,9 @@ function resolveBootstrapPython(
   if (bundled) {
     return bundled;
   }
-  return shouldAllowSystemPythonFallback(options) ? "python" : null;
+  return shouldAllowSystemPythonFallback(options)
+    ? resolveSystemPythonCommand()
+    : null;
 }
 
 /** @param {string[]} candidates @returns {string | null} */
@@ -270,9 +272,19 @@ function findAvailablePython(candidates) {
   return (
     candidates.find(
       (candidate) =>
-        candidate && (candidate === "python" || existsSync(candidate)),
+        candidate && (isPythonCommand(candidate) || existsSync(candidate)),
     ) || null
   );
+}
+
+/** @param {string} candidate @returns {boolean} */
+function isPythonCommand(candidate) {
+  return candidate === "python" || candidate === "python3";
+}
+
+/** @returns {string} */
+function resolveSystemPythonCommand() {
+  return process.platform === "win32" ? "python" : "python3";
 }
 
 /** @param {RuntimeOptions} [options] @returns {boolean} */

--- a/src/main/runtime/simple-page-tar-utils.cjs
+++ b/src/main/runtime/simple-page-tar-utils.cjs
@@ -5,7 +5,7 @@ const {
   readlinkSync,
   realpathSync,
 } = require("node:fs");
-const { chmod, mkdir } = require("node:fs/promises");
+const { chmod, mkdir, rm, symlink } = require("node:fs/promises");
 const path = require("node:path");
 const tar = require("tar");
 
@@ -41,19 +41,25 @@ async function extractSelectedTarEntries(
     unlink: true,
     filter: (entryPath, entry) => {
       const tarEntry = /** @type {any} */ (entry);
-      return shouldExtractTarEntry(
-        {
-          path: entryPath,
-          type: tarEntry.type,
-          linkpath: tarEntry.linkpath,
-          size: tarEntry.size,
-          mode: tarEntry.mode,
-        },
-        stripComponents,
-        shouldExtract,
+      const entryInfo = {
+        path: entryPath,
+        type: tarEntry.type,
+        linkpath: tarEntry.linkpath,
+        size: tarEntry.size,
+        mode: tarEntry.mode,
+      };
+      return (
+        !isSymbolicLinkType(entryInfo.type) &&
+        shouldExtractTarEntry(entryInfo, stripComponents, shouldExtract)
       );
     },
   });
+  await createSelectedTarSymlinks(
+    entries,
+    outputDir,
+    stripComponents,
+    shouldExtract,
+  );
   assertExtractedSymlinksStayInside(outputDir);
   const serverPath = path.join(outputDir, "llama-server");
   try {
@@ -61,6 +67,29 @@ async function extractSelectedTarEntries(
   } catch (_error) {
     // error-policy-allow: the caller validates and reports a missing server.
     // The caller reports the missing required binary with runtime details.
+  }
+}
+
+/** @param {TarEntryInfo[]} entries @param {string} outputDir @param {number} stripComponents @param {RuntimeEntryFilter} shouldExtract */
+async function createSelectedTarSymlinks(
+  entries,
+  outputDir,
+  stripComponents,
+  shouldExtract,
+) {
+  for (const entry of entries) {
+    if (
+      !isSymbolicLinkType(entry.type) ||
+      !shouldExtractTarEntry(entry, stripComponents, shouldExtract)
+    ) {
+      continue;
+    }
+    const safePath = normalizeSafeArchivePath(entry.path);
+    const outputPath = stripArchivePath(safePath, stripComponents);
+    const linkPath = path.join(outputDir, outputPath);
+    await mkdir(path.dirname(linkPath), { recursive: true });
+    await rm(linkPath, { force: true });
+    await symlink(String(entry.linkpath), linkPath);
   }
 }
 
@@ -226,6 +255,7 @@ function inspectExtractedEntry(entryPath, root, stack) {
 function assertSafeExtractedSymlink(entryPath, root) {
   const target = readlinkSync(entryPath);
   const resolved = path.resolve(path.dirname(entryPath), target);
+  const realRoot = realpathSync(root);
   let realResolved;
   try {
     realResolved = realpathSync(entryPath);
@@ -234,7 +264,7 @@ function assertSafeExtractedSymlink(entryPath, root) {
       cause,
     });
   }
-  if (!isPathInside(resolved, root) || !isPathInside(realResolved, root)) {
+  if (!isPathInside(resolved, root) || !isPathInside(realResolved, realRoot)) {
     throw new Error(
       `Extracted runtime symlink escapes extraction root: ${entryPath}`,
     );

--- a/tests/electronExecutable.test.ts
+++ b/tests/electronExecutable.test.ts
@@ -1,8 +1,20 @@
-import { join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const { resolveElectronExecutable } =
+const { ensureElectronExecutable, resolveElectronExecutable } =
   require("../scripts/electron-executable.cjs") as {
+    ensureElectronExecutable: (
+      root: string,
+      platform: NodeJS.Platform,
+    ) => string;
     resolveElectronExecutable: (
       root: string,
       platform: NodeJS.Platform,
@@ -32,5 +44,36 @@ describe("Electron executable resolution", () => {
     expect(resolveElectronExecutable("/repo", "linux")).toBe(
       join("/repo", "node_modules", "electron", "dist", "electron"),
     );
+  });
+
+  it("downloads the Electron binary before a direct first launch", () => {
+    const temporaryRoot = mkdtempSync(
+      join(tmpdir(), "mgt-electron-bootstrap-"),
+    );
+    try {
+      const installerPath = join(
+        temporaryRoot,
+        "node_modules",
+        "electron",
+        "install.js",
+      );
+      const executablePath = resolveElectronExecutable(
+        temporaryRoot,
+        process.platform,
+      );
+      mkdirSync(dirname(installerPath), { recursive: true });
+      writeFileSync(
+        installerPath,
+        `require("node:fs").mkdirSync(${JSON.stringify(dirname(executablePath))}, { recursive: true });\nrequire("node:fs").writeFileSync(${JSON.stringify(executablePath)}, "electron");\n`,
+        "utf8",
+      );
+
+      expect(ensureElectronExecutable(temporaryRoot, process.platform)).toBe(
+        executablePath,
+      );
+      expect(existsSync(executablePath)).toBe(true);
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/ffmpegPath.test.ts
+++ b/tests/ffmpegPath.test.ts
@@ -1,0 +1,32 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const { resolveFfmpegPath } =
+  require("../src/main/runtime/assets/ffmpeg-path.cjs") as {
+    resolveFfmpegPath: (options: { toolsDir: string }) => string;
+  };
+
+describe("FFmpeg path resolution", () => {
+  it("uses the installed development FFmpeg when tools has no bundled copy", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "mgt-ffmpeg-path-"));
+    const toolsDir = join(temporaryRoot, "tools");
+    mkdirSync(join(toolsDir, "ffmpeg"), { recursive: true });
+
+    try {
+      const ffmpegPath = resolveFfmpegPath({ toolsDir });
+      const result = spawnSync(ffmpegPath, ["-version"], {
+        encoding: "utf8",
+        shell: false,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("ffmpeg version");
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/fluxEngine.test.ts
+++ b/tests/fluxEngine.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolveFluxProcessSize } from "../src/main/inpainting/maskGeometry";
 
 const tempDirs: string[] = [];
 
@@ -17,6 +18,43 @@ afterEach(() => {
 });
 
 describe("Flux inpainting engine change detection", () => {
+  it("upscales small crops to the model pixel budget", () => {
+    const size = resolveFluxProcessSize(320, 160, 1024 * 1024, 16);
+
+    expect(size.width).toBeGreaterThan(320);
+    expect(size.height).toBeGreaterThan(160);
+    expect(size.width % 16).toBe(0);
+    expect(size.height % 16).toBe(0);
+    expect(size.width * size.height).toBeLessThanOrEqual(1024 * 1024);
+    expect(size.width / size.height).toBeCloseTo(2, 1);
+  });
+
+  it("matches generated crop tone to the unchanged context", async () => {
+    vi.doMock("electron", () => ({ nativeImage: createFakeNativeImage() }));
+    const { matchFluxOutputToOriginalContext } = await import(
+      "../src/main/inpainting/fluxToneCorrection"
+    );
+    const original = Buffer.alloc(16 * 16 * 4);
+    const generated = Buffer.alloc(16 * 16 * 4);
+    const mask = new Uint8Array(16 * 16);
+    for (let index = 0; index < 16 * 16; index += 1) {
+      const offset = index * 4;
+      original.set([180, 180, 180, 255], offset);
+      generated.set([90, 120, 150, 255], offset);
+      const x = index % 16;
+      const y = Math.floor(index / 16);
+      mask[index] = x >= 6 && x < 10 && y >= 6 && y < 10 ? 1 : 0;
+    }
+
+    expect(
+      matchFluxOutputToOriginalContext(original, generated, mask),
+    ).toBe(true);
+    const maskedOffset = (7 * 16 + 7) * 4;
+    expect([...generated.subarray(maskedOffset, maskedOffset + 3)]).toEqual([
+      180, 180, 180,
+    ]);
+  });
+
   it("warns instead of failing when every crop comes back unchanged", async () => {
     const logInfo = vi.fn();
     const logWarn = vi.fn();
@@ -38,15 +76,22 @@ describe("Flux inpainting engine change detection", () => {
       },
       runRootDir: root,
     });
-    const bitmap = Buffer.alloc(16 * 16 * 4, 180);
-    const mask = new Uint8Array(16 * 16).fill(1);
+    const bitmap = Buffer.alloc(256 * 256 * 4, 180);
+    const mask = new Uint8Array(256 * 256).fill(1);
 
     await expect(
-      engine.inpaint(bitmap, 16, 16, mask, [{ x: 0, y: 0, w: 16, h: 16 }], {
-        contextPx: 16,
-        maskPaddingPx: 0,
-        maxPixels: 256 * 256,
-      }),
+      engine.inpaint(
+        bitmap,
+        256,
+        256,
+        mask,
+        [{ x: 0, y: 0, w: 256, h: 256 }],
+        {
+          contextPx: 16,
+          maskPaddingPx: 0,
+          maxPixels: 256 * 256,
+        },
+      ),
     ).resolves.toBeUndefined();
     await engine.dispose();
 

--- a/tests/macGemmaMetal.test.ts
+++ b/tests/macGemmaMetal.test.ts
@@ -5,6 +5,7 @@ import {
   existsSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -176,6 +177,12 @@ describe("Apple Silicon Gemma Metal runtimes", () => {
     expect(
       llamaRuntimeProbeLooksGpuBacked(
         "ggml_metal_init: GPU name: Apple M3 Max; Metal device 0",
+        "metal",
+      ),
+    ).toBe(true);
+    expect(
+      llamaRuntimeProbeLooksGpuBacked(
+        "Available devices:\n  MTL0: Apple M4 Max (53084 MiB, 53083 MiB free)\n  BLAS: Accelerate (0 MiB, 0 MiB free)",
         "metal",
       ),
     ).toBe(true);
@@ -371,6 +378,37 @@ describe("Metal runtime archive integrity", () => {
         "metal",
       );
       expect(() => readFileSync(join(output, "README.md"))).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("extracts runtime symlinks after their target files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mgt-mac-runtime-symlink-"));
+    try {
+      const source = join(dir, "source");
+      const releaseName = "beellama-v0.3.1";
+      const release = join(source, releaseName);
+      const output = join(dir, "output");
+      const archive = join(dir, "runtime.tar.gz");
+      mkdirSync(release, { recursive: true });
+      writeFileSync(join(release, "libmtmd.0.dylib"), "metal");
+      writeFileSync(join(release, "llama-server"), "mach-o");
+      symlinkSync("libmtmd.0.dylib", join(release, "libmtmd.dylib"));
+      await tar.c({ cwd: source, file: archive, gzip: true }, [
+        `${releaseName}/libmtmd.dylib`,
+        `${releaseName}/libmtmd.0.dylib`,
+        `${releaseName}/llama-server`,
+      ]);
+
+      await extractSelectedTarEntries(
+        archive,
+        output,
+        shouldExtractLlamaRuntimeFile,
+        { stripComponents: 1 },
+      );
+
+      expect(readFileSync(join(output, "libmtmd.dylib"), "utf8")).toBe("metal");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/macInpaintingRunnerBootstrap.test.ts
+++ b/tests/macInpaintingRunnerBootstrap.test.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const { resolveMacInpaintingRunnerPaths, resolveMissingMacInpaintingRunners } =
+  require("../scripts/mac-inpainting-runners.cjs") as {
+    resolveMacInpaintingRunnerPaths: (root: string) => string[];
+    resolveMissingMacInpaintingRunners: (
+      root: string,
+      options: {
+        platform: NodeJS.Platform;
+        arch: string;
+        isUsable: (filePath: string) => boolean;
+      },
+    ) => string[];
+  };
+
+describe("macOS inpainting runner bootstrap", () => {
+  it("requires both native runners on Apple Silicon", () => {
+    const root = join("workspace", "CarrotMangaTranslator");
+    const paths = resolveMacInpaintingRunnerPaths(root);
+
+    expect(paths).toEqual([
+      join(
+        root,
+        "tools",
+        "mgt-koharu-inpaint-runner",
+        "target",
+        "aarch64-apple-darwin",
+        "release",
+        "mgt-koharu-inpaint-runner",
+      ),
+      join(
+        root,
+        "tools",
+        "mgt-flux-klein-runner",
+        "target",
+        "aarch64-apple-darwin",
+        "release",
+        "mgt-flux-klein",
+      ),
+    ]);
+    expect(
+      resolveMissingMacInpaintingRunners(root, {
+        platform: "darwin",
+        arch: "arm64",
+        isUsable: vi.fn(() => false),
+      }),
+    ).toEqual(paths);
+  });
+
+  it("does not build Metal runners on other platforms", () => {
+    const isUsable = vi.fn(() => false);
+    expect(
+      resolveMissingMacInpaintingRunners("workspace", {
+        platform: "win32",
+        arch: "x64",
+        isUsable,
+      }),
+    ).toEqual([]);
+    expect(isUsable).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ocrBootstrapPython.test.ts
+++ b/tests/ocrBootstrapPython.test.ts
@@ -1,0 +1,47 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const { resolveBootstrapPython } =
+  require("../src/main/runtime/ocr/runtime-layout.cjs") as {
+    resolveBootstrapPython: (options: { toolsDir: string }) => string | null;
+  };
+
+describe("OCR bootstrap Python resolution", () => {
+  it("uses a working platform Python command during development", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "mgt-ocr-python-"));
+    const toolsDir = join(temporaryRoot, "tools");
+    mkdirSync(toolsDir, { recursive: true });
+
+    try {
+      const pythonCommand = resolveBootstrapPython({ toolsDir });
+      const expectedCommand =
+        process.platform === "win32" ? "python" : "python3";
+      const result = spawnSync(pythonCommand ?? "", ["--version"], {
+        encoding: "utf8",
+        shell: false,
+      });
+
+      expect(pythonCommand).toBe(expectedCommand);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain("Python 3");
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not use system Python for packaged tools by default", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "mgt-ocr-python-"));
+    const toolsDir = join(temporaryRoot, "resources", "tools");
+    mkdirSync(toolsDir, { recursive: true });
+
+    try {
+      expect(resolveBootstrapPython({ toolsDir })).toBeNull();
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/ocrCpuWorkerConfig.test.ts
+++ b/tests/ocrCpuWorkerConfig.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+const { createOcrBatchConfig } =
+  require("../src/main/runtime/ocr/bbox-batch-config.cjs") as {
+    createOcrBatchConfig: (dependencies: {
+      os: {
+        cpus: () => unknown[];
+        platform: () => NodeJS.Platform;
+      };
+      runtimeOverrideEnv: () => undefined;
+      readPositiveInteger: (value: unknown) => number | null;
+      emitRuntimeProgress: () => void;
+    }) => {
+      resolveOcrCpuWorkerCount: (
+        options: { ocrCpuWorkers?: number },
+        pageCount: number,
+      ) => number;
+      resolveOcrCpuWorkerMinFreeRamRatio: (options?: {
+        ocrCpuWorkerMinFreeRamPercent?: number;
+      }) => number;
+    };
+  };
+
+function createConfig(platform: NodeJS.Platform) {
+  return createOcrBatchConfig({
+    os: {
+      cpus: () => Array.from({ length: 8 }, () => ({})),
+      platform: () => platform,
+    },
+    runtimeOverrideEnv: () => undefined,
+    readPositiveInteger: (value) => {
+      const parsed = Number(value);
+      return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    },
+    emitRuntimeProgress: () => undefined,
+  });
+}
+
+describe("OCR CPU worker configuration", () => {
+  it("keeps parallel workers on macOS", () => {
+    expect(createConfig("darwin").resolveOcrCpuWorkerCount({}, 3)).toBe(3);
+  });
+
+  it("disables the unreliable macOS free-memory floor by default", () => {
+    const config = createConfig("darwin");
+    expect(config.resolveOcrCpuWorkerMinFreeRamRatio()).toBe(0);
+    expect(
+      config.resolveOcrCpuWorkerMinFreeRamRatio({
+        ocrCpuWorkerMinFreeRamPercent: 35,
+      }),
+    ).toBe(0.35);
+  });
+
+  it("keeps the existing worker and memory defaults on Windows", () => {
+    const config = createConfig("win32");
+    expect(config.resolveOcrCpuWorkerCount({}, 5)).toBe(4);
+    expect(config.resolveOcrCpuWorkerMinFreeRamRatio()).toBe(0.2);
+  });
+});

--- a/tests/ocrScript.test.ts
+++ b/tests/ocrScript.test.ts
@@ -10,7 +10,8 @@ describe("PaddleOCR-VL bbox script", () => {
       "python",
       "test_paddleocr_vl_bboxes.py",
     );
-    const result = spawnSync(process.env.PYTHON ?? "python", [testFile], {
+    const defaultPython = process.platform === "win32" ? "python" : "python3";
+    const result = spawnSync(process.env.PYTHON ?? defaultPython, [testFile], {
       cwd: process.cwd(),
       encoding: "utf8",
       env: {

--- a/tests/overlayItems.test.ts
+++ b/tests/overlayItems.test.ts
@@ -30,6 +30,45 @@ describe("overlay item conversion", () => {
     expect(block.renderDirection).toBe("horizontal");
   });
 
+  it("keeps translated ordinary text upright when the model reports a left slant", () => {
+    const block = overlayItemToBlock(
+      {
+        id: 1,
+        type: "nonsolid",
+        textRole: "ordinary",
+        bbox: { x: 400, y: 100, w: 70, h: 360 },
+        jp: "ありがとうございます",
+        ko: "감사합니다.",
+        direction: "vertical",
+        angle: -30,
+        confidence: 1,
+      },
+      makePage(),
+      0,
+    );
+
+    expect(block.rotationDeg).toBe(0);
+  });
+
+  it("preserves a detected source slant for sound effects", () => {
+    const block = overlayItemToBlock(
+      {
+        id: 1,
+        type: "nonsolid",
+        textRole: "sound",
+        bbox: { x: 100, y: 100, w: 200, h: 120 },
+        jp: "ドン",
+        ko: "쾅",
+        angle: -18,
+        confidence: 1,
+      },
+      makePage(),
+      0,
+    );
+
+    expect(block.rotationDeg).toBe(-18);
+  });
+
   it("prefers language-neutral text aliases when creating a block", () => {
     const block = overlayItemToBlock(
       {

--- a/tools/mgt-flux-klein-runner/Cargo.lock
+++ b/tools/mgt-flux-klein-runner/Cargo.lock
@@ -494,6 +494,14 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.9.2"
+dependencies = [
+ "candle-core",
+ "candle-nn 0.9.2 (git+https://github.com/mayocream/candle?branch=flash-attn)",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.9.2"
 source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "candle-core",
@@ -515,7 +523,7 @@ source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414d
 dependencies = [
  "byteorder",
  "candle-core",
- "candle-nn",
+ "candle-nn 0.9.2 (git+https://github.com/mayocream/candle?branch=flash-attn)",
  "fancy-regex",
  "num-traits",
  "rand 0.9.4",
@@ -2244,7 +2252,7 @@ dependencies = [
  "anyhow",
  "candle-core",
  "candle-flash-attn",
- "candle-nn",
+ "candle-nn 0.9.2",
  "candle-transformers",
  "clap",
  "cudarc 0.19.7",

--- a/tools/mgt-flux-klein-runner/Cargo.toml
+++ b/tools/mgt-flux-klein-runner/Cargo.toml
@@ -24,7 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [patch.crates-io]
 candle-core = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
-candle-nn = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
+candle-nn = { path = "vendor/candle-nn-metal-attention" }
 candle-transformers = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
 candle-flash-attn = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
 ug = { git = "https://github.com/mayocream/ug", branch = "cuda-dynamic-loading" }

--- a/tools/mgt-flux-klein-runner/src/main.rs
+++ b/tools/mgt-flux-klein-runner/src/main.rs
@@ -10,7 +10,8 @@ use std::ffi::CStr;
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
-use koharu_ml::flux2_klein::{Flux2InpaintOptions, Flux2Klein, Flux2KleinPaths};
+use image::GenericImageView;
+use koharu_ml::flux2_klein::{Flux2ImageToImageOptions, Flux2Klein, Flux2KleinPaths};
 use koharu_runtime::{Catalog, ComputePolicy, RuntimeManager};
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{EnvFilter, fmt};
@@ -111,6 +112,7 @@ async fn main() -> Result<()> {
     }
     if cli.require_metal {
         ensure_metal_available()?;
+        prepare_metal_matrix_runtime();
     } else if cli.require_zluda {
         prepare_zluda_runtime(&cli).await?;
         // ZLUDA's nvcudart_hybrid64.dll is not a complete CUDA Runtime API
@@ -146,6 +148,18 @@ async fn main() -> Result<()> {
 
     run_worker(&model, &cli)?;
     Ok(())
+}
+
+fn prepare_metal_matrix_runtime() {
+    if std::env::var_os("CANDLE_DEQUANTIZE_ALL").is_none()
+        && std::env::var_os("CANDLE_DEQUANTIZE_ALL_F16").is_none()
+    {
+        // Candle's quantized Metal matmul corrupts the FLUX transformer output
+        // on some Apple GPUs. Materializing the GGUF weights as F16 once during
+        // model load keeps inference on Metal while using the stable matmul path.
+        unsafe { std::env::set_var("CANDLE_DEQUANTIZE_ALL_F16", "1") };
+        eprintln!("mgt-flux-klein: using dequantized F16 Metal matrix kernels");
+    }
 }
 
 fn print_capabilities() -> Result<()> {
@@ -476,17 +490,20 @@ fn run_worker(model: &Flux2Klein, cli: &Cli) -> Result<()> {
                 mask_padding,
             } => {
                 let started = Instant::now();
+                // The app owns mask expansion and final compositing.  Keep accepting
+                // mask_padding for protocol compatibility, but do not crop or clamp
+                // latents a second time inside the model runtime.
+                let _mask_padding = mask_padding.unwrap_or(cli.mask_padding);
                 let result = run_inpaint(
                     model,
                     cli,
                     &input,
                     &mask,
                     &output,
-                    Flux2InpaintOptions {
+                    Flux2ImageToImageOptions {
                         num_inference_steps: steps.unwrap_or(cli.steps),
                         strength: strength.unwrap_or(cli.strength),
                         max_pixels: max_pixels.unwrap_or(cli.max_pixels),
-                        mask_padding: mask_padding.unwrap_or(cli.mask_padding),
                     },
                 );
                 let response = match result {
@@ -518,15 +535,31 @@ fn run_inpaint(
     input: &PathBuf,
     mask: &PathBuf,
     output: &PathBuf,
-    options: Flux2InpaintOptions,
+    options: Flux2ImageToImageOptions,
 ) -> Result<()> {
     let image = image::open(input)
         .with_context(|| format!("failed to open input image {}", input.display()))?;
     let mask_image = image::open(mask)
         .with_context(|| format!("failed to open mask image {}", mask.display()))?;
+    if image.dimensions() != mask_image.dimensions() {
+        bail!(
+            "image/mask dimensions mismatch: image is {:?}, mask is {:?}",
+            image.dimensions(),
+            mask_image.dimensions()
+        );
+    }
+    if !mask_image.to_luma8().pixels().any(|pixel| pixel.0[0] > 0) {
+        bail!("inpainting mask is empty");
+    }
+
+    // FLUX.2 Klein is an image-edit model.  Generate the complete contextual
+    // crop, then let the Electron side blend only the requested mask back into
+    // the page. This mirrors the proven MangaTranslator pipeline and avoids a
+    // second internal crop plus per-step latent clamping that would deprive the
+    // edit model of the surrounding context prepared by the app.
     let result = model
-        .inpaint(&image, &mask_image, &options)
-        .with_context(|| "Flux.2 Klein inpainting failed")?;
+        .image_to_image(&image, &options)
+        .with_context(|| "Flux.2 Klein image edit failed")?;
     result
         .save(output)
         .with_context(|| format!("failed to write output image {}", output.display()))?;
@@ -586,6 +619,10 @@ fn install_panic_hook() {
                     .map(|text| text.as_str())
             })
             .unwrap_or("unknown panic");
-        eprintln!("mgt-flux-klein: fatal runtime panic: {message}");
+        let location = panic_info
+            .location()
+            .map(|location| format!(" at {}:{}", location.file(), location.line()))
+            .unwrap_or_default();
+        eprintln!("mgt-flux-klein: fatal runtime panic: {message}{location}");
     }));
 }

--- a/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/Cargo.toml
+++ b/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "candle-nn"
+version = "0.9.2"
+edition = "2021"
+publish = false
+
+[features]
+default = []
+accelerate = ["candle-nn-upstream/accelerate"]
+cuda = ["candle-nn-upstream/cuda"]
+cudnn = ["candle-nn-upstream/cudnn"]
+mkl = ["candle-nn-upstream/mkl"]
+metal = ["candle-nn-upstream/metal", "candle-core/metal"]
+
+[dependencies]
+candle-core = "=0.9.2"
+candle-nn-upstream = { git = "https://github.com/mayocream/candle", branch = "flash-attn", package = "candle-nn", default-features = false }
+
+[patch.crates-io]
+candle-core = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }

--- a/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/src/lib.rs
+++ b/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/src/lib.rs
@@ -1,0 +1,220 @@
+//! Candle NN compatibility layer for Flux.2 Klein on Metal.
+//!
+//! Candle's fused Metal SDPA both limits supported head dimensions and produces
+//! corrupted Flux.2 transformer output on the supported 128-wide heads. Route
+//! Flux's unmasked, non-causal attention through bounded Metal matmuls instead.
+
+macro_rules! reexport_module {
+    ($name:ident) => {
+        pub mod $name {
+            pub use candle_nn_upstream::$name::*;
+        }
+    };
+}
+
+reexport_module!(activation);
+reexport_module!(batch_norm);
+reexport_module!(conv);
+reexport_module!(cpu_flash_attention);
+reexport_module!(embedding);
+reexport_module!(encoding);
+reexport_module!(func);
+reexport_module!(group_norm);
+reexport_module!(init);
+reexport_module!(kv_cache);
+reexport_module!(layer_norm);
+reexport_module!(linear);
+reexport_module!(loss);
+reexport_module!(optim);
+reexport_module!(rnn);
+reexport_module!(rotary_emb);
+reexport_module!(sampling);
+reexport_module!(sequential);
+reexport_module!(var_builder);
+reexport_module!(var_map);
+pub use candle_nn_upstream::batch_norm::batch_norm;
+pub use candle_nn_upstream::embedding::embedding;
+pub use candle_nn_upstream::func::func;
+pub use candle_nn_upstream::group_norm::group_norm;
+pub use candle_nn_upstream::layer_norm::layer_norm;
+pub use candle_nn_upstream::linear::linear;
+pub use candle_nn_upstream::{
+    conv1d, conv1d_no_bias, conv2d, conv2d_no_bias, conv_transpose1d, conv_transpose1d_no_bias,
+    conv_transpose2d, conv_transpose2d_no_bias, func_t, gru, layer_norm_no_bias, linear_b,
+    linear_no_bias, lstm, prelu, rms_norm, seq, Activation, AdamW, BatchNorm, BatchNormConfig,
+    Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, ConvTranspose1d, ConvTranspose1dConfig,
+    ConvTranspose2d, ConvTranspose2dConfig, Embedding, Func, FuncT, GRUConfig, GroupNorm, Init,
+    LSTMConfig, LayerNorm, LayerNormConfig, Linear, Module, ModuleT, Optimizer, PReLU, ParamsAdamW,
+    RmsNorm, Sequential, VarBuilder, VarMap, GRU, LSTM, RNN, SGD,
+};
+
+pub mod ops {
+    use std::sync::Once;
+
+    use candle_core::{DType, Result, Tensor, D};
+
+    pub use candle_nn_upstream::ops::{
+        dropout, hard_sigmoid, layer_norm, layer_norm_slow, leaky_relu, log_softmax, mish,
+        pixel_shuffle, pixel_unshuffle, replication_pad2d, rms_norm, rms_norm_slow, selu, sigmoid,
+        silu, softmax, softmax_last_dim, swiglu, Dropout, Identity,
+    };
+
+    static METAL_CHUNKED_ATTENTION_LOG: Once = Once::new();
+
+    pub fn sdpa(
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        mask: Option<&Tensor>,
+        do_causal: bool,
+        scale: f32,
+        softcapping: f32,
+    ) -> Result<Tensor> {
+        let head_dim = q.dim(D::Minus1)?;
+        let can_use_flux_chunking =
+            q.device().is_metal() && mask.is_none() && !do_causal && softcapping == 1.0;
+        if can_use_flux_chunking {
+            METAL_CHUNKED_ATTENTION_LOG.call_once(|| {
+                eprintln!(
+                    "mgt-flux-klein: using numerically stable Metal chunked attention (head dim {head_dim})"
+                );
+            });
+            return chunked_attention(q, k, v, scale, attention_chunk_size(q)?);
+        }
+        candle_nn_upstream::ops::sdpa(q, k, v, mask, do_causal, scale, softcapping)
+    }
+
+    fn attention_chunk_size(q: &Tensor) -> Result<usize> {
+        Ok(if q.dim(2)? > 4096 { 64 } else { 128 })
+    }
+
+    fn chunked_attention(
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        scale: f32,
+        chunk_size: usize,
+    ) -> Result<Tensor> {
+        // Keep the score matrix bounded without forcing the transformer through
+        // dozens of tiny Metal command buffers for normal inpainting crops.
+        const KEY_CHUNK_SIZE: usize = 1024;
+
+        let (batch, heads, query_len, _) = q.dims4()?;
+        let key_len = k.dim(2)?;
+        let value_dim = v.dim(D::Minus1)?;
+        let output_dtype = q.dtype();
+        let mut chunks = Vec::with_capacity(query_len.div_ceil(chunk_size));
+        for query_start in (0..query_len).step_by(chunk_size) {
+            let query_chunk_len = chunk_size.min(query_len - query_start);
+            let query = q
+                .narrow(2, query_start, query_chunk_len)?
+                .contiguous()?
+                .to_dtype(DType::F32)?;
+            let mut output_accumulator = Tensor::from_vec(
+                vec![0f32; batch * heads * query_chunk_len * value_dim],
+                (batch, heads, query_chunk_len, value_dim),
+                q.device(),
+            )?;
+            let mut max_scores = Tensor::from_vec(
+                vec![f32::NEG_INFINITY; batch * heads * query_chunk_len],
+                (batch, heads, query_chunk_len, 1),
+                q.device(),
+            )?;
+            let mut exponential_sum = Tensor::from_vec(
+                vec![0f32; batch * heads * query_chunk_len],
+                (batch, heads, query_chunk_len, 1),
+                q.device(),
+            )?;
+
+            for key_start in (0..key_len).step_by(KEY_CHUNK_SIZE) {
+                let key_chunk_len = KEY_CHUNK_SIZE.min(key_len - key_start);
+                let key = k
+                    .narrow(2, key_start, key_chunk_len)?
+                    .contiguous()?
+                    .to_dtype(DType::F32)?;
+                let value = v
+                    .narrow(2, key_start, key_chunk_len)?
+                    .contiguous()?
+                    .to_dtype(DType::F32)?;
+                let scores = (query.matmul(&key.transpose(2, 3)?.contiguous()?)? * scale as f64)?;
+                let tile_max = scores.max_keepdim(D::Minus1)?;
+                let next_max = max_scores.maximum(&tile_max)?;
+                let previous_scale = (&max_scores - &next_max)?.exp()?;
+                output_accumulator = output_accumulator.broadcast_mul(&previous_scale)?;
+                exponential_sum = exponential_sum.broadcast_mul(&previous_scale)?;
+                let exponentials = scores.broadcast_sub(&next_max)?.exp()?;
+                output_accumulator = (output_accumulator + exponentials.matmul(&value)?)?;
+                exponential_sum = (exponential_sum + exponentials.sum_keepdim(D::Minus1)?)?;
+                max_scores = next_max;
+            }
+            chunks.push(
+                output_accumulator
+                    .broadcast_div(&exponential_sum)?
+                    .to_dtype(output_dtype)?,
+            );
+        }
+        Tensor::cat(&chunks, 2)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use candle_core::{Device, Tensor};
+
+        #[test]
+        fn chunked_attention_matches_full_attention() -> Result<()> {
+            let device = Device::Cpu;
+            let q = (Tensor::arange(0f32, 12f32, &device)? / 12.0)?.reshape((1, 1, 4, 3))?;
+            let k = (Tensor::arange(1f32, 13f32, &device)? / 13.0)?.reshape((1, 1, 4, 3))?;
+            let v = (Tensor::arange(0f32, 8f32, &device)? / 8.0)?.reshape((1, 1, 4, 2))?;
+            let scale = 1.0 / 3f32.sqrt();
+            let scores = (q.matmul(&k.transpose(2, 3)?.contiguous()?)? * scale as f64)?;
+            let expected = softmax_last_dim(&scores)?.matmul(&v)?;
+            let actual = chunked_attention(&q, &k, &v, scale, 2)?;
+            let delta = (&expected - &actual)?
+                .abs()?
+                .max_all()?
+                .to_scalar::<f32>()?;
+            assert!(delta < 1e-5, "chunked attention delta was {delta}");
+            Ok(())
+        }
+
+        #[cfg(feature = "metal")]
+        #[test]
+        fn metal_chunked_attention_matches_cpu_for_flux_vae_head_dim() -> Result<()> {
+            let cpu = Device::Cpu;
+            let metal = Device::new_metal(0)?;
+            let query_elements = 4 * 512;
+            let key_len = 1031;
+            let key_elements = key_len * 512;
+            let q_cpu = (Tensor::arange(0f32, query_elements as f32, &cpu)?
+                / query_elements as f64)?
+                .reshape((1, 1, 4, 512))?;
+            let k_cpu = (Tensor::arange(1f32, (key_elements + 1) as f32, &cpu)?
+                / (key_elements + 1) as f64)?
+                .reshape((1, 1, key_len, 512))?;
+            let v_cpu = (Tensor::arange(0f32, key_elements as f32, &cpu)?
+                / (key_elements * 2) as f64)?
+                .reshape((1, 1, key_len, 512))?;
+            let scale = 1.0 / 512f32.sqrt();
+            let scores = (q_cpu.matmul(&k_cpu.transpose(2, 3)?.contiguous()?)? * scale as f64)?;
+            let expected = softmax_last_dim(&scores)?.matmul(&v_cpu)?;
+            let actual = chunked_attention(
+                &q_cpu.to_device(&metal)?,
+                &k_cpu.to_device(&metal)?,
+                &v_cpu.to_device(&metal)?,
+                scale,
+                2,
+            )?
+            .to_device(&cpu)?;
+            let delta = (&expected - &actual)?
+                .abs()?
+                .max_all()?
+                .to_scalar::<f32>()?;
+            assert!(delta < 1e-4, "Metal chunked attention delta was {delta}");
+            Ok(())
+        }
+    }
+}
+
+pub use ops::Dropout;


### PR DESCRIPTION
## Summary

- bootstrap Electron and missing Apple Silicon inpainting runners before local development and smoke launches
- harden macOS FFmpeg, Python, Metal probe, OCR worker, and runtime archive handling
- fix FLUX.2 Klein Metal corruption with stable F16 matmul and tiled attention
- follow the proven contextual image-edit workflow, then color-match and composite only the requested mask
- keep ordinary translated text upright while preserving sound-effect rotation

## Root cause

The macOS alpha path assumed first-run runtime assets already existed and did not account for current Electron, Python, llama.cpp, and tar-symlink behavior. Separately, Candle's quantized Metal matmul produced corrupted FLUX transformer output on the tested Apple GPU, while the native inpaint path applied a second crop and latent clamp after the app had already prepared contextual crops.

## User impact

Fresh macOS development checkouts now prepare their required executables automatically, packaged runtime discovery handles current Apple Silicon layouts, and FLUX Metal inpainting removes text without the previous horizontal bands or page corruption. Ordinary speech and captions no longer inherit spurious source slants.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint -- --quiet`
- focused regression suite: 39 passed, 28 platform-skipped
- Apple Silicon Metal release runner build
- Metal attention CPU-reference tests: 2 passed
- real FLUX Metal image-edit smoke: no banding; representative crop completed in about 5.2 seconds

The F16 dequantization workaround increases model-load memory and observed load time to about 3 seconds, but avoids the corrupt Q4 Metal matmul path.

Supersedes #32.
