### PR TITLE
fix: harden macOS runtime bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
+.DS_Store
+.mac-alpha-onboarding-v1
 out/
 dist/
 .tmp/

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -1,9 +1,11 @@
 const http = require("node:http");
 const net = require("node:net");
 const { join } = require("node:path");
-const { existsSync } = require("node:fs");
 const { spawn, spawnSync } = require("node:child_process");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
+const {
+  resolveMissingMacInpaintingRunners,
+} = require("./mac-inpainting-runners.cjs");
 const { prepareRuntimeAssets } = require("./prepare-runtime.cjs");
 
 const root = join(__dirname, "..");
@@ -36,6 +38,19 @@ function runSync(command, args) {
   });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
+  }
+}
+
+function prepareMacInpaintingRunners() {
+  const missing = resolveMissingMacInpaintingRunners(root);
+  if (missing.length === 0) return;
+  log(`building ${missing.length} missing Metal inpainting runner(s)`);
+  runSync(process.execPath, [join(__dirname, "build-mac-runners.cjs")]);
+  const remaining = resolveMissingMacInpaintingRunners(root);
+  if (remaining.length > 0) {
+    throw new Error(
+      `Metal inpainting runner build completed without: ${remaining.join(", ")}`,
+    );
   }
 }
 
@@ -184,6 +199,7 @@ function shutdown(exitCode = 0) {
 }
 
 (async () => {
+  prepareMacInpaintingRunners();
   log("preparing runtime assets");
   prepareRuntimeAssets({ root, outputDir: join(root, "out", "app-runtime") });
   log("compiling Electron main process");
@@ -204,10 +220,7 @@ function shutdown(exitCode = 0) {
   ]);
   log(`waiting for renderer ${rendererUrl}`);
   await waitForUrl(rendererUrl);
-  const electronExe = resolveElectronExecutable(root);
-  if (!existsSync(electronExe)) {
-    throw new Error(`Electron executable is missing: ${electronExe}`);
-  }
+  const electronExe = ensureElectronExecutable(root);
   spawnChild("electron", electronExe, ["."], {
     ELECTRON_RENDERER_URL: rendererUrl,
     ELECTRON_RUN_AS_NODE: undefined,

--- a/scripts/electron-executable.cjs
+++ b/scripts/electron-executable.cjs
@@ -1,4 +1,6 @@
 // @ts-check
+const { spawnSync } = require("node:child_process");
+const { existsSync } = require("node:fs");
 const { join } = require("node:path");
 
 /**
@@ -14,4 +16,38 @@ function resolveElectronExecutable(root, platform = process.platform) {
   return join(distRoot, "electron");
 }
 
-module.exports = { resolveElectronExecutable };
+/**
+ * Electron 42+ downloads its binary on first use instead of during npm install.
+ * These scripts launch the binary directly, so mirror that first-use bootstrap
+ * before returning the executable path.
+ *
+ * @param {string} root
+ * @param {NodeJS.Platform} [platform]
+ */
+function ensureElectronExecutable(root, platform = process.platform) {
+  const executablePath = resolveElectronExecutable(root, platform);
+  if (existsSync(executablePath)) {
+    return executablePath;
+  }
+
+  const installerPath = join(root, "node_modules", "electron", "install.js");
+  const result = spawnSync(process.execPath, [installerPath], {
+    cwd: root,
+    stdio: "inherit",
+    shell: false,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Electron binary installation failed with exit code ${result.status ?? "null"}.`,
+    );
+  }
+  if (!existsSync(executablePath)) {
+    throw new Error(`Electron installer did not create: ${executablePath}`);
+  }
+  return executablePath;
+}
+
+module.exports = { ensureElectronExecutable, resolveElectronExecutable };

--- a/scripts/mac-inpainting-runners.cjs
+++ b/scripts/mac-inpainting-runners.cjs
@@ -1,0 +1,54 @@
+// @ts-check
+const { statSync } = require("node:fs");
+const { join } = require("node:path");
+
+const MAC_INPAINTING_RUNNERS = [
+  "mgt-koharu-inpaint-runner",
+  "mgt-flux-klein-runner",
+];
+
+/** @param {string} root */
+function resolveMacInpaintingRunnerPaths(root) {
+  return MAC_INPAINTING_RUNNERS.map((directory) => {
+    const executable =
+      directory === "mgt-flux-klein-runner" ? "mgt-flux-klein" : directory;
+    return join(
+      root,
+      "tools",
+      directory,
+      "target",
+      "aarch64-apple-darwin",
+      "release",
+      executable,
+    );
+  });
+}
+
+/** @param {string} filePath */
+function isUsableExecutable(filePath) {
+  try {
+    const stat = statSync(filePath);
+    return stat.isFile() && stat.size > 0 && (stat.mode & 0o111) !== 0;
+  } catch (_error) {
+    return false;
+  }
+}
+
+/**
+ * @param {string} root
+ * @param {{ platform?: NodeJS.Platform; arch?: string; isUsable?: (filePath: string) => boolean }} [options]
+ */
+function resolveMissingMacInpaintingRunners(root, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  if (platform !== "darwin" || arch !== "arm64") return [];
+  const isUsable = options.isUsable ?? isUsableExecutable;
+  return resolveMacInpaintingRunnerPaths(root).filter(
+    (filePath) => !isUsable(filePath),
+  );
+}
+
+module.exports = {
+  resolveMacInpaintingRunnerPaths,
+  resolveMissingMacInpaintingRunners,
+};

--- a/scripts/run-flux-pattern-smoke.cjs
+++ b/scripts/run-flux-pattern-smoke.cjs
@@ -1,15 +1,10 @@
 const { spawnSync } = require("node:child_process");
-const { existsSync } = require("node:fs");
 const { join } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const smokeScript = join(root, "scripts", "smoke-flux-pattern-chapter.cjs");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 /** @type {NodeJS.ProcessEnv} */
 const env = {

--- a/scripts/run-gemma-economy-benchmark.cjs
+++ b/scripts/run-gemma-economy-benchmark.cjs
@@ -1,15 +1,10 @@
 const { spawnSync } = require("node:child_process");
-const { existsSync } = require("node:fs");
 const { join } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const benchmarkScript = join(root, "scripts", "benchmark-gemma-economy.cjs");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 const env = { ...process.env };
 delete env.ELECTRON_RUN_AS_NODE;

--- a/scripts/run-image-protocol-smoke.cjs
+++ b/scripts/run-image-protocol-smoke.cjs
@@ -1,12 +1,12 @@
 // @ts-check
 const { spawn } = require("node:child_process");
-const { existsSync, mkdirSync } = require("node:fs");
+const { mkdirSync } = require("node:fs");
 const { readFile, rm } = require("node:fs/promises");
 const { isAbsolute, join, relative, resolve } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const smokeScript = join(root, "scripts", "smoke-image-protocol.cjs");
 const smokeTempRoot = join(
   root,
@@ -16,10 +16,6 @@ const smokeTempRoot = join(
 );
 const userDataDir = join(smokeTempRoot, "electron-user-data");
 const resultPath = join(smokeTempRoot, "result.json");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 assertPathInsideRoot(smokeTempRoot);
 mkdirSync(userDataDir, { recursive: true });

--- a/scripts/run-smoke-overlay.cjs
+++ b/scripts/run-smoke-overlay.cjs
@@ -1,15 +1,10 @@
 const { spawnSync } = require("node:child_process");
-const { existsSync } = require("node:fs");
 const { join } = require("node:path");
-const { resolveElectronExecutable } = require("./electron-executable.cjs");
+const { ensureElectronExecutable } = require("./electron-executable.cjs");
 
 const root = join(__dirname, "..");
-const electronExe = resolveElectronExecutable(root);
+const electronExe = ensureElectronExecutable(root);
 const smokeScript = join(root, "scripts", "smoke-overlay.cjs");
-
-if (!existsSync(electronExe)) {
-  throw new Error(`Electron executable is missing: ${electronExe}`);
-}
 
 const env = { ...process.env };
 delete env.ELECTRON_RUN_AS_NODE;

--- a/scripts/smoke-flux-pattern-chapter.cjs
+++ b/scripts/smoke-flux-pattern-chapter.cjs
@@ -74,12 +74,18 @@ async function main() {
   );
 
   if (!process.env.MGT_FLUX_KLEIN_EXE) {
-    const localMgtFlux = path.join(
-      ROOT,
-      "tools",
-      "mgt-flux-klein",
-      "mgt-flux-klein.exe",
-    );
+    const localMgtFlux =
+      process.platform === "darwin" && process.arch === "arm64"
+        ? path.join(
+            ROOT,
+            "tools",
+            "mgt-flux-klein-runner",
+            "target",
+            "aarch64-apple-darwin",
+            "release",
+            "mgt-flux-klein",
+          )
+        : path.join(ROOT, "tools", "mgt-flux-klein", "mgt-flux-klein.exe");
     if (existsSync(localMgtFlux)) {
       process.env.MGT_FLUX_KLEIN_EXE = localMgtFlux;
     }
@@ -93,6 +99,10 @@ async function main() {
       "mgt-flux-klein-runtime",
     ),
     modelDir: path.join(ROOT, "models", "inpainting", "flux-klein-4b"),
+    fluxBackend:
+      process.platform === "darwin" && process.arch === "arm64"
+        ? "metal-native"
+        : undefined,
     onProgress:
       /** @param {FluxProgress} progress */
       (progress) => {

--- a/src/main/runtime/assets/ffmpeg-path.cjs
+++ b/src/main/runtime/assets/ffmpeg-path.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const { existsSync } = require("node:fs");
+const { existsSync, statSync } = require("node:fs");
 const path = require("node:path");
 
 const {
@@ -25,7 +25,7 @@ function bundledFfmpegCandidates(toolsDir) {
 function resolveFfmpegPath(options = {}) {
   const toolsDir = resolveToolsDir(options);
   const candidates = bundledFfmpegCandidates(toolsDir);
-  const bundledPath = candidates.find((candidate) => existsSync(candidate));
+  const bundledPath = candidates.find(isExistingFilePath);
   if (bundledPath) return bundledPath;
   if (isLikelyPackagedToolsDir(toolsDir)) {
     throw createDetailedError(
@@ -40,8 +40,34 @@ function resolveFfmpegPath(options = {}) {
   const explicit = [
     options.ffmpegPath,
     runtimeOverrideEnv("MANGA_TRANSLATOR_FFMPEG_PATH", options),
-  ].find((candidate) => typeof candidate === "string" && existsSync(candidate));
-  return explicit || (process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg");
+  ].find(isExistingFilePath);
+  return (
+    explicit ||
+    resolveDevelopmentFfmpegPath() ||
+    (process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg")
+  );
 }
 
-module.exports = { resolveFfmpegPath };
+/** @returns {string | null} */
+function resolveDevelopmentFfmpegPath() {
+  try {
+    const ffmpegPath = /** @type {unknown} */ (require("ffmpeg-static"));
+    return isExistingFilePath(ffmpegPath)
+      ? /** @type {string} */ (ffmpegPath)
+      : null;
+  } catch (_error) {
+    // error-policy-allow: packaged apps use the verified bundled tools directory.
+    return null;
+  }
+}
+
+/** @param {unknown} candidate */
+function isExistingFilePath(candidate) {
+  return (
+    typeof candidate === "string" &&
+    existsSync(candidate) &&
+    statSync(candidate).isFile()
+  );
+}
+
+module.exports = { resolveDevelopmentFfmpegPath, resolveFfmpegPath };

--- a/src/main/runtime/simple-page-tar-utils.cjs
+++ b/src/main/runtime/simple-page-tar-utils.cjs
@@ -5,7 +5,7 @@ const {
   readlinkSync,
   realpathSync,
 } = require("node:fs");
-const { chmod, mkdir } = require("node:fs/promises");
+const { chmod, mkdir, rm, symlink } = require("node:fs/promises");
 const path = require("node:path");
 const tar = require("tar");
 
@@ -41,19 +41,25 @@ async function extractSelectedTarEntries(
     unlink: true,
     filter: (entryPath, entry) => {
       const tarEntry = /** @type {any} */ (entry);
-      return shouldExtractTarEntry(
-        {
-          path: entryPath,
-          type: tarEntry.type,
-          linkpath: tarEntry.linkpath,
-          size: tarEntry.size,
-          mode: tarEntry.mode,
-        },
-        stripComponents,
-        shouldExtract,
+      const entryInfo = {
+        path: entryPath,
+        type: tarEntry.type,
+        linkpath: tarEntry.linkpath,
+        size: tarEntry.size,
+        mode: tarEntry.mode,
+      };
+      return (
+        !isSymbolicLinkType(entryInfo.type) &&
+        shouldExtractTarEntry(entryInfo, stripComponents, shouldExtract)
       );
     },
   });
+  await createSelectedTarSymlinks(
+    entries,
+    outputDir,
+    stripComponents,
+    shouldExtract,
+  );
   assertExtractedSymlinksStayInside(outputDir);
   const serverPath = path.join(outputDir, "llama-server");
   try {
@@ -61,6 +67,29 @@ async function extractSelectedTarEntries(
   } catch (_error) {
     // error-policy-allow: the caller validates and reports a missing server.
     // The caller reports the missing required binary with runtime details.
+  }
+}
+
+/** @param {TarEntryInfo[]} entries @param {string} outputDir @param {number} stripComponents @param {RuntimeEntryFilter} shouldExtract */
+async function createSelectedTarSymlinks(
+  entries,
+  outputDir,
+  stripComponents,
+  shouldExtract,
+) {
+  for (const entry of entries) {
+    if (
+      !isSymbolicLinkType(entry.type) ||
+      !shouldExtractTarEntry(entry, stripComponents, shouldExtract)
+    ) {
+      continue;
+    }
+    const safePath = normalizeSafeArchivePath(entry.path);
+    const outputPath = stripArchivePath(safePath, stripComponents);
+    const linkPath = path.join(outputDir, outputPath);
+    await mkdir(path.dirname(linkPath), { recursive: true });
+    await rm(linkPath, { force: true });
+    await symlink(String(entry.linkpath), linkPath);
   }
 }
 
@@ -226,6 +255,7 @@ function inspectExtractedEntry(entryPath, root, stack) {
 function assertSafeExtractedSymlink(entryPath, root) {
   const target = readlinkSync(entryPath);
   const resolved = path.resolve(path.dirname(entryPath), target);
+  const realRoot = realpathSync(root);
   let realResolved;
   try {
     realResolved = realpathSync(entryPath);
@@ -234,7 +264,7 @@ function assertSafeExtractedSymlink(entryPath, root) {
       cause,
     });
   }
-  if (!isPathInside(resolved, root) || !isPathInside(realResolved, root)) {
+  if (!isPathInside(resolved, root) || !isPathInside(realResolved, realRoot)) {
     throw new Error(
       `Extracted runtime symlink escapes extraction root: ${entryPath}`,
     );

--- a/tests/electronExecutable.test.ts
+++ b/tests/electronExecutable.test.ts
@@ -1,8 +1,20 @@
-import { join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const { resolveElectronExecutable } =
+const { ensureElectronExecutable, resolveElectronExecutable } =
   require("../scripts/electron-executable.cjs") as {
+    ensureElectronExecutable: (
+      root: string,
+      platform: NodeJS.Platform,
+    ) => string;
     resolveElectronExecutable: (
       root: string,
       platform: NodeJS.Platform,
@@ -32,5 +44,36 @@ describe("Electron executable resolution", () => {
     expect(resolveElectronExecutable("/repo", "linux")).toBe(
       join("/repo", "node_modules", "electron", "dist", "electron"),
     );
+  });
+
+  it("downloads the Electron binary before a direct first launch", () => {
+    const temporaryRoot = mkdtempSync(
+      join(tmpdir(), "mgt-electron-bootstrap-"),
+    );
+    try {
+      const installerPath = join(
+        temporaryRoot,
+        "node_modules",
+        "electron",
+        "install.js",
+      );
+      const executablePath = resolveElectronExecutable(
+        temporaryRoot,
+        process.platform,
+      );
+      mkdirSync(dirname(installerPath), { recursive: true });
+      writeFileSync(
+        installerPath,
+        `require("node:fs").mkdirSync(${JSON.stringify(dirname(executablePath))}, { recursive: true });\nrequire("node:fs").writeFileSync(${JSON.stringify(executablePath)}, "electron");\n`,
+        "utf8",
+      );
+
+      expect(ensureElectronExecutable(temporaryRoot, process.platform)).toBe(
+        executablePath,
+      );
+      expect(existsSync(executablePath)).toBe(true);
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/ffmpegPath.test.ts
+++ b/tests/ffmpegPath.test.ts
@@ -1,0 +1,32 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const { resolveFfmpegPath } =
+  require("../src/main/runtime/assets/ffmpeg-path.cjs") as {
+    resolveFfmpegPath: (options: { toolsDir: string }) => string;
+  };
+
+describe("FFmpeg path resolution", () => {
+  it("uses the installed development FFmpeg when tools has no bundled copy", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "mgt-ffmpeg-path-"));
+    const toolsDir = join(temporaryRoot, "tools");
+    mkdirSync(join(toolsDir, "ffmpeg"), { recursive: true });
+
+    try {
+      const ffmpegPath = resolveFfmpegPath({ toolsDir });
+      const result = spawnSync(ffmpegPath, ["-version"], {
+        encoding: "utf8",
+        shell: false,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("ffmpeg version");
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/macGemmaMetal.test.ts
+++ b/tests/macGemmaMetal.test.ts
@@ -5,6 +5,7 @@ import {
   existsSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -371,6 +372,37 @@ describe("Metal runtime archive integrity", () => {
         "metal",
       );
       expect(() => readFileSync(join(output, "README.md"))).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("extracts runtime symlinks after their target files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mgt-mac-runtime-symlink-"));
+    try {
+      const source = join(dir, "source");
+      const releaseName = "beellama-v0.3.1";
+      const release = join(source, releaseName);
+      const output = join(dir, "output");
+      const archive = join(dir, "runtime.tar.gz");
+      mkdirSync(release, { recursive: true });
+      writeFileSync(join(release, "libmtmd.0.dylib"), "metal");
+      writeFileSync(join(release, "llama-server"), "mach-o");
+      symlinkSync("libmtmd.0.dylib", join(release, "libmtmd.dylib"));
+      await tar.c({ cwd: source, file: archive, gzip: true }, [
+        `${releaseName}/libmtmd.dylib`,
+        `${releaseName}/libmtmd.0.dylib`,
+        `${releaseName}/llama-server`,
+      ]);
+
+      await extractSelectedTarEntries(
+        archive,
+        output,
+        shouldExtractLlamaRuntimeFile,
+        { stripComponents: 1 },
+      );
+
+      expect(readFileSync(join(output, "libmtmd.dylib"), "utf8")).toBe("metal");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/macInpaintingRunnerBootstrap.test.ts
+++ b/tests/macInpaintingRunnerBootstrap.test.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const { resolveMacInpaintingRunnerPaths, resolveMissingMacInpaintingRunners } =
+  require("../scripts/mac-inpainting-runners.cjs") as {
+    resolveMacInpaintingRunnerPaths: (root: string) => string[];
+    resolveMissingMacInpaintingRunners: (
+      root: string,
+      options: {
+        platform: NodeJS.Platform;
+        arch: string;
+        isUsable: (filePath: string) => boolean;
+      },
+    ) => string[];
+  };
+
+describe("macOS inpainting runner bootstrap", () => {
+  it("requires both native runners on Apple Silicon", () => {
+    const root = join("workspace", "CarrotMangaTranslator");
+    const paths = resolveMacInpaintingRunnerPaths(root);
+
+    expect(paths).toEqual([
+      join(
+        root,
+        "tools",
+        "mgt-koharu-inpaint-runner",
+        "target",
+        "aarch64-apple-darwin",
+        "release",
+        "mgt-koharu-inpaint-runner",
+      ),
+      join(
+        root,
+        "tools",
+        "mgt-flux-klein-runner",
+        "target",
+        "aarch64-apple-darwin",
+        "release",
+        "mgt-flux-klein",
+      ),
+    ]);
+    expect(
+      resolveMissingMacInpaintingRunners(root, {
+        platform: "darwin",
+        arch: "arm64",
+        isUsable: vi.fn(() => false),
+      }),
+    ).toEqual(paths);
+  });
+
+  it("does not build Metal runners on other platforms", () => {
+    const isUsable = vi.fn(() => false);
+    expect(
+      resolveMissingMacInpaintingRunners("workspace", {
+        platform: "win32",
+        arch: "x64",
+        isUsable,
+      }),
+    ).toEqual([]);
+    expect(isUsable).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

- Resolve the Electron executable consistently across development and smoke scripts on macOS.
- Build missing native inpainting runners before development startup.
- Harden FFmpeg lookup and selective runtime archive extraction, including dylib symlinks.
- Keep macOS onboarding artifacts out of source control.

## Why

macOS development startup and smoke commands relied on platform-specific executable names and prebuilt native runners. Runtime archives could also expose symlinks before their targets were extracted, which made otherwise valid Metal runtime packages fail to bootstrap.

## Impact

- macOS development and smoke workflows start from a reproducible runtime layout.
- Windows/Linux behavior remains on the existing executable resolution paths.
- No renderer UI or model-selection behavior changes.

## Checks

- `npm run check`
- Electron executable, FFmpeg path, native runner bootstrap, and runtime archive regression tests
