### PR TITLE
fix: stabilize macOS model runtime preflight

### DIFF
--- a/src/main/runtime/model/server-preflight.cjs
+++ b/src/main/runtime/model/server-preflight.cjs
@@ -187,7 +187,10 @@ function llamaRuntimeProbeLooksGpuBacked(output, backend = "cuda") {
   const normalized = String(backend || "cuda").toLowerCase();
   if (normalized === "vulkan") return /(vulkan|radeon|amd|gpu)/i.test(text);
   if (normalized === "metal") {
-    return /metal/i.test(text) && /(apple|gpu|m[1-9])/i.test(text);
+    return (
+      (/metal/i.test(text) && /(apple|gpu|m[1-9])/i.test(text)) ||
+      /^\s*MTL\d+:\s*Apple\s+M\d+/im.test(text)
+    );
   }
   if (normalized === "rocm" || normalized === "hip")
     return /(rocm|hip|radeon|amd|gpu)/i.test(text);

--- a/src/main/runtime/ocr/bbox-batch-config.cjs
+++ b/src/main/runtime/ocr/bbox-batch-config.cjs
@@ -104,7 +104,8 @@ function resolveOcrCpuWorkerMinFreeRamRatio(dependencies, options = {}) {
     ),
     options.ocrCpuWorkerMinFreeRamPercent,
   ]);
-  return Math.max(0, Math.min(95, explicit ?? 20)) / 100;
+  const defaultPercent = dependencies.os.platform() === "darwin" ? 0 : 20;
+  return Math.max(0, Math.min(95, explicit ?? defaultPercent)) / 100;
 }
 
 /** @param {Dependencies} dependencies @param {OcrBboxOptions} [options] */

--- a/src/main/runtime/ocr/runtime-layout.cjs
+++ b/src/main/runtime/ocr/runtime-layout.cjs
@@ -262,7 +262,9 @@ function resolveBootstrapPython(
   if (bundled) {
     return bundled;
   }
-  return shouldAllowSystemPythonFallback(options) ? "python" : null;
+  return shouldAllowSystemPythonFallback(options)
+    ? resolveSystemPythonCommand()
+    : null;
 }
 
 /** @param {string[]} candidates @returns {string | null} */
@@ -270,9 +272,19 @@ function findAvailablePython(candidates) {
   return (
     candidates.find(
       (candidate) =>
-        candidate && (candidate === "python" || existsSync(candidate)),
+        candidate && (isPythonCommand(candidate) || existsSync(candidate)),
     ) || null
   );
+}
+
+/** @param {string} candidate @returns {boolean} */
+function isPythonCommand(candidate) {
+  return candidate === "python" || candidate === "python3";
+}
+
+/** @returns {string} */
+function resolveSystemPythonCommand() {
+  return process.platform === "win32" ? "python" : "python3";
 }
 
 /** @param {RuntimeOptions} [options] @returns {boolean} */

--- a/tests/macGemmaMetal.test.ts
+++ b/tests/macGemmaMetal.test.ts
@@ -179,6 +179,12 @@ describe("Apple Silicon Gemma Metal runtimes", () => {
         "metal",
       ),
     ).toBe(true);
+    expect(
+      llamaRuntimeProbeLooksGpuBacked(
+        "Available devices:\n  MTL0: Apple M4 Max (53084 MiB, 53083 MiB free)\n  BLAS: Accelerate (0 MiB, 0 MiB free)",
+        "metal",
+      ),
+    ).toBe(true);
     expect(llamaRuntimeProbeLooksGpuBacked("CPU device only", "metal")).toBe(
       false,
     );

--- a/tests/ocrBootstrapPython.test.ts
+++ b/tests/ocrBootstrapPython.test.ts
@@ -1,0 +1,47 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const { resolveBootstrapPython } =
+  require("../src/main/runtime/ocr/runtime-layout.cjs") as {
+    resolveBootstrapPython: (options: { toolsDir: string }) => string | null;
+  };
+
+describe("OCR bootstrap Python resolution", () => {
+  it("uses a working platform Python command during development", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "mgt-ocr-python-"));
+    const toolsDir = join(temporaryRoot, "tools");
+    mkdirSync(toolsDir, { recursive: true });
+
+    try {
+      const pythonCommand = resolveBootstrapPython({ toolsDir });
+      const expectedCommand =
+        process.platform === "win32" ? "python" : "python3";
+      const result = spawnSync(pythonCommand ?? "", ["--version"], {
+        encoding: "utf8",
+        shell: false,
+      });
+
+      expect(pythonCommand).toBe(expectedCommand);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain("Python 3");
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not use system Python for packaged tools by default", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "mgt-ocr-python-"));
+    const toolsDir = join(temporaryRoot, "resources", "tools");
+    mkdirSync(toolsDir, { recursive: true });
+
+    try {
+      expect(resolveBootstrapPython({ toolsDir })).toBeNull();
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/ocrCpuWorkerConfig.test.ts
+++ b/tests/ocrCpuWorkerConfig.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+const { createOcrBatchConfig } =
+  require("../src/main/runtime/ocr/bbox-batch-config.cjs") as {
+    createOcrBatchConfig: (dependencies: {
+      os: {
+        cpus: () => unknown[];
+        platform: () => NodeJS.Platform;
+      };
+      runtimeOverrideEnv: () => undefined;
+      readPositiveInteger: (value: unknown) => number | null;
+      emitRuntimeProgress: () => void;
+    }) => {
+      resolveOcrCpuWorkerCount: (
+        options: { ocrCpuWorkers?: number },
+        pageCount: number,
+      ) => number;
+      resolveOcrCpuWorkerMinFreeRamRatio: (options?: {
+        ocrCpuWorkerMinFreeRamPercent?: number;
+      }) => number;
+    };
+  };
+
+function createConfig(platform: NodeJS.Platform) {
+  return createOcrBatchConfig({
+    os: {
+      cpus: () => Array.from({ length: 8 }, () => ({})),
+      platform: () => platform,
+    },
+    runtimeOverrideEnv: () => undefined,
+    readPositiveInteger: (value) => {
+      const parsed = Number(value);
+      return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    },
+    emitRuntimeProgress: () => undefined,
+  });
+}
+
+describe("OCR CPU worker configuration", () => {
+  it("keeps parallel workers on macOS", () => {
+    expect(createConfig("darwin").resolveOcrCpuWorkerCount({}, 3)).toBe(3);
+  });
+
+  it("disables the unreliable macOS free-memory floor by default", () => {
+    const config = createConfig("darwin");
+    expect(config.resolveOcrCpuWorkerMinFreeRamRatio()).toBe(0);
+    expect(
+      config.resolveOcrCpuWorkerMinFreeRamRatio({
+        ocrCpuWorkerMinFreeRamPercent: 35,
+      }),
+    ).toBe(0.35);
+  });
+
+  it("keeps the existing worker and memory defaults on Windows", () => {
+    const config = createConfig("win32");
+    expect(config.resolveOcrCpuWorkerCount({}, 5)).toBe(4);
+    expect(config.resolveOcrCpuWorkerMinFreeRamRatio()).toBe(0.2);
+  });
+});

--- a/tests/ocrScript.test.ts
+++ b/tests/ocrScript.test.ts
@@ -10,7 +10,8 @@ describe("PaddleOCR-VL bbox script", () => {
       "python",
       "test_paddleocr_vl_bboxes.py",
     );
-    const result = spawnSync(process.env.PYTHON ?? "python", [testFile], {
+    const defaultPython = process.platform === "win32" ? "python" : "python3";
+    const result = spawnSync(process.env.PYTHON ?? defaultPython, [testFile], {
       cwd: process.cwd(),
       encoding: "utf8",
       env: {


### PR DESCRIPTION
## What

- Recognize current Apple Metal device probe output.
- Prefer `python3` for non-Windows OCR bootstrap fallback.
- Allow macOS OCR CPU workers to use unified memory without the Windows/Linux free-RAM reserve default.
- Add focused runtime preflight and OCR bootstrap tests.

## Why

The macOS runtime preflight rejected valid `MTL0: Apple M*` output, while the OCR bootstrap assumed a `python` command and applied a reserve policy that is too conservative for Apple unified memory.

## Impact

- Apple Silicon model and OCR startup is less likely to fail or idle unnecessarily.
- Explicit configuration still overrides the platform defaults.
- No inpainting model-selection behavior changes.

## Checks

- `npm run check`
- Metal probe, OCR Python bootstrap, CPU worker, and OCR script regression tests
