### PR TITLE
Fix final macOS artifact verification

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -10,6 +10,12 @@ const bundleFluxNvidiaRunners =
   process.env.MGT_BUNDLE_FLUX_NVIDIA_RUNNERS === "1";
 const isMacBuild =
   process.platform === "darwin" || process.env.MGT_TARGET_PLATFORM === "darwin";
+// APFS stores Korean filenames in a decomposed Unicode form. Electron 43
+// compares launched Helper paths byte-for-byte against paths derived from
+// CFBundleName, so a Korean macOS product name makes the comparison fail and
+// aborts before app.whenReady(). Keep bundle/helper names ASCII on macOS while
+// preserving the user-facing Korean display name below.
+const productName = isMacBuild ? "CarrotMangaTranslator" : "당근망가번역기";
 const macDeveloperSigning = process.env.MGT_MAC_SIGNING_MODE === "developer-id";
 const macRuntimeRoot =
   process.env.MGT_MAC_RUNTIME_ROOT || join(__dirname, ".tmp", "mac-runtime");
@@ -151,7 +157,7 @@ function listFilesRecursively(directory) {
 
 module.exports = {
   appId: "com.sam40.mangagemma.translator",
-  productName: "당근망가번역기",
+  productName,
   directories: {
     output: "dist",
   },
@@ -238,6 +244,9 @@ module.exports = {
     category: "public.app-category.graphics-design",
     minimumSystemVersion: "14.0",
     executableName: "CarrotMangaTranslator",
+    extendInfo: {
+      CFBundleDisplayName: "당근망가번역기",
+    },
     artifactName: "CarrotMangaTranslator-${version}-macOS-arm64-alpha.${ext}",
     electronLanguages: ["en-US", "en-GB", "ko", "ja", "zh-CN", "zh-TW"],
     identity: macDeveloperSigning ? undefined : "-",
@@ -254,6 +263,11 @@ module.exports = {
   },
   dmg: {
     sign: macDeveloperSigning,
+    // The bundled OCR/Metal runtimes make the app roughly 2 GB. dmgbuild's
+    // automatic HFS+ sizing can silently omit the 191 MB Electron Framework
+    // executable when the calculated image is too tight, so reserve explicit
+    // headroom before the image is shrunk and compressed.
+    size: "3g",
   },
   nsis: {
     oneClick: false,

--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -326,6 +326,35 @@ function verifyRequiredRuntimes(appPath) {
 }
 
 /** @param {string} appPath */
+function verifyPackagedTarRuntime(appPath) {
+  const appExecutable = join(
+    appPath,
+    "Contents",
+    "MacOS",
+    "CarrotMangaTranslator",
+  );
+  const tarRuntimePath = join(
+    appPath,
+    "Contents",
+    "Resources",
+    "app-runtime",
+    "simple-page-tar-utils.cjs",
+  );
+  if (!existsSync(tarRuntimePath)) {
+    throw new Error(`Packaged tar runtime is missing: ${tarRuntimePath}`);
+  }
+  const smokeScript = [
+    `const runtime = require(${JSON.stringify(tarRuntimePath)});`,
+    "if (typeof runtime.extractSelectedTarEntries !== 'function') throw new Error('Packaged tar runtime did not load');",
+    "console.log('packaged-tar-runtime-ok');",
+  ].join("\n");
+  run(appExecutable, ["-e", smokeScript], {
+    env: { ELECTRON_RUN_AS_NODE: "1" },
+    timeout: 30_000,
+  });
+}
+
+/** @param {string} appPath */
 function verifySigning(appPath) {
   run("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath]);
   const details = run("codesign", ["-dvvv", appPath]).stderr;
@@ -389,6 +418,7 @@ function verifyFinalDiskImage(diskImagePath) {
     const appPath = findSingleAppBundle(mountRoot, "final DMG");
     assertElectronFrameworkExecutable(appPath);
     verifySigning(appPath);
+    verifyPackagedTarRuntime(appPath);
     verifyApplicationDirectorySmoke(appPath);
     console.log(
       `[mac-verify] mounted, signed, copied, and launched final DMG app ${relative(root, appPath)}`,
@@ -414,6 +444,7 @@ function verifyFinalZipArchive(zipPath) {
     const appPath = findSingleAppBundle(extractRoot, "final ZIP");
     assertElectronFrameworkExecutable(appPath);
     verifySigning(appPath);
+    verifyPackagedTarRuntime(appPath);
     console.log(
       `[mac-verify] extracted and verified final ZIP app ${relative(root, appPath)}`,
     );
@@ -788,6 +819,7 @@ async function main() {
   // running any executable from it.  The second check below proves that the
   // runtime smokes kept the signed .app immutable.
   verifySigning(appPath);
+  verifyPackagedTarRuntime(appPath);
   // Launch through LaunchServices exactly as a user opens an installed .app,
   // before the memory-intensive OCR and Metal model smokes run.
   verifyApplicationDirectorySmoke(appPath);
@@ -844,6 +876,7 @@ module.exports = {
   looksLikeNativeBinary,
   requiresOtoolAlias,
   shouldAllowHostedGuiSmokeFailure,
+  verifyPackagedTarRuntime,
   verifyFinalDiskImage,
   verifyFinalZipArchive,
 };

--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -28,6 +28,14 @@ const HOSTED_APP_SMOKE_WAIVER_PATH = join(
   "mac-alpha-hosted-app-smoke-waiver.json",
 );
 const SMOKE_APP_PATH = "/Applications/CarrotMangaTranslatorAlphaSmoke.app";
+const ELECTRON_FRAMEWORK_EXECUTABLE = join(
+  "Contents",
+  "Frameworks",
+  "Electron Framework.framework",
+  "Versions",
+  "A",
+  "Electron Framework",
+);
 
 /** @typedef {{ status: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string; error?: Error }} CommandResult */
 
@@ -93,6 +101,33 @@ function findAppBundles(directory) {
     }
   }
   return apps;
+}
+
+/** @param {string} directory @param {string} artifactLabel */
+function findSingleAppBundle(directory, artifactLabel) {
+  const apps = findAppBundles(directory);
+  if (apps.length !== 1) {
+    throw new Error(
+      `Expected one .app in ${artifactLabel}, found ${apps.length}: ${apps.join(", ") || "none"}`,
+    );
+  }
+  return apps[0];
+}
+
+/** @param {string} appPath */
+function assertElectronFrameworkExecutable(appPath) {
+  const frameworkExecutable = join(appPath, ELECTRON_FRAMEWORK_EXECUTABLE);
+  if (!existsSync(frameworkExecutable)) {
+    throw new Error(
+      `Final app is missing the Electron Framework executable: ${frameworkExecutable}`,
+    );
+  }
+  const metadata = statSync(frameworkExecutable);
+  if (!metadata.isFile() || metadata.size === 0) {
+    throw new Error(
+      `Final app has an invalid Electron Framework executable: ${frameworkExecutable}`,
+    );
+  }
 }
 
 /** @param {string} filePath */
@@ -281,6 +316,76 @@ function verifySigning(appPath) {
     run("xcrun", ["stapler", "validate", appPath]);
   } else if (!/Signature=adhoc/m.test(details)) {
     throw new Error(`Expected ad-hoc signature, got:\n${details}`);
+  }
+}
+
+/** @param {string} diskImagePath */
+function verifyFinalDiskImage(diskImagePath) {
+  const mountRoot = mkdtempSync(join(tmpdir(), "mgt-final-dmg-"));
+  let attachedDevice = "";
+  try {
+    const attachResult = run(
+      "hdiutil",
+      [
+        "attach",
+        "-readonly",
+        "-nobrowse",
+        "-mountpoint",
+        mountRoot,
+        "-plist",
+        diskImagePath,
+      ],
+      { timeout: 120_000 },
+    );
+    /** @type {{ "system-entities"?: Array<Record<string, unknown>> }} */
+    const attachJson = JSON.parse(
+      run("plutil", ["-convert", "json", "-o", "-", "-"], {
+        input: attachResult.stdout,
+      }).stdout,
+    );
+    const mountedEntity = attachJson["system-entities"]?.find(
+      (entity) => entity["mount-point"] && entity["dev-entry"],
+    );
+    attachedDevice = String(mountedEntity?.["dev-entry"] || "");
+    if (!attachedDevice) {
+      throw new Error(
+        `Could not resolve the mounted device for final DMG: ${diskImagePath}`,
+      );
+    }
+
+    const appPath = findSingleAppBundle(mountRoot, "final DMG");
+    assertElectronFrameworkExecutable(appPath);
+    verifySigning(appPath);
+    verifyApplicationDirectorySmoke(appPath);
+    console.log(
+      `[mac-verify] mounted, signed, copied, and launched final DMG app ${relative(root, appPath)}`,
+    );
+  } finally {
+    try {
+      if (attachedDevice) {
+        run("hdiutil", ["detach", attachedDevice], { timeout: 120_000 });
+      }
+    } finally {
+      rmSync(mountRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+/** @param {string} zipPath */
+function verifyFinalZipArchive(zipPath) {
+  const extractRoot = mkdtempSync(join(tmpdir(), "mgt-final-zip-"));
+  try {
+    run("ditto", ["-x", "-k", zipPath, extractRoot], {
+      timeout: 300_000,
+    });
+    const appPath = findSingleAppBundle(extractRoot, "final ZIP");
+    assertElectronFrameworkExecutable(appPath);
+    verifySigning(appPath);
+    console.log(
+      `[mac-verify] extracted and verified final ZIP app ${relative(root, appPath)}`,
+    );
+  } finally {
+    rmSync(extractRoot, { recursive: true, force: true });
   }
 }
 
@@ -643,6 +748,7 @@ async function main() {
     throw new Error(`Expected one unpacked .app in dist, found ${apps.length}`);
   }
   const appPath = apps[0];
+  assertElectronFrameworkExecutable(appPath);
   verifyNativePayload(appPath);
   // Establish that electron-builder produced a valid sealed bundle before
   // running any executable from it.  The second check below proves that the
@@ -670,6 +776,8 @@ async function main() {
   if (process.env.MGT_MAC_SIGNING_MODE === "developer-id") {
     run("xcrun", ["stapler", "validate", dmgFiles[0]]);
   }
+  verifyFinalDiskImage(dmgFiles[0]);
+  verifyFinalZipArchive(zipFiles[0]);
 
   const artifacts = [...dmgFiles, ...zipFiles];
   const sums = (
@@ -694,9 +802,13 @@ if (require.main === module) {
 }
 
 module.exports = {
+  assertElectronFrameworkExecutable,
   findAppBundles,
+  findSingleAppBundle,
   listFiles,
   looksLikeNativeBinary,
   requiresOtoolAlias,
   shouldAllowHostedGuiSmokeFailure,
+  verifyFinalDiskImage,
+  verifyFinalZipArchive,
 };

--- a/scripts/verify-mac-package.cjs
+++ b/scripts/verify-mac-package.cjs
@@ -36,6 +36,12 @@ const ELECTRON_FRAMEWORK_EXECUTABLE = join(
   "A",
   "Electron Framework",
 );
+const ELECTRON_HELPER_SUFFIXES = [
+  "Helper",
+  "Helper (GPU)",
+  "Helper (Plugin)",
+  "Helper (Renderer)",
+];
 
 /** @typedef {{ status: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string; error?: Error }} CommandResult */
 
@@ -127,6 +133,33 @@ function assertElectronFrameworkExecutable(appPath) {
     throw new Error(
       `Final app has an invalid Electron Framework executable: ${frameworkExecutable}`,
     );
+  }
+}
+
+/** @param {string} appPath */
+function assertElectronHelperExecutables(appPath) {
+  for (const suffix of ELECTRON_HELPER_SUFFIXES) {
+    const helperName = `CarrotMangaTranslator ${suffix}`;
+    const helperExecutable = join(
+      appPath,
+      "Contents",
+      "Frameworks",
+      `${helperName}.app`,
+      "Contents",
+      "MacOS",
+      helperName,
+    );
+    if (!existsSync(helperExecutable)) {
+      throw new Error(
+        `Final app is missing the ASCII Electron Helper executable: ${helperExecutable}`,
+      );
+    }
+    const metadata = statSync(helperExecutable);
+    if (!metadata.isFile() || metadata.size === 0) {
+      throw new Error(
+        `Final app has an invalid Electron Helper executable: ${helperExecutable}`,
+      );
+    }
   }
 }
 
@@ -749,6 +782,7 @@ async function main() {
   }
   const appPath = apps[0];
   assertElectronFrameworkExecutable(appPath);
+  assertElectronHelperExecutables(appPath);
   verifyNativePayload(appPath);
   // Establish that electron-builder produced a valid sealed bundle before
   // running any executable from it.  The second check below proves that the
@@ -803,6 +837,7 @@ if (require.main === module) {
 
 module.exports = {
   assertElectronFrameworkExecutable,
+  assertElectronHelperExecutables,
   findAppBundles,
   findSingleAppBundle,
   listFiles,

--- a/src/main/runtime/simple-page-tar-utils.cjs
+++ b/src/main/runtime/simple-page-tar-utils.cjs
@@ -6,8 +6,47 @@ const {
   realpathSync,
 } = require("node:fs");
 const { chmod, mkdir, rm, symlink } = require("node:fs/promises");
+const { createRequire } = require("node:module");
 const path = require("node:path");
-const tar = require("tar");
+
+/**
+ * app-runtime is copied outside app.asar, so its ordinary CommonJS lookup
+ * cannot see production dependencies stored inside app.asar. Development can
+ * use the repository node_modules directly; packaged apps retry from the ASAR
+ * package root.
+ *
+ * @param {{ moduleRequire?: NodeRequire; resourcesPath?: string; createPackagedRequire?: typeof createRequire }} [options]
+ */
+function loadTarRuntime(options = {}) {
+  const moduleRequire = options.moduleRequire ?? require;
+  try {
+    return moduleRequire("tar");
+  } catch (error) {
+    const resourcesPath =
+      options.resourcesPath ??
+      /** @type {NodeJS.Process & { resourcesPath?: string }} */ (process)
+        .resourcesPath;
+    if (!isMissingDirectTarModule(error) || !resourcesPath) {
+      throw error;
+    }
+    const packagedRequire = (options.createPackagedRequire ?? createRequire)(
+      path.join(resourcesPath, "app.asar", "package.json"),
+    );
+    return packagedRequire("tar");
+  }
+}
+
+/** @param {unknown} error */
+function isMissingDirectTarModule(error) {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "MODULE_NOT_FOUND" &&
+    /Cannot find module ['"]tar['"]/.test(error.message)
+  );
+}
+
+const tar = loadTarRuntime();
 
 /** @typedef {(name: string, relativePath: string) => boolean} RuntimeEntryFilter */
 /** @typedef {{ path: string; type?: string; linkpath?: string; size?: number; mode?: number }} TarEntryInfo */
@@ -39,6 +78,7 @@ async function extractSelectedTarEntries(
     preserveOwner: false,
     strict: true,
     unlink: true,
+    /** @param {string} entryPath @param {any} entry */
     filter: (entryPath, entry) => {
       const tarEntry = /** @type {any} */ (entry);
       const entryInfo = {
@@ -100,6 +140,7 @@ async function inspectTarEntries(archivePath) {
   await tar.t({
     file: archivePath,
     strict: true,
+    /** @param {any} entry */
     onentry: (entry) => {
       entries.push({
         path: entry.path,
@@ -288,6 +329,7 @@ function normalizeStripComponents(value) {
 
 module.exports = {
   extractSelectedTarEntries,
+  loadTarRuntime,
   normalizeSafeArchivePath,
   validateSymlinkTarget,
   validateTarEntries,

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -54,10 +54,12 @@ const { configureElectronBuilderSigningEnvironment } =
   };
 const {
   assertElectronFrameworkExecutable,
+  assertElectronHelperExecutables,
   requiresOtoolAlias,
   shouldAllowHostedGuiSmokeFailure,
 } = require("../scripts/verify-mac-package.cjs") as {
   assertElectronFrameworkExecutable: (appPath: string) => void;
+  assertElectronHelperExecutables: (appPath: string) => void;
   requiresOtoolAlias: (filePath: string) => boolean;
   shouldAllowHostedGuiSmokeFailure: (
     input: {
@@ -302,6 +304,39 @@ describe("Apple Silicon Alpha packaging", () => {
     }
   });
 
+  it("requires ASCII Electron Helper bundle and executable names", () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "mgt-helper-app-"));
+    const helperSuffixes = [
+      "Helper",
+      "Helper (GPU)",
+      "Helper (Plugin)",
+      "Helper (Renderer)",
+    ];
+    try {
+      expect(() => assertElectronHelperExecutables(appRoot)).toThrow(
+        "missing the ASCII Electron Helper executable",
+      );
+
+      for (const suffix of helperSuffixes) {
+        const helperName = `CarrotMangaTranslator ${suffix}`;
+        const executableDir = join(
+          appRoot,
+          "Contents",
+          "Frameworks",
+          `${helperName}.app`,
+          "Contents",
+          "MacOS",
+        );
+        mkdirSync(executableDir, { recursive: true });
+        writeFileSync(join(executableDir, helperName), "helper");
+      }
+
+      expect(() => assertElectronHelperExecutables(appRoot)).not.toThrow();
+    } finally {
+      rmSync(appRoot, { recursive: true, force: true });
+    }
+  });
+
   it("waives only the exact fresh GitHub-hosted pre-ready Electron trap", () => {
     const environment: NodeJS.ProcessEnv = {
       MGT_MAC_ALPHA_ALLOW_HOSTED_APP_SMOKE_TRAP:
@@ -389,6 +424,11 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(config).toContain('target: "zip"');
     expect(config).toContain('arch: ["arm64"]');
     expect(config).toContain('executableName: "CarrotMangaTranslator"');
+    expect(config).toContain(
+      'const productName = isMacBuild ? "CarrotMangaTranslator" : "당근망가번역기"',
+    );
+    expect(config).toContain('CFBundleDisplayName: "당근망가번역기"');
+    expect(config).toContain('size: "3g"');
     expect(config).toContain("macExtraResources");
     expect(config).toContain("windowsExtraResources");
     expect(config).toContain("Windows binaries leaked into the macOS app");

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -52,29 +52,33 @@ const { configureElectronBuilderSigningEnvironment } =
       environment: NodeJS.ProcessEnv,
     ) => void;
   };
-const { requiresOtoolAlias, shouldAllowHostedGuiSmokeFailure } =
-  require("../scripts/verify-mac-package.cjs") as {
-    requiresOtoolAlias: (filePath: string) => boolean;
-    shouldAllowHostedGuiSmokeFailure: (
-      input: {
-        stage: "copy" | "prepare" | "verify";
-        markerExists: boolean;
-        message: string;
-        smokeStartedAtMs: number;
-        crashReport: {
-          path: string;
-          mtimeMs: number;
-          procPath: string;
-          exceptionType: string;
-          signal: string;
-          faultingThread: number;
-          triggered: boolean;
-          threadName: string;
-        } | null;
-      },
-      environment: NodeJS.ProcessEnv,
-    ) => boolean;
-  };
+const {
+  assertElectronFrameworkExecutable,
+  requiresOtoolAlias,
+  shouldAllowHostedGuiSmokeFailure,
+} = require("../scripts/verify-mac-package.cjs") as {
+  assertElectronFrameworkExecutable: (appPath: string) => void;
+  requiresOtoolAlias: (filePath: string) => boolean;
+  shouldAllowHostedGuiSmokeFailure: (
+    input: {
+      stage: "copy" | "prepare" | "verify";
+      markerExists: boolean;
+      message: string;
+      smokeStartedAtMs: number;
+      crashReport: {
+        path: string;
+        mtimeMs: number;
+        procPath: string;
+        exceptionType: string;
+        signal: string;
+        faultingThread: number;
+        triggered: boolean;
+        threadName: string;
+      } | null;
+    },
+    environment: NodeJS.ProcessEnv,
+  ) => boolean;
+};
 
 describe("Apple Silicon Alpha packaging", () => {
   it("pins Electron and every downloaded executable runtime", () => {
@@ -274,6 +278,30 @@ describe("Apple Silicon Alpha packaging", () => {
     ).toContain("process.exit(1)");
   });
 
+  it("rejects a final app whose Electron Framework executable is missing", () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "mgt-final-app-"));
+    try {
+      const frameworkRoot = join(
+        appRoot,
+        "Contents",
+        "Frameworks",
+        "Electron Framework.framework",
+        "Versions",
+        "A",
+      );
+      mkdirSync(frameworkRoot, { recursive: true });
+
+      expect(() => assertElectronFrameworkExecutable(appRoot)).toThrow(
+        "missing the Electron Framework executable",
+      );
+
+      writeFileSync(join(frameworkRoot, "Electron Framework"), "electron");
+      expect(() => assertElectronFrameworkExecutable(appRoot)).not.toThrow();
+    } finally {
+      rmSync(appRoot, { recursive: true, force: true });
+    }
+  });
+
   it("waives only the exact fresh GitHub-hosted pre-ready Electron trap", () => {
     const environment: NodeJS.ProcessEnv = {
       MGT_MAC_ALPHA_ALLOW_HOSTED_APP_SMOKE_TRAP:
@@ -379,7 +407,7 @@ describe("Apple Silicon Alpha packaging", () => {
     );
 
     expect(verifier).toContain("await verifyMacRuntimeSmokes({ appPath })");
-    expect(verifier.match(/^\s+verifySigning\(appPath\);$/gm)).toHaveLength(2);
+    expect(verifier.match(/^\s+verifySigning\(appPath\);$/gm)).toHaveLength(4);
     expect(verifier).toContain('PYTHONDONTWRITEBYTECODE: "1"');
     expect(smokes).toContain('PYTHONDONTWRITEBYTECODE: "1"');
     expect(smokes).toContain('PYTHONPYCACHEPREFIX: join(workRoot, "pycache")');
@@ -410,6 +438,13 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(verifier).toContain("contents.slice(0, 20 * 1024)");
     expect(verifier).toContain("result.signal");
     expect(verifier).toContain('"--entitlements",');
+    expect(verifier).toContain('"attach",');
+    expect(verifier).toContain('"-readonly",');
+    expect(verifier).toContain('findSingleAppBundle(mountRoot, "final DMG")');
+    expect(verifier).toContain("verifyApplicationDirectorySmoke(appPath)");
+    expect(verifier).toContain('"-x", "-k", zipPath, extractRoot');
+    expect(verifier).toContain("verifyFinalDiskImage(dmgFiles[0])");
+    expect(verifier).toContain("verifyFinalZipArchive(zipFiles[0])");
     const appSmoke = readFileSync(
       join(repoRoot, "src", "main", "macPackageSmoke.ts"),
       "utf8",

--- a/tests/packagedTarRuntime.test.ts
+++ b/tests/packagedTarRuntime.test.ts
@@ -1,0 +1,66 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const { loadTarRuntime } =
+  require("../src/main/runtime/simple-page-tar-utils.cjs") as {
+    loadTarRuntime: (options?: {
+      moduleRequire?: NodeRequire;
+      resourcesPath?: string;
+      createPackagedRequire?: typeof createRequire;
+    }) => unknown;
+  };
+
+describe("packaged tar runtime resolution", () => {
+  it("uses the ordinary dependency lookup in development", () => {
+    const directRuntime = { x: vi.fn(), t: vi.fn() };
+    const moduleRequire = vi.fn(() => directRuntime) as unknown as NodeRequire;
+    const createPackagedRequire = vi.fn();
+
+    expect(loadTarRuntime({ moduleRequire, createPackagedRequire })).toBe(
+      directRuntime,
+    );
+    expect(moduleRequire).toHaveBeenCalledWith("tar");
+    expect(createPackagedRequire).not.toHaveBeenCalled();
+  });
+
+  it("retries from app.asar when app-runtime is outside the archive", () => {
+    const missing = Object.assign(new Error("Cannot find module 'tar'"), {
+      code: "MODULE_NOT_FOUND",
+    });
+    const moduleRequire = vi.fn(() => {
+      throw missing;
+    }) as unknown as NodeRequire;
+    const packagedRuntime = { x: vi.fn(), t: vi.fn() };
+    const packagedRequire = vi.fn(
+      () => packagedRuntime,
+    ) as unknown as NodeRequire;
+    const createPackagedRequire = vi.fn(
+      () => packagedRequire,
+    ) as unknown as typeof createRequire;
+    const resourcesPath = join("Applications", "Example.app", "Resources");
+
+    expect(
+      loadTarRuntime({
+        moduleRequire,
+        resourcesPath,
+        createPackagedRequire,
+      }),
+    ).toBe(packagedRuntime);
+    expect(createPackagedRequire).toHaveBeenCalledWith(
+      join(resourcesPath, "app.asar", "package.json"),
+    );
+    expect(packagedRequire).toHaveBeenCalledWith("tar");
+  });
+
+  it("does not hide unrelated module initialization errors", () => {
+    const failure = new Error("tar initialization failed");
+    const moduleRequire = vi.fn(() => {
+      throw failure;
+    }) as unknown as NodeRequire;
+
+    expect(() =>
+      loadTarRuntime({ moduleRequire, resourcesPath: "/Applications/App" }),
+    ).toThrow(failure);
+  });
+});


### PR DESCRIPTION
## What changed

- require the Electron Framework executable to exist and be non-empty in every macOS app being verified
- keep macOS bundle/helper names ASCII while preserving the Korean Finder display name
- give dmgbuild a 3 GiB staging filesystem so the ~1.9 GiB app is copied completely before shrink/compression
- mount the final DMG read-only, verify its framework payload and deep signature, copy it to `/Applications`, and run the two-stage packaged lifecycle smoke
- extract the final ZIP and verify its framework payload, deep signature, and packaged `tar` runtime
- resolve `tar` from `app.asar` when the copied `app-runtime` executes outside the archive
- clean up mounts and temporary extraction directories on verification failure
- add regression coverage for the framework/helper requirements and packaged ASAR dependency lookup

## Why

Alpha 2's unpacked app passed package verification, but the published DMG omitted:

```text
Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework
```

The old release check only used `hdiutil verify` on the final DMG, which validates the disk image checksum without validating the app stored inside it. Separately, Korean bundle/helper paths were normalized differently and triggered Electron 43's byte-wise helper-path check before `app.whenReady()`.

The final release containers must be treated as the artifacts under test.

## User impact

Broken containers like `v1.6.3-mac-alpha.2` now fail the release job before checksums are generated or assets are published. The affected Alpha 2 release has also been marked **BROKEN / 다운로드 금지**.

Closes #41

## Validation

- latest head: `5623583567fa57d6e768507a63870cccc92a2c37`
- Windows and macOS arm64 PR checks passed
- local `npm run check` passed (183 test files; 1,160 tests passed, 2 platform skips) before the final focused runtime commit
- latest focused tests passed: 16 passed, 1 Windows-only skip
- full Apple Silicon artifact dry run: https://github.com/ucx0204/CarrotMangaTranslator/actions/runs/29737617239
  - `Build and verify arm64 DMG and ZIP`: passed
  - `Confirm release artifacts`: passed
  - verified 600 signed arm64 Mach-O files
  - mounted, signed, copied, and launched the final DMG app
  - extracted and verified the final ZIP app
  - generated `SHA256SUMS-mac-alpha.txt`
  - no hosted GUI waiver, SIGTRAP, or EXC_BREAKPOINT occurred
- the dry run's overall red status is the expected post-validation guard: release publishing is allowed only from `refs/heads/master`
- the published Alpha 2 DMG fails the new framework check with the expected diagnostic and detaches cleanly
