### PR TITLE
fix: correct Flux quantized Metal inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ tools/llama-b8833-cuda13.1/
 tools/beellama*/
 tools/mgt-flux-cuda12.*/
 tools/mgt-flux-klein-runner/target/
+tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/Cargo.lock
+tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/target/
 tools/mgt-koharu-inpaint-runner/target/
 tools/mgt-flux-klein-sm*/
 tools/mgt-flux-klein/*.exe

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dist:win:nvidia": "node scripts/dist-win-thin.cjs --with-flux-nvidia",
     "dist:win:amd": "node scripts/dist-win-thin.cjs",
     "build:mac:runners": "node scripts/build-mac-runners.cjs",
+    "test:flux-metal": "node scripts/test-flux-metal.cjs",
     "prepare:mac:runtime": "node scripts/prepare-mac-runtime.cjs",
     "dist:mac:alpha": "node scripts/dist-mac-alpha.cjs",
     "verify:mac:package": "node scripts/verify-mac-package.cjs",

--- a/scripts/build-mac-runners.cjs
+++ b/scripts/build-mac-runners.cjs
@@ -4,6 +4,7 @@
 const { spawnSync } = require("node:child_process");
 const { existsSync, readFileSync } = require("node:fs");
 const { join } = require("node:path");
+const { patchCandleMetalQMatMul } = require("./patch-candle-metal-qmatmul.cjs");
 
 const root = join(__dirname, "..");
 const target = "aarch64-apple-darwin";
@@ -51,6 +52,13 @@ function main() {
   if (process.platform !== "darwin" || process.arch !== "arm64") {
     throw new Error("Metal runner builds require an Apple Silicon Mac.");
   }
+  const fluxManifest = join(
+    root,
+    "tools",
+    "mgt-flux-klein-runner",
+    "Cargo.toml",
+  );
+  patchCandleMetalQMatMul({ cwd: root, manifestPath: fluxManifest });
   const koharuManifest = join(
     root,
     "tools",
@@ -59,12 +67,6 @@ function main() {
   );
   buildMetalRunner(koharuManifest);
 
-  const fluxManifest = join(
-    root,
-    "tools",
-    "mgt-flux-klein-runner",
-    "Cargo.toml",
-  );
   if (!existsSync(fluxManifest)) {
     throw new Error(`Missing Flux Metal runner manifest: ${fluxManifest}`);
   }

--- a/scripts/patch-candle-metal-qmatmul.cjs
+++ b/scripts/patch-candle-metal-qmatmul.cjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// @ts-check
+
+const { readFileSync, writeFileSync } = require("node:fs");
+const { dirname, join } = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const CANDLE_REVISION = "e7e71e18414db8de91113963beaabb6b4046a0a5";
+const BROKEN_OFFSET =
+  "src1_l.start_offset() * storage.dtype().size_in_bytes(),";
+const FIXED_OFFSET = "layout.start_offset() * storage.dtype().size_in_bytes(),";
+
+/**
+ * Apply the non-zero input storage offset fix to the exact Candle source used
+ * by Cargo. Git dependencies are immutable inputs, so reject any unexpected
+ * source instead of guessing how a newer revision should be patched.
+ *
+ * @param {string} sourcePath
+ * @returns {"applied" | "already-applied"}
+ */
+function patchCandleMetalSource(sourcePath) {
+  const source = readFileSync(sourcePath, "utf8");
+  const brokenCount = source.split(BROKEN_OFFSET).length - 1;
+  const fixedCount = source.split(FIXED_OFFSET).length - 1;
+  if (brokenCount === 0 && fixedCount === 1) {
+    return "already-applied";
+  }
+  if (brokenCount !== 1 || fixedCount !== 0) {
+    throw new Error(
+      `Unexpected Candle quantized Metal offset implementation in ${sourcePath}`,
+    );
+  }
+  writeFileSync(sourcePath, source.replace(BROKEN_OFFSET, FIXED_OFFSET));
+  return "applied";
+}
+
+/**
+ * @param {{ manifestPath: string; cwd: string }} options
+ * @returns {string}
+ */
+function resolveCandleMetalSource(options) {
+  const result = spawnSync(
+    "cargo",
+    [
+      "metadata",
+      "--manifest-path",
+      options.manifestPath,
+      "--locked",
+      "--format-version",
+      "1",
+    ],
+    {
+      cwd: options.cwd,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      shell: false,
+      env: process.env,
+    },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || "cargo metadata failed");
+  }
+  const stdout = String(result.stdout || "");
+  const jsonStart = stdout.indexOf("{");
+  if (jsonStart < 0) {
+    throw new Error("cargo metadata did not return JSON");
+  }
+  /**
+   * @type {{ packages: Array<{ name: string, source?: string, manifest_path: string }> }}
+   */
+  const metadata = JSON.parse(stdout.slice(jsonStart));
+  const packageInfo = metadata.packages.find(
+    (pkg) =>
+      pkg.name === "candle-core" &&
+      String(pkg.source || "").includes(CANDLE_REVISION),
+  );
+  if (!packageInfo?.manifest_path) {
+    throw new Error(
+      `Could not find candle-core at pinned revision ${CANDLE_REVISION}`,
+    );
+  }
+  return join(
+    dirname(packageInfo.manifest_path),
+    "src",
+    "quantized",
+    "metal.rs",
+  );
+}
+
+/** @param {{ manifestPath: string; cwd: string }} options */
+function patchCandleMetalQMatMul(options) {
+  const sourcePath = resolveCandleMetalSource(options);
+  const status = patchCandleMetalSource(sourcePath);
+  console.log(`Candle Metal QMatMul offset patch ${status}: ${sourcePath}`);
+}
+
+if (require.main === module) {
+  const root = join(__dirname, "..");
+  patchCandleMetalQMatMul({
+    cwd: root,
+    manifestPath: join(root, "tools", "mgt-flux-klein-runner", "Cargo.toml"),
+  });
+}
+
+module.exports = {
+  BROKEN_OFFSET,
+  CANDLE_REVISION,
+  FIXED_OFFSET,
+  patchCandleMetalQMatMul,
+  patchCandleMetalSource,
+  resolveCandleMetalSource,
+};

--- a/scripts/prepare-flux-klein-runner.cjs
+++ b/scripts/prepare-flux-klein-runner.cjs
@@ -9,6 +9,7 @@ const {
 const { tmpdir } = require("node:os");
 const { delimiter, join } = require("node:path");
 const { spawnSync } = require("node:child_process");
+const { patchCandleMetalQMatMul } = require("./patch-candle-metal-qmatmul.cjs");
 
 /**
  * @typedef {{ outDir: string; outExe: string }} BuildAlias
@@ -51,6 +52,7 @@ if (!existsSync(manifestPath)) {
   process.exit(1);
 }
 
+patchCandleMetalQMatMul({ cwd: root, manifestPath });
 patchKoharuFluxSources();
 for (const entry of buildPlan) {
   runCargo(["build", "--release", "--manifest-path", manifestPath], entry);

--- a/scripts/test-flux-metal.cjs
+++ b/scripts/test-flux-metal.cjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// @ts-check
+
+const { spawnSync } = require("node:child_process");
+const { join } = require("node:path");
+const { patchCandleMetalQMatMul } = require("./patch-candle-metal-qmatmul.cjs");
+
+const root = join(__dirname, "..");
+const runnerManifest = join(
+  root,
+  "tools",
+  "mgt-flux-klein-runner",
+  "Cargo.toml",
+);
+const attentionManifest = join(
+  root,
+  "tools",
+  "mgt-flux-klein-runner",
+  "vendor",
+  "candle-nn-metal-attention",
+  "Cargo.toml",
+);
+
+/** @param {string[]} args */
+function cargo(args) {
+  const result = spawnSync("cargo", args, {
+    cwd: root,
+    env: {
+      ...process.env,
+      CANDLE_METAL_XCODE: "1",
+      LLAMA_CPP_TAG: process.env.LLAMA_CPP_TAG || "b-mgt-unused",
+    },
+    stdio: "inherit",
+    shell: false,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`cargo failed with exit code ${result.status ?? "null"}`);
+  }
+}
+
+function main() {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new Error("Flux Metal tests require an Apple Silicon Mac.");
+  }
+
+  patchCandleMetalQMatMul({ cwd: root, manifestPath: runnerManifest });
+  cargo([
+    "test",
+    "--manifest-path",
+    runnerManifest,
+    "--locked",
+    "--no-default-features",
+    "--features",
+    "metal",
+    "--",
+    "--test-threads=1",
+  ]);
+  cargo([
+    "test",
+    "--manifest-path",
+    attentionManifest,
+    "--features",
+    "metal",
+    "--",
+    "--test-threads=1",
+  ]);
+}
+
+main();

--- a/tests/candleMetalPatch.test.ts
+++ b/tests/candleMetalPatch.test.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const { BROKEN_OFFSET, FIXED_OFFSET, patchCandleMetalSource } =
+  require("../scripts/patch-candle-metal-qmatmul.cjs") as {
+    BROKEN_OFFSET: string;
+    FIXED_OFFSET: string;
+    patchCandleMetalSource: (
+      sourcePath: string,
+    ) => "applied" | "already-applied";
+  };
+
+describe("Candle quantized Metal source patch", () => {
+  it("replaces the temporary layout offset and is idempotent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mgt-candle-metal-patch-"));
+    const sourcePath = join(dir, "metal.rs");
+    try {
+      writeFileSync(sourcePath, `before\n${BROKEN_OFFSET}\nafter\n`);
+
+      expect(patchCandleMetalSource(sourcePath)).toBe("applied");
+      expect(readFileSync(sourcePath, "utf8")).toContain(FIXED_OFFSET);
+      expect(patchCandleMetalSource(sourcePath)).toBe("already-applied");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an unknown Candle implementation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mgt-candle-metal-patch-"));
+    const sourcePath = join(dir, "metal.rs");
+    try {
+      writeFileSync(sourcePath, "unrelated source\n");
+      expect(() => patchCandleMetalSource(sourcePath)).toThrow(
+        /Unexpected Candle quantized Metal offset implementation/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/mgt-flux-klein-runner/Cargo.lock
+++ b/tools/mgt-flux-klein-runner/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-build"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "anyhow",
 ]
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "bindgen_cuda",
 ]
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "half",
  "objc2",
@@ -494,7 +494,15 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+dependencies = [
+ "candle-core",
+ "candle-nn 0.9.2 (git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5)",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.9.2"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -511,11 +519,11 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "byteorder",
  "candle-core",
- "candle-nn",
+ "candle-nn 0.9.2 (git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5)",
  "fancy-regex",
  "num-traits",
  "rand 0.9.4",
@@ -529,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -2244,7 +2252,7 @@ dependencies = [
  "anyhow",
  "candle-core",
  "candle-flash-attn",
- "candle-nn",
+ "candle-nn 0.9.2",
  "candle-transformers",
  "clap",
  "cudarc 0.19.7",
@@ -2522,6 +2530,7 @@ name = "mgt-flux-klein"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "candle-core",
  "clap",
  "cudarc 0.19.7",
  "image",

--- a/tools/mgt-flux-klein-runner/Cargo.toml
+++ b/tools/mgt-flux-klein-runner/Cargo.toml
@@ -11,6 +11,7 @@ metal = ["koharu-ml/metal"]
 
 [dependencies]
 anyhow = "1.0"
+candle-core = { version = "0.9.2", default-features = false }
 clap = { version = "4.5", features = ["derive"] }
 cudarc = { version = "0.19.7", default-features = false, features = ["fallback-dynamic-loading", "runtime", "std"], optional = true }
 image = "0.25"
@@ -23,9 +24,9 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [patch.crates-io]
-candle-core = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
-candle-nn = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
-candle-transformers = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
-candle-flash-attn = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
+candle-core = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }
+candle-nn = { path = "vendor/candle-nn-metal-attention" }
+candle-transformers = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }
+candle-flash-attn = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }
 ug = { git = "https://github.com/mayocream/ug", branch = "cuda-dynamic-loading" }
 ug-cuda = { git = "https://github.com/mayocream/ug", branch = "cuda-dynamic-loading" }

--- a/tools/mgt-flux-klein-runner/src/bin/check_flux_inpaint_output.rs
+++ b/tools/mgt-flux-klein-runner/src/bin/check_flux_inpaint_output.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use mgt_flux_klein::quality::{assert_flux_quality, measure_flux_quality};
+
+#[derive(Debug, Parser)]
+struct Args {
+    input: PathBuf,
+    mask: PathBuf,
+    output: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let input = image::open(&args.input)
+        .with_context(|| format!("failed to open input {}", args.input.display()))?;
+    let mask = image::open(&args.mask)
+        .with_context(|| format!("failed to open mask {}", args.mask.display()))?;
+    let output = image::open(&args.output)
+        .with_context(|| format!("failed to open output {}", args.output.display()))?;
+    let metrics = measure_flux_quality(&input, &mask, &output)?;
+    println!("{}", serde_json::to_string_pretty(&metrics)?);
+    assert_flux_quality(&metrics)
+}

--- a/tools/mgt-flux-klein-runner/src/bin/generate_flux_regression_fixtures.rs
+++ b/tools/mgt-flux-klein-runner/src/bin/generate_flux_regression_fixtures.rs
@@ -1,0 +1,45 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use image::{GrayImage, Luma, Rgb, RgbImage};
+
+#[derive(Debug, Parser)]
+struct Args {
+    output_dir: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    fs::create_dir_all(&args.output_dir).with_context(|| {
+        format!(
+            "failed to create fixture directory {}",
+            args.output_dir.display()
+        )
+    })?;
+    let mut input = RgbImage::from_pixel(256, 256, Rgb([220, 220, 220]));
+    let mut mask = GrayImage::from_pixel(256, 256, Luma([0]));
+    let mut positive = input.clone();
+    let mut negative = input.clone();
+    for y in 64..192 {
+        for x in 64..192 {
+            mask.put_pixel(x, y, Luma([255]));
+            input.put_pixel(x, y, Rgb([170, 170, 170]));
+            positive.put_pixel(x, y, Rgb([218, 218, 218]));
+            negative.put_pixel(
+                x,
+                y,
+                if ((x / 16) + (y / 16)) % 2 == 0 {
+                    Rgb([245, 40, 30])
+                } else {
+                    Rgb([30, 80, 245])
+                },
+            );
+        }
+    }
+    input.save(args.output_dir.join("input.png"))?;
+    mask.save(args.output_dir.join("mask.png"))?;
+    positive.save(args.output_dir.join("positive.png"))?;
+    negative.save(args.output_dir.join("negative-colored-tiles.png"))?;
+    Ok(())
+}

--- a/tools/mgt-flux-klein-runner/src/bin/inspect_flux_gguf.rs
+++ b/tools/mgt-flux-klein-runner/src/bin/inspect_flux_gguf.rs
@@ -1,0 +1,55 @@
+use std::{fs::File, path::PathBuf};
+
+use anyhow::{Context, Result, bail};
+use candle_core::quantized::{GgmlDType, gguf_file::Content};
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// FLUX transformer GGUF file to inspect.
+    gguf: PathBuf,
+
+    /// Fail unless at least one double-stream image projection is quantized.
+    #[arg(long)]
+    require_quantized_image_projection: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mut reader = File::open(&args.gguf)
+        .with_context(|| format!("failed to open GGUF {}", args.gguf.display()))?;
+    let content = Content::read(&mut reader).context("failed to parse GGUF metadata")?;
+    let mut projections = content
+        .tensor_infos
+        .iter()
+        .filter(|(name, _)| {
+            name.starts_with("double_blocks.") && name.ends_with(".img_attn.proj.weight")
+        })
+        .collect::<Vec<_>>();
+    projections.sort_by(|left, right| left.0.cmp(right.0));
+    if projections.is_empty() {
+        bail!("GGUF contains no double-stream image attention projections");
+    }
+
+    let mut quantized = 0usize;
+    for (name, info) in &projections {
+        let is_quantized = !matches!(
+            info.ggml_dtype,
+            GgmlDType::F32 | GgmlDType::F16 | GgmlDType::BF16
+        );
+        quantized += usize::from(is_quantized);
+        println!(
+            "{name}\tshape={:?}\tdtype={:?}\tquantized={is_quantized}",
+            info.shape.dims(),
+            info.ggml_dtype,
+        );
+    }
+    println!(
+        "image projections: total={}, quantized={quantized}",
+        projections.len()
+    );
+    if args.require_quantized_image_projection && quantized == 0 {
+        bail!("all double-stream image projections are full precision");
+    }
+    Ok(())
+}

--- a/tools/mgt-flux-klein-runner/src/lib.rs
+++ b/tools/mgt-flux-klein-runner/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod quality;

--- a/tools/mgt-flux-klein-runner/src/quality.rs
+++ b/tools/mgt-flux-klein-runner/src/quality.rs
@@ -1,0 +1,218 @@
+use anyhow::{Result, bail};
+use image::{DynamicImage, GrayImage, RgbImage};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FluxQualityMetrics {
+    pub mean_chroma_excess: f64,
+    pub p95_chroma_excess: f64,
+    pub input_boundary_ratio: f64,
+    pub output_boundary_ratio: f64,
+    pub changed_ratio: f64,
+    pub outside_mean_delta: f64,
+}
+
+pub fn measure_flux_quality(
+    input: &DynamicImage,
+    mask: &DynamicImage,
+    output: &DynamicImage,
+) -> Result<FluxQualityMetrics> {
+    let input = input.to_rgb8();
+    let output = output.to_rgb8();
+    let mask = mask.to_luma8();
+    if input.dimensions() != output.dimensions() || input.dimensions() != mask.dimensions() {
+        bail!(
+            "quality image dimensions differ: input={:?}, mask={:?}, output={:?}",
+            input.dimensions(),
+            mask.dimensions(),
+            output.dimensions()
+        );
+    }
+
+    let mut chroma_excess = Vec::new();
+    let mut changed = 0usize;
+    let mut masked = 0usize;
+    let mut outside_delta = 0f64;
+    let mut outside_samples = 0usize;
+    for ((input_pixel, output_pixel), mask_pixel) in
+        input.pixels().zip(output.pixels()).zip(mask.pixels())
+    {
+        if mask_pixel.0[0] > 0 {
+            masked += 1;
+            let input_chroma = chroma(input_pixel.0);
+            let output_chroma = chroma(output_pixel.0);
+            chroma_excess.push((output_chroma - input_chroma).max(0.0));
+            if input_pixel != output_pixel {
+                changed += 1;
+            }
+        } else {
+            outside_delta += rgb_delta(input_pixel.0, output_pixel.0);
+            outside_samples += 1;
+        }
+    }
+    if masked == 0 {
+        bail!("quality mask is empty");
+    }
+    chroma_excess.sort_by(f64::total_cmp);
+    let p95_index = ((chroma_excess.len() - 1) as f64 * 0.95).round() as usize;
+    Ok(FluxQualityMetrics {
+        mean_chroma_excess: chroma_excess.iter().sum::<f64>() / chroma_excess.len() as f64,
+        p95_chroma_excess: chroma_excess[p95_index],
+        input_boundary_ratio: boundary_ratio(&input, &mask),
+        output_boundary_ratio: boundary_ratio(&output, &mask),
+        changed_ratio: changed as f64 / masked as f64,
+        outside_mean_delta: if outside_samples == 0 {
+            0.0
+        } else {
+            outside_delta / outside_samples as f64
+        },
+    })
+}
+
+pub fn assert_flux_quality(metrics: &FluxQualityMetrics) -> Result<()> {
+    let boundary_limit = 1.04f64.max(metrics.input_boundary_ratio + 0.025);
+    let mut failures = Vec::new();
+    if metrics.mean_chroma_excess > 8.0 {
+        failures.push(format!(
+            "mean chroma excess {:.3} > 8",
+            metrics.mean_chroma_excess
+        ));
+    }
+    if metrics.p95_chroma_excess > 20.0 {
+        failures.push(format!(
+            "p95 chroma excess {:.3} > 20",
+            metrics.p95_chroma_excess
+        ));
+    }
+    if metrics.output_boundary_ratio > boundary_limit {
+        failures.push(format!(
+            "16px boundary ratio {:.4} > {:.4}",
+            metrics.output_boundary_ratio, boundary_limit
+        ));
+    }
+    if metrics.changed_ratio < 0.10 {
+        failures.push(format!(
+            "masked changed ratio {:.4} < 0.10",
+            metrics.changed_ratio
+        ));
+    }
+    if metrics.outside_mean_delta > 0.01 {
+        failures.push(format!(
+            "outside mean delta {:.5} > 0.01",
+            metrics.outside_mean_delta
+        ));
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        bail!("Flux output quality gate failed: {}", failures.join("; "))
+    }
+}
+
+fn chroma(rgb: [u8; 3]) -> f64 {
+    let min = rgb[0].min(rgb[1]).min(rgb[2]);
+    let max = rgb[0].max(rgb[1]).max(rgb[2]);
+    f64::from(max - min)
+}
+
+fn rgb_delta(left: [u8; 3], right: [u8; 3]) -> f64 {
+    left.into_iter()
+        .zip(right)
+        .map(|(left, right)| f64::from(left.abs_diff(right)))
+        .sum::<f64>()
+        / 3.0
+}
+
+fn boundary_ratio(image: &RgbImage, mask: &GrayImage) -> f64 {
+    let (width, height) = image.dimensions();
+    let mut boundary_delta = 0f64;
+    let mut boundary_edges = 0usize;
+    let mut regular_delta = 0f64;
+    let mut regular_edges = 0usize;
+    for y in 0..height {
+        for x in 0..width {
+            if mask.get_pixel(x, y).0[0] == 0 {
+                continue;
+            }
+            if x > 0 && mask.get_pixel(x - 1, y).0[0] > 0 {
+                let delta = rgb_delta(image.get_pixel(x - 1, y).0, image.get_pixel(x, y).0);
+                if x % 16 == 0 {
+                    boundary_delta += delta;
+                    boundary_edges += 1;
+                } else {
+                    regular_delta += delta;
+                    regular_edges += 1;
+                }
+            }
+            if y > 0 && mask.get_pixel(x, y - 1).0[0] > 0 {
+                let delta = rgb_delta(image.get_pixel(x, y - 1).0, image.get_pixel(x, y).0);
+                if y % 16 == 0 {
+                    boundary_delta += delta;
+                    boundary_edges += 1;
+                } else {
+                    regular_delta += delta;
+                    regular_edges += 1;
+                }
+            }
+        }
+    }
+    if boundary_edges == 0 || regular_edges == 0 {
+        return 1.0;
+    }
+    let boundary_mean = boundary_delta / boundary_edges as f64;
+    let regular_mean = regular_delta / regular_edges as f64;
+    if boundary_mean <= f64::EPSILON && regular_mean <= f64::EPSILON {
+        1.0
+    } else {
+        boundary_mean / regular_mean.max(1e-6)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use image::{DynamicImage, GrayImage, Luma, Rgb, RgbImage};
+
+    use super::{assert_flux_quality, measure_flux_quality};
+
+    #[test]
+    fn synthetic_controls_separate_clean_fill_from_colored_tiles() {
+        let (input, mask, positive, negative) = synthetic_fixtures();
+        let positive_metrics = measure_flux_quality(&input, &mask, &positive).unwrap();
+        assert_flux_quality(&positive_metrics).unwrap();
+
+        let negative_metrics = measure_flux_quality(&input, &mask, &negative).unwrap();
+        assert!(assert_flux_quality(&negative_metrics).is_err());
+        assert!(negative_metrics.mean_chroma_excess > 8.0);
+        assert!(negative_metrics.output_boundary_ratio > 1.04);
+    }
+
+    fn synthetic_fixtures() -> (DynamicImage, DynamicImage, DynamicImage, DynamicImage) {
+        let mut input = RgbImage::from_pixel(256, 256, Rgb([220, 220, 220]));
+        let mut mask = GrayImage::from_pixel(256, 256, Luma([0]));
+        let mut positive = input.clone();
+        let mut negative = input.clone();
+        for y in 64..192 {
+            for x in 64..192 {
+                mask.put_pixel(x, y, Luma([255]));
+                input.put_pixel(x, y, Rgb([170, 170, 170]));
+                positive.put_pixel(x, y, Rgb([218, 218, 218]));
+                let tile = ((x / 16) + (y / 16)) % 2;
+                negative.put_pixel(
+                    x,
+                    y,
+                    if tile == 0 {
+                        Rgb([245, 40, 30])
+                    } else {
+                        Rgb([30, 80, 245])
+                    },
+                );
+            }
+        }
+        (
+            DynamicImage::ImageRgb8(input),
+            DynamicImage::ImageLuma8(mask),
+            DynamicImage::ImageRgb8(positive),
+            DynamicImage::ImageRgb8(negative),
+        )
+    }
+}

--- a/tools/mgt-flux-klein-runner/tests/metal_qmatmul_offset.rs
+++ b/tools/mgt-flux-klein-runner/tests/metal_qmatmul_offset.rs
@@ -1,0 +1,55 @@
+#[cfg(feature = "metal")]
+use candle_core::{
+    Device, Module, Result, Tensor,
+    quantized::{GgmlDType, QMatMul, QTensor},
+};
+
+#[cfg(feature = "metal")]
+#[test]
+fn quantized_metal_matmul_respects_flux_image_view_offset() -> Result<()> {
+    const CHANNELS: usize = 256;
+    const TEXT_TOKENS: usize = 512;
+
+    let cpu = Device::Cpu;
+    let metal = Device::new_metal(0)?;
+    let weights = Tensor::from_vec(
+        deterministic_values(CHANNELS * CHANNELS, 0),
+        (CHANNELS, CHANNELS),
+        &cpu,
+    )?;
+    let weights = QTensor::quantize_onto(&weights, GgmlDType::Q4K, &metal)?;
+    let projection = QMatMul::from_qtensor(weights)?;
+
+    for image_tokens in [880usize, 2_736usize] {
+        let image_values = deterministic_values(image_tokens * CHANNELS, TEXT_TOKENS * CHANNELS);
+        let offset_zero = Tensor::from_vec(image_values, (1, image_tokens, CHANNELS), &metal)?;
+        let joined = Tensor::from_vec(
+            deterministic_values((TEXT_TOKENS + image_tokens) * CHANNELS, 0),
+            (1, TEXT_TOKENS + image_tokens, CHANNELS),
+            &metal,
+        )?;
+        let offset_view = joined.narrow(1, TEXT_TOKENS, image_tokens)?;
+
+        let expected = projection.forward(&offset_zero)?;
+        let actual = projection.forward(&offset_view)?;
+        let max_delta = (&expected - &actual)?
+            .abs()?
+            .max_all()?
+            .to_scalar::<f32>()?;
+        assert!(
+            max_delta <= 1e-5,
+            "image_tokens={image_tokens} max_delta={max_delta}"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(feature = "metal")]
+fn deterministic_values(len: usize, offset: usize) -> Vec<f32> {
+    (0..len)
+        .map(|index| {
+            let value = ((index + offset) % 251) as f32;
+            (value - 125.0) / 125.0
+        })
+        .collect()
+}

--- a/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/Cargo.toml
+++ b/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "candle-nn"
+version = "0.9.2"
+edition = "2021"
+publish = false
+
+[features]
+default = []
+accelerate = ["candle-nn-upstream/accelerate"]
+cuda = ["candle-nn-upstream/cuda"]
+cudnn = ["candle-nn-upstream/cudnn"]
+mkl = ["candle-nn-upstream/mkl"]
+metal = ["candle-nn-upstream/metal", "candle-core/metal"]
+
+[dependencies]
+candle-core = "=0.9.2"
+candle-nn-upstream = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5", package = "candle-nn", default-features = false }
+
+[patch.crates-io]
+candle-core = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }

--- a/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/src/lib.rs
+++ b/tools/mgt-flux-klein-runner/vendor/candle-nn-metal-attention/src/lib.rs
@@ -1,0 +1,250 @@
+//! Candle NN compatibility layer for Flux.2 Klein on Metal.
+//!
+//! Candle's fused Metal SDPA both limits supported head dimensions and produces
+//! corrupted Flux.2 transformer output on the supported 128-wide heads. Route
+//! Flux's unmasked, non-causal attention through bounded Metal matmuls instead.
+
+macro_rules! reexport_module {
+    ($name:ident) => {
+        pub mod $name {
+            pub use candle_nn_upstream::$name::*;
+        }
+    };
+}
+
+reexport_module!(activation);
+reexport_module!(batch_norm);
+reexport_module!(conv);
+reexport_module!(cpu_flash_attention);
+reexport_module!(embedding);
+reexport_module!(encoding);
+reexport_module!(func);
+reexport_module!(group_norm);
+reexport_module!(init);
+reexport_module!(kv_cache);
+reexport_module!(layer_norm);
+reexport_module!(linear);
+reexport_module!(loss);
+reexport_module!(optim);
+reexport_module!(rnn);
+reexport_module!(rotary_emb);
+reexport_module!(sampling);
+reexport_module!(sequential);
+reexport_module!(var_builder);
+reexport_module!(var_map);
+pub use candle_nn_upstream::batch_norm::batch_norm;
+pub use candle_nn_upstream::embedding::embedding;
+pub use candle_nn_upstream::func::func;
+pub use candle_nn_upstream::group_norm::group_norm;
+pub use candle_nn_upstream::layer_norm::layer_norm;
+pub use candle_nn_upstream::linear::linear;
+pub use candle_nn_upstream::{
+    conv1d, conv1d_no_bias, conv2d, conv2d_no_bias, conv_transpose1d, conv_transpose1d_no_bias,
+    conv_transpose2d, conv_transpose2d_no_bias, func_t, gru, layer_norm_no_bias, linear_b,
+    linear_no_bias, lstm, prelu, rms_norm, seq, Activation, AdamW, BatchNorm, BatchNormConfig,
+    Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, ConvTranspose1d, ConvTranspose1dConfig,
+    ConvTranspose2d, ConvTranspose2dConfig, Embedding, Func, FuncT, GRUConfig, GroupNorm, Init,
+    LSTMConfig, LayerNorm, LayerNormConfig, Linear, Module, ModuleT, Optimizer, PReLU, ParamsAdamW,
+    RmsNorm, Sequential, VarBuilder, VarMap, GRU, LSTM, RNN, SGD,
+};
+
+pub mod ops {
+    use std::sync::Once;
+
+    use candle_core::{DType, Result, Tensor, D};
+
+    pub use candle_nn_upstream::ops::{
+        dropout, hard_sigmoid, layer_norm, layer_norm_slow, leaky_relu, log_softmax, mish,
+        pixel_shuffle, pixel_unshuffle, replication_pad2d, rms_norm, rms_norm_slow, selu, sigmoid,
+        silu, softmax, softmax_last_dim, swiglu, Dropout, Identity,
+    };
+
+    static METAL_CHUNKED_ATTENTION_LOG: Once = Once::new();
+
+    pub fn sdpa(
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        mask: Option<&Tensor>,
+        do_causal: bool,
+        scale: f32,
+        softcapping: f32,
+    ) -> Result<Tensor> {
+        let head_dim = q.dim(D::Minus1)?;
+        let can_use_flux_chunking =
+            q.device().is_metal() && mask.is_none() && !do_causal && softcapping == 1.0;
+        if can_use_flux_chunking {
+            METAL_CHUNKED_ATTENTION_LOG.call_once(|| {
+                eprintln!(
+                    "mgt-flux-klein: using numerically stable Metal chunked attention (head dim {head_dim})"
+                );
+            });
+            return chunked_attention(q, k, v, scale, attention_chunk_size(q)?);
+        }
+        candle_nn_upstream::ops::sdpa(q, k, v, mask, do_causal, scale, softcapping)
+    }
+
+    fn attention_chunk_size(q: &Tensor) -> Result<usize> {
+        Ok(if q.dim(2)? > 4096 { 64 } else { 128 })
+    }
+
+    fn chunked_attention(
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        scale: f32,
+        chunk_size: usize,
+    ) -> Result<Tensor> {
+        // Keep the score matrix bounded without forcing the transformer through
+        // dozens of tiny Metal command buffers for normal inpainting crops.
+        const KEY_CHUNK_SIZE: usize = 1024;
+
+        let (batch, heads, query_len, _) = q.dims4()?;
+        let key_len = k.dim(2)?;
+        let value_dim = v.dim(D::Minus1)?;
+        let output_dtype = q.dtype();
+        let mut chunks = Vec::with_capacity(query_len.div_ceil(chunk_size));
+        for query_start in (0..query_len).step_by(chunk_size) {
+            let query_chunk_len = chunk_size.min(query_len - query_start);
+            let query = q
+                .narrow(2, query_start, query_chunk_len)?
+                .contiguous()?
+                .to_dtype(DType::F32)?;
+            let mut output_accumulator = Tensor::from_vec(
+                vec![0f32; batch * heads * query_chunk_len * value_dim],
+                (batch, heads, query_chunk_len, value_dim),
+                q.device(),
+            )?;
+            let mut max_scores = Tensor::from_vec(
+                vec![f32::NEG_INFINITY; batch * heads * query_chunk_len],
+                (batch, heads, query_chunk_len, 1),
+                q.device(),
+            )?;
+            let mut exponential_sum = Tensor::from_vec(
+                vec![0f32; batch * heads * query_chunk_len],
+                (batch, heads, query_chunk_len, 1),
+                q.device(),
+            )?;
+
+            for key_start in (0..key_len).step_by(KEY_CHUNK_SIZE) {
+                let key_chunk_len = KEY_CHUNK_SIZE.min(key_len - key_start);
+                let key = k
+                    .narrow(2, key_start, key_chunk_len)?
+                    .contiguous()?
+                    .to_dtype(DType::F32)?;
+                let value = v
+                    .narrow(2, key_start, key_chunk_len)?
+                    .contiguous()?
+                    .to_dtype(DType::F32)?;
+                let scores = (query.matmul(&key.transpose(2, 3)?.contiguous()?)? * scale as f64)?;
+                let tile_max = scores.max_keepdim(D::Minus1)?;
+                let next_max = max_scores.maximum(&tile_max)?;
+                let previous_scale = (&max_scores - &next_max)?.exp()?;
+                output_accumulator = output_accumulator.broadcast_mul(&previous_scale)?;
+                exponential_sum = exponential_sum.broadcast_mul(&previous_scale)?;
+                let exponentials = scores.broadcast_sub(&next_max)?.exp()?;
+                output_accumulator = (output_accumulator + exponentials.matmul(&value)?)?;
+                exponential_sum = (exponential_sum + exponentials.sum_keepdim(D::Minus1)?)?;
+                max_scores = next_max;
+            }
+            chunks.push(
+                output_accumulator
+                    .broadcast_div(&exponential_sum)?
+                    .to_dtype(output_dtype)?,
+            );
+        }
+        Tensor::cat(&chunks, 2)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use candle_core::{Device, Tensor};
+
+        #[test]
+        fn chunked_attention_matches_full_attention() -> Result<()> {
+            let device = Device::Cpu;
+            let q = (Tensor::arange(0f32, 12f32, &device)? / 12.0)?.reshape((1, 1, 4, 3))?;
+            let k = (Tensor::arange(1f32, 13f32, &device)? / 13.0)?.reshape((1, 1, 4, 3))?;
+            let v = (Tensor::arange(0f32, 8f32, &device)? / 8.0)?.reshape((1, 1, 4, 2))?;
+            let scale = 1.0 / 3f32.sqrt();
+            let scores = (q.matmul(&k.transpose(2, 3)?.contiguous()?)? * scale as f64)?;
+            let expected = softmax_last_dim(&scores)?.matmul(&v)?;
+            let actual = chunked_attention(&q, &k, &v, scale, 2)?;
+            let delta = (&expected - &actual)?
+                .abs()?
+                .max_all()?
+                .to_scalar::<f32>()?;
+            assert!(delta < 1e-5, "chunked attention delta was {delta}");
+            Ok(())
+        }
+
+        #[cfg(feature = "metal")]
+        #[test]
+        fn metal_chunked_attention_matches_cpu_for_flux_shapes() -> Result<()> {
+            let cpu = Device::Cpu;
+            let metal = Device::new_metal(0)?;
+            for (heads, query_len, key_len, head_dim) in [
+                (1, 127, 257, 128),
+                (1, 128, 257, 128),
+                (1, 129, 257, 128),
+                (24, 257, 1_392, 128),
+                (2, 1_392, 1_392, 128),
+                (1, 4, 1_031, 512),
+            ] {
+                compare_metal_attention_to_cpu(&cpu, &metal, heads, query_len, key_len, head_dim)?;
+            }
+            Ok(())
+        }
+
+        #[cfg(feature = "metal")]
+        fn compare_metal_attention_to_cpu(
+            cpu: &Device,
+            metal: &Device,
+            heads: usize,
+            query_len: usize,
+            key_len: usize,
+            head_dim: usize,
+        ) -> Result<()> {
+            let q_cpu = test_tensor(heads * query_len * head_dim, 0, cpu)?
+                .reshape((1, heads, query_len, head_dim))?;
+            let k_cpu = test_tensor(heads * key_len * head_dim, 17, cpu)?
+                .reshape((1, heads, key_len, head_dim))?;
+            let v_cpu = test_tensor(heads * key_len * head_dim, 43, cpu)?
+                .reshape((1, heads, key_len, head_dim))?;
+            let scale = 1.0 / (head_dim as f32).sqrt();
+            let scores = (q_cpu.matmul(&k_cpu.transpose(2, 3)?.contiguous()?)? * scale as f64)?;
+            let expected = softmax_last_dim(&scores)?.matmul(&v_cpu)?;
+            let actual = chunked_attention(
+                &q_cpu.to_device(metal)?,
+                &k_cpu.to_device(metal)?,
+                &v_cpu.to_device(metal)?,
+                scale,
+                128,
+            )?
+            .to_device(cpu)?;
+            let delta = (&expected - &actual)?
+                .abs()?
+                .max_all()?
+                .to_scalar::<f32>()?;
+            assert!(
+                delta < 5e-4,
+                "Metal attention delta={delta} for heads={heads}, q={query_len}, kv={key_len}, d={head_dim}"
+            );
+            Ok(())
+        }
+
+        #[cfg(feature = "metal")]
+        fn test_tensor(len: usize, offset: usize, device: &Device) -> Result<Tensor> {
+            let values = (0..len)
+                .map(|index| {
+                    let value = ((index + offset) % 97) as f32;
+                    (value - 48.0) / 48.0
+                })
+                .collect::<Vec<_>>();
+            Tensor::from_vec(values, len, device)
+        }
+    }
+}
+
+pub use ops::Dropout;

--- a/tools/mgt-koharu-inpaint-runner/Cargo.lock
+++ b/tools/mgt-koharu-inpaint-runner/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "candle-core"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-build"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "anyhow",
 ]
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "bindgen_cuda",
 ]
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "half",
  "objc2",
@@ -420,7 +420,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.9.2"
-source = "git+https://github.com/mayocream/candle?branch=flash-attn#e7e71e18414db8de91113963beaabb6b4046a0a5"
+source = "git+https://github.com/mayocream/candle?rev=e7e71e18414db8de91113963beaabb6b4046a0a5#e7e71e18414db8de91113963beaabb6b4046a0a5"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/tools/mgt-koharu-inpaint-runner/Cargo.toml
+++ b/tools/mgt-koharu-inpaint-runner/Cargo.toml
@@ -28,9 +28,9 @@ zip = { version = "8.6", default-features = false, features = ["deflate"] }
 koharu-runtime = { path = "vendor/koharu-runtime-lite" }
 
 [patch.crates-io]
-candle-core = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
-candle-nn = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
-candle-transformers = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
-candle-flash-attn = { git = "https://github.com/mayocream/candle", branch = "flash-attn" }
+candle-core = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }
+candle-nn = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }
+candle-transformers = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }
+candle-flash-attn = { git = "https://github.com/mayocream/candle", rev = "e7e71e18414db8de91113963beaabb6b4046a0a5" }
 ug = { git = "https://github.com/mayocream/ug", branch = "cuda-dynamic-loading" }
 ug-cuda = { git = "https://github.com/mayocream/ug", branch = "cuda-dynamic-loading" }


### PR DESCRIPTION
## What

- Pin the Flux/Koharu Candle revision and apply the quantized Metal matrix-offset correction during runner preparation.
- Vendor the Metal-compatible Candle attention adapter used by the runners.
- Add Metal QMatMul offset, attention parity, and synthetic output-quality regression tooling.

## Why

Flux image tensors can be non-zero-offset views. The pinned Candle quantized Metal matrix-matrix path ignored that view offset, so Metal inference could read the wrong region while CPU/CUDA paths remained correct.

## Impact

- Quantized Flux Metal inference respects tensor view offsets.
- Native runner builds use one verified Candle revision.
- The patch script is idempotent and fails if the expected upstream source no longer matches.

## Checks

- `npm run check`
- `npm run test:flux-metal`
- Metal QMatMul offset and CPU/Metal attention parity tests
