### PR TITLE
Add conditional RT-DETR and SAM bubble recovery

### DIFF
--- a/src/main/inpainting/bubbleMaskDetection.ts
+++ b/src/main/inpainting/bubbleMaskDetection.ts
@@ -10,6 +10,8 @@ export type BubbleMaskDetectionResult = {
   matchedBlocks: number;
   regions: number;
   splitRegions: number;
+  recoveryCandidates?: number;
+  recoveredBlocks?: number;
 };
 
 export function refinePreciseBubbleMask(

--- a/src/main/inpainting/bubbleQualityRecovery.ts
+++ b/src/main/inpainting/bubbleQualityRecovery.ts
@@ -1,0 +1,199 @@
+import type { MangaPage } from "../../shared/libraryTypes";
+import type { TranslationBlock } from "../../shared/textTypes";
+import {
+  bboxToPixels,
+  clamp,
+  normalizeBboxTo1000,
+} from "../../shared/geometry";
+import type { PixelRect } from "./maskGeometry";
+
+export type BubbleRecoveryHint = {
+  blockId: string;
+  rect: PixelRect;
+};
+
+export type BubbleRecoveryMergeResult = {
+  mask: Uint8Array;
+  recoveredBlocks: number;
+};
+
+const MINIMUM_MASK_COVERAGE = 0.45;
+const MINIMUM_BUBBLE_WIDTH_RATIO = 1.35;
+const MINIMUM_BUBBLE_HEIGHT_RATIO = 1.12;
+
+export function findBubbleRecoveryHints(
+  page: MangaPage,
+  bubbleMask: Uint8Array,
+): BubbleRecoveryHint[] {
+  const candidates = page.blocks.filter(isBubbleRecoveryCandidate);
+  if (bubbleMask.length !== page.width * page.height) {
+    return candidates.map((block) => toRecoveryHint(block, page));
+  }
+  return candidates.flatMap((block) => {
+    const hint = toRecoveryHint(block, page);
+    return maskNeedsRecovery(bubbleMask, page, hint.rect) ? [hint] : [];
+  });
+}
+
+export function mergeRecoveredBubbleMask(
+  baseMask: Uint8Array,
+  recoveredMask: Uint8Array,
+  page: Pick<MangaPage, "width" | "height">,
+  hints: BubbleRecoveryHint[],
+): BubbleRecoveryMergeResult {
+  if (
+    baseMask.length !== page.width * page.height ||
+    recoveredMask.length !== baseMask.length
+  ) {
+    return { mask: baseMask, recoveredBlocks: 0 };
+  }
+  const mask = baseMask.slice();
+  let nextId = Math.min(255, maximumMaskId(mask) + 1);
+  let recoveredBlocks = 0;
+  for (const [hintIndex, hint] of hints.entries()) {
+    const recoveryId = hintIndex + 1;
+    const recoveredPixels = countMaskId(recoveredMask, recoveryId);
+    const minimumPixels = Math.max(
+      16,
+      Math.round(hint.rect.w * hint.rect.h * 0.5),
+    );
+    if (recoveredPixels < minimumPixels) continue;
+    const replacedId = dominantMaskId(mask, page.width, hint.rect);
+    if (replacedId) clearMaskId(mask, replacedId);
+    for (let index = 0; index < mask.length; index += 1) {
+      if (recoveredMask[index] === recoveryId && !mask[index]) {
+        mask[index] = nextId;
+      }
+    }
+    nextId = Math.min(255, nextId + 1);
+    recoveredBlocks += 1;
+  }
+  return { mask, recoveredBlocks };
+}
+
+function isBubbleRecoveryCandidate(block: TranslationBlock): boolean {
+  return (
+    !block.inpaintExcluded &&
+    block.bbox.w > 0 &&
+    block.bbox.h > 0 &&
+    Number.isFinite(block.bbox.x) &&
+    Number.isFinite(block.bbox.y)
+  );
+}
+
+function toRecoveryHint(
+  block: TranslationBlock,
+  page: MangaPage,
+): BubbleRecoveryHint {
+  const normalized = normalizeBboxTo1000(
+    block.bbox,
+    { width: page.width, height: page.height },
+    block.bboxSpace,
+  );
+  const pixels = bboxToPixels(normalized, page.width, page.height);
+  const x = clamp(Math.floor(pixels.x), 0, Math.max(0, page.width - 1));
+  const y = clamp(Math.floor(pixels.y), 0, Math.max(0, page.height - 1));
+  const right = clamp(Math.ceil(pixels.x + pixels.w), x + 1, page.width);
+  const bottom = clamp(Math.ceil(pixels.y + pixels.h), y + 1, page.height);
+  return {
+    blockId: block.id,
+    rect: { x, y, w: right - x, h: bottom - y },
+  };
+}
+
+function maskNeedsRecovery(
+  mask: Uint8Array,
+  page: Pick<MangaPage, "width" | "height">,
+  rect: PixelRect,
+): boolean {
+  const bubbleId = dominantMaskId(mask, page.width, rect);
+  if (!bubbleId) return true;
+  const coverage =
+    countMaskIdInRect(mask, page.width, rect, bubbleId) /
+    Math.max(1, rect.w * rect.h);
+  if (coverage < MINIMUM_MASK_COVERAGE) return true;
+  const bounds = findMaskIdBounds(mask, page.width, page.height, bubbleId);
+  if (!bounds) return true;
+  return (
+    bounds.w < rect.w * MINIMUM_BUBBLE_WIDTH_RATIO ||
+    bounds.h < rect.h * MINIMUM_BUBBLE_HEIGHT_RATIO
+  );
+}
+
+function dominantMaskId(
+  mask: Uint8Array,
+  width: number,
+  rect: PixelRect,
+): number {
+  const counts = new Uint32Array(256);
+  for (let y = rect.y; y < rect.y + rect.h; y += 1) {
+    for (let x = rect.x; x < rect.x + rect.w; x += 1) {
+      const id = mask[y * width + x] ?? 0;
+      if (id) counts[id] += 1;
+    }
+  }
+  let best = 0;
+  for (let id = 1; id < counts.length; id += 1) {
+    if (counts[id] > counts[best]) best = id;
+  }
+  return best;
+}
+
+function countMaskIdInRect(
+  mask: Uint8Array,
+  width: number,
+  rect: PixelRect,
+  id: number,
+): number {
+  let count = 0;
+  for (let y = rect.y; y < rect.y + rect.h; y += 1) {
+    for (let x = rect.x; x < rect.x + rect.w; x += 1) {
+      if (mask[y * width + x] === id) count += 1;
+    }
+  }
+  return count;
+}
+
+function findMaskIdBounds(
+  mask: Uint8Array,
+  width: number,
+  height: number,
+  id: number,
+): PixelRect | null {
+  let left = width;
+  let top = height;
+  let right = -1;
+  let bottom = -1;
+  for (let index = 0; index < mask.length; index += 1) {
+    if (mask[index] !== id) continue;
+    const x = index % width;
+    const y = Math.floor(index / width);
+    left = Math.min(left, x);
+    top = Math.min(top, y);
+    right = Math.max(right, x);
+    bottom = Math.max(bottom, y);
+  }
+  return right >= left && bottom >= top
+    ? { x: left, y: top, w: right - left + 1, h: bottom - top + 1 }
+    : null;
+}
+
+function countMaskId(mask: Uint8Array, id: number): number {
+  let count = 0;
+  for (const value of mask) {
+    if (value === id) count += 1;
+  }
+  return count;
+}
+
+function maximumMaskId(mask: Uint8Array): number {
+  let maximum = 0;
+  for (const value of mask) maximum = Math.max(maximum, value);
+  return maximum;
+}
+
+function clearMaskId(mask: Uint8Array, id: number): void {
+  for (let index = 0; index < mask.length; index += 1) {
+    if (mask[index] === id) mask[index] = 0;
+  }
+}

--- a/src/main/inpainting/bubbleQualityRecovery.ts
+++ b/src/main/inpainting/bubbleQualityRecovery.ts
@@ -1,10 +1,5 @@
 import type { MangaPage } from "../../shared/libraryTypes";
 import type { TranslationBlock } from "../../shared/textTypes";
-import {
-  bboxToPixels,
-  clamp,
-  normalizeBboxTo1000,
-} from "../../shared/geometry";
 import type { PixelRect } from "./maskGeometry";
 
 export type BubbleRecoveryHint = {
@@ -85,20 +80,28 @@ function toRecoveryHint(
   block: TranslationBlock,
   page: MangaPage,
 ): BubbleRecoveryHint {
-  const normalized = normalizeBboxTo1000(
-    block.bbox,
-    { width: page.width, height: page.height },
-    block.bboxSpace,
+  const scaleX = block.bboxSpace === "pixels" ? 1 : page.width / 1000;
+  const scaleY = block.bboxSpace === "pixels" ? 1 : page.height / 1000;
+  const pixelX = block.bbox.x * scaleX;
+  const pixelY = block.bbox.y * scaleY;
+  const pixelWidth = block.bbox.w * scaleX;
+  const pixelHeight = block.bbox.h * scaleY;
+  const x = clampValue(Math.floor(pixelX), 0, Math.max(0, page.width - 1));
+  const y = clampValue(Math.floor(pixelY), 0, Math.max(0, page.height - 1));
+  const right = clampValue(Math.ceil(pixelX + pixelWidth), x + 1, page.width);
+  const bottom = clampValue(
+    Math.ceil(pixelY + pixelHeight),
+    y + 1,
+    page.height,
   );
-  const pixels = bboxToPixels(normalized, page.width, page.height);
-  const x = clamp(Math.floor(pixels.x), 0, Math.max(0, page.width - 1));
-  const y = clamp(Math.floor(pixels.y), 0, Math.max(0, page.height - 1));
-  const right = clamp(Math.ceil(pixels.x + pixels.w), x + 1, page.width);
-  const bottom = clamp(Math.ceil(pixels.y + pixels.h), y + 1, page.height);
   return {
     blockId: block.id,
     rect: { x, y, w: right - x, h: bottom - y },
   };
+}
+
+function clampValue(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
 }
 
 function maskNeedsRecovery(

--- a/src/main/inpainting/bubbleQualityRefiner.ts
+++ b/src/main/inpainting/bubbleQualityRefiner.ts
@@ -1,0 +1,23 @@
+import type { BubbleRecoveryHint } from "./bubbleQualityRecovery";
+
+export type BubbleQualityRefiner = {
+  backend: string;
+  model: "sam2.1" | "sam3";
+  refine: (
+    bitmap: Buffer,
+    width: number,
+    height: number,
+    hints: BubbleRecoveryHint[],
+    options?: { signal?: AbortSignal },
+  ) => Promise<Uint8Array>;
+};
+
+export type BubbleQualityRefinerLease = {
+  refiner: BubbleQualityRefiner;
+  release: () => void;
+};
+
+export type BubbleQualityRefinerEngine = BubbleQualityRefiner & {
+  dispose: () => Promise<void>;
+  isHealthy: () => boolean;
+};

--- a/src/main/inpainting/bubbleQualityRefinerEngine.ts
+++ b/src/main/inpainting/bubbleQualityRefinerEngine.ts
@@ -1,0 +1,49 @@
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { safeCleanup } from "../safeCleanup";
+import { readGeneratedBitmap, writePngFromBitmap } from "./imageRaster";
+import type { BubbleQualityRefinerEngine } from "./bubbleQualityRefiner";
+import type { BubbleQualityWorkerLaunch } from "./bubbleQualityRuntime";
+import { BubbleQualityWorker } from "./bubbleQualityWorker";
+
+export function createBubbleQualityRefinerEngine(options: {
+  launch: BubbleQualityWorkerLaunch;
+  runRootDir: string;
+}): BubbleQualityRefinerEngine {
+  const worker = new BubbleQualityWorker(options.launch);
+  return {
+    backend: options.launch.backend,
+    model: options.launch.model,
+    isHealthy: () => worker.isHealthy(),
+    async refine(bitmap, width, height, hints, runOptions = {}) {
+      const runDir = join(
+        options.runRootDir,
+        `quality-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+      );
+      await mkdir(runDir, { recursive: true });
+      try {
+        const inputPath = join(runDir, "input.png");
+        const outputPath = join(runDir, "recovered-mask.png");
+        await writePngFromBitmap(inputPath, bitmap, width, height, {
+          width,
+          height,
+        });
+        await worker.refine(
+          { input: inputPath, output: outputPath, hints: hints.slice(0, 254) },
+          runOptions.signal,
+        );
+        const generated = await readGeneratedBitmap(outputPath, width, height);
+        const mask = new Uint8Array(width * height);
+        for (let index = 0; index < mask.length; index += 1) {
+          mask[index] = generated[index * 4] ?? 0;
+        }
+        return mask;
+      } finally {
+        await safeCleanup("remove bubble quality run directory", () =>
+          rm(runDir, { recursive: true, force: true }),
+        );
+      }
+    },
+    dispose: () => worker.dispose(),
+  };
+}

--- a/src/main/inpainting/bubbleQualityRefinerPool.ts
+++ b/src/main/inpainting/bubbleQualityRefinerPool.ts
@@ -1,0 +1,81 @@
+import { join } from "node:path";
+import type { KoharuInpaintingBackend } from "../../shared/inpaintingSettingsTypes";
+import type { AppPaths } from "../appPaths";
+import { createBubbleQualityRefinerEngine } from "./bubbleQualityRefinerEngine";
+import type {
+  BubbleQualityRefinerEngine,
+  BubbleQualityRefinerLease,
+} from "./bubbleQualityRefiner";
+import {
+  ensureBubbleQualityWorkerLaunch,
+  type BubbleQualityModel,
+} from "./bubbleQualityRuntime";
+import type { InpaintingRuntimeProgress } from "./inpaintingEngine";
+import { logInpaintingRuntimeInfo } from "./inpaintingRuntimeLogger";
+import { LeasedIdleResourcePool } from "./leasedIdleResource";
+
+const QUALITY_REFINER_IDLE_TTL_MS = 30 * 1000;
+
+const refinerPool = new LeasedIdleResourcePool<BubbleQualityRefinerEngine>({
+  idleTtlMs: QUALITY_REFINER_IDLE_TTL_MS,
+  isReusable: (refiner) => refiner.isHealthy(),
+  dispose: async (refiner, reason) => {
+    await refiner.dispose();
+    logInpaintingRuntimeInfo("Bubble quality refiner disposed", { reason });
+  },
+});
+
+export async function acquireBubbleQualityRefiner(options: {
+  appPaths: AppPaths;
+  backend: Exclude<KoharuInpaintingBackend, "auto">;
+  requestedModel: BubbleQualityModel;
+  signal?: AbortSignal;
+  onProgress?: (progress: InpaintingRuntimeProgress) => void;
+}): Promise<BubbleQualityRefinerLease> {
+  const key = [
+    options.backend,
+    options.requestedModel,
+    options.appPaths.dataRoot,
+  ].join("\n");
+  const lease = await refinerPool.acquire(key, async () => {
+    const launch = await ensureBubbleQualityWorkerLaunch({
+      backend: options.backend,
+      dataRoot: options.appPaths.dataRoot,
+      requestedModel: options.requestedModel,
+      signal: options.signal,
+      onProgress: options.onProgress,
+    });
+    const engine = createBubbleQualityRefinerEngine({
+      launch,
+      runRootDir: join(
+        options.appPaths.dataRoot,
+        "tmp",
+        "runtime",
+        "bubble-quality",
+      ),
+    });
+    try {
+      await smokeTest(engine, options.signal);
+      return engine;
+    } catch (error) {
+      await engine.dispose();
+      throw error;
+    }
+  });
+  return { refiner: lease.resource, release: lease.release };
+}
+
+async function smokeTest(
+  refiner: BubbleQualityRefinerEngine,
+  signal?: AbortSignal,
+): Promise<void> {
+  const width = 64;
+  const height = 64;
+  await refiner.refine(
+    Buffer.alloc(width * height * 4, 255),
+    width,
+    height,
+    [{ blockId: "smoke", rect: { x: 24, y: 20, w: 16, h: 24 } }],
+    { signal },
+  );
+}

--- a/src/main/inpainting/bubbleQualityRuntime.ts
+++ b/src/main/inpainting/bubbleQualityRuntime.ts
@@ -1,0 +1,360 @@
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { delimiter, isAbsolute, join } from "node:path";
+import type { KoharuInpaintingBackend } from "../../shared/inpaintingSettingsTypes";
+import type { InpaintingRuntimeProgress } from "./inpaintingEngine";
+import { runCommand } from "./fluxAssets/errors";
+import { sha256FileSync } from "./fluxAssets/fileProbe";
+import {
+  ensureEmbeddedPythonPackagePath,
+  findPythonCommand,
+} from "./fluxAssets/pythonBootstrap";
+import type { PythonCommand } from "./fluxAssets/types";
+
+export type BubbleQualityModel = "sam2.1" | "sam3";
+
+export type BubbleQualityWorkerLaunch = {
+  args: string[];
+  backend: string;
+  env: NodeJS.ProcessEnv;
+  executable: string;
+  model: BubbleQualityModel;
+};
+
+const WORKER_FILE = "bubble-quality-worker.py";
+const RTDETR_MODEL = {
+  repo: "ogkalu/comic-text-and-bubble-detector",
+  revision: "16e8a622f91fabc6b5b65c96d32d1183f8843546",
+  files: ["config.json", "preprocessor_config.json", "model.safetensors"],
+};
+const SAM2_MODEL = {
+  repo: "facebook/sam2.1-hiera-large",
+  revision: "665f8e2ad61cf5f53d65644ff27c8ee525124610",
+  files: [
+    "config.json",
+    "model.safetensors",
+    "preprocessor_config.json",
+    "processor_config.json",
+  ],
+};
+const SAM3_MODEL = {
+  repo: "facebook/sam3",
+  revision: "3c879f39826c281e95690f02c7821c4de09afae7",
+  files: [
+    "config.json",
+    "merges.txt",
+    "model.safetensors",
+    "processor_config.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json",
+  ],
+};
+
+export async function ensureBubbleQualityWorkerLaunch(options: {
+  backend: Exclude<KoharuInpaintingBackend, "auto">;
+  dataRoot: string;
+  requestedModel: BubbleQualityModel;
+  signal?: AbortSignal;
+  onProgress?: (progress: InpaintingRuntimeProgress) => void;
+}): Promise<BubbleQualityWorkerLaunch> {
+  const model = resolveAvailableBubbleQualityModel(
+    options.requestedModel,
+    options.backend,
+  );
+  const runtimeDir = join(options.dataRoot, "runtime", "bubble-quality");
+  const packageDir = join(runtimeDir, "python-packages");
+  const workerPath = join(runtimeDir, WORKER_FILE);
+  const modelsDir = join(options.dataRoot, "models", "bubble-quality");
+  await mkdir(runtimeDir, { recursive: true });
+  const workerSource = resolveWorkerSource();
+  await copyFile(workerSource, workerPath);
+  const python = await findPythonCommand({
+    runtimeDir,
+    runtimeLabel: "말풍선 최고 품질",
+    signal: options.signal,
+    onProgress: options.onProgress,
+  });
+  const device = resolveBubbleQualityTorchDevice(options.backend);
+  const env = buildRuntimeEnv(packageDir, modelsDir);
+  if (isAbsolute(python.command) && python.args.length === 0) {
+    ensureEmbeddedPythonPackagePath(python.command, packageDir);
+  }
+  await ensurePythonPackages({
+    device,
+    env,
+    packageDir,
+    python,
+    runtimeDir,
+    signal: options.signal,
+    workerSource,
+    onProgress: options.onProgress,
+  });
+  const rtdetrDir = await ensureModelSnapshot({
+    env,
+    label: "RT-DETR 말풍선 복구 모델",
+    model: RTDETR_MODEL,
+    modelDir: join(modelsDir, "rtdetr"),
+    onProgress: options.onProgress,
+    python,
+    signal: options.signal,
+  });
+  const samSpec = model === "sam3" ? SAM3_MODEL : SAM2_MODEL;
+  const samDir = await ensureModelSnapshot({
+    env,
+    label: model === "sam3" ? "SAM 3 실험 모델" : "SAM 2.1 경계 보정 모델",
+    model: samSpec,
+    modelDir: join(modelsDir, model === "sam3" ? "sam3" : "sam2.1"),
+    onProgress: options.onProgress,
+    python,
+    signal: options.signal,
+  });
+  return {
+    args: [
+      ...python.args,
+      "-u",
+      workerPath,
+      "--rtdetr-model-dir",
+      rtdetrDir,
+      "--sam-model-dir",
+      samDir,
+      "--sam-model",
+      model,
+      "--device",
+      device,
+    ],
+    backend: options.backend,
+    env,
+    executable: python.command,
+    model,
+  };
+}
+
+export function resolveAvailableBubbleQualityModel(
+  requested: BubbleQualityModel,
+  backend: Exclude<KoharuInpaintingBackend, "auto">,
+): BubbleQualityModel {
+  if (
+    requested === "sam3" &&
+    backend === "cuda-native" &&
+    Boolean(process.env.HF_TOKEN?.trim())
+  ) {
+    return "sam3";
+  }
+  return "sam2.1";
+}
+
+export function resolveBubbleQualityTorchDevice(
+  backend: Exclude<KoharuInpaintingBackend, "auto">,
+): "cpu" | "cuda" | "mps" {
+  if (backend === "cuda-native") return "cuda";
+  if (backend === "metal-native") return "mps";
+  return "cpu";
+}
+
+function resolveWorkerSource(): string {
+  const candidates = [
+    process.resourcesPath
+      ? join(process.resourcesPath, "app-runtime", WORKER_FILE)
+      : "",
+    join(process.cwd(), "out", "app-runtime", WORKER_FILE),
+    join(process.cwd(), "src", "main", "runtime", WORKER_FILE),
+  ];
+  const source = candidates.find(
+    (candidate) => candidate && existsSync(candidate),
+  );
+  if (!source) {
+    throw new Error(`${WORKER_FILE}를 찾지 못했습니다.`);
+  }
+  return source;
+}
+
+async function ensurePythonPackages(options: {
+  device: "cpu" | "cuda" | "mps";
+  env: NodeJS.ProcessEnv;
+  packageDir: string;
+  python: PythonCommand;
+  runtimeDir: string;
+  signal?: AbortSignal;
+  workerSource: string;
+  onProgress?: (progress: InpaintingRuntimeProgress) => void;
+}): Promise<void> {
+  const markerPath = join(options.runtimeDir, ".bubble-quality-runtime.json");
+  const signature = {
+    pythonPackages: [
+      "numpy>=1.26,<3",
+      "pillow>=11,<13",
+      "safetensors>=0.6,<1",
+      "huggingface_hub>=0.36,<2",
+      "transformers>=5.0,<6",
+    ],
+    torchDevice: options.device,
+    workerHash: sha256FileSync(options.workerSource),
+  };
+  if (await isCurrentRuntime(markerPath, options.packageDir, signature)) return;
+  await rm(options.packageDir, { recursive: true, force: true });
+  await mkdir(options.packageDir, { recursive: true });
+  options.onProgress?.({
+    progressText: "말풍선 최고 품질 런타임 설치 중",
+    detail: options.device.toUpperCase(),
+    progressMode: "indeterminate",
+    installLogLine: "RT-DETR 및 SAM용 Python 패키지를 자동 설치합니다.",
+  });
+  const torchArgs =
+    options.device === "cpu" && process.platform !== "darwin"
+      ? [
+          "--index-url",
+          "https://download.pytorch.org/whl/cpu",
+          "torch",
+          "torchvision",
+        ]
+      : ["torch", "torchvision"];
+  await installTargetPackages(options, torchArgs);
+  await installTargetPackages(options, signature.pythonPackages);
+  await writeFile(
+    markerPath,
+    `${JSON.stringify(signature, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function installTargetPackages(
+  options: {
+    env: NodeJS.ProcessEnv;
+    packageDir: string;
+    python: PythonCommand;
+    signal?: AbortSignal;
+    onProgress?: (progress: InpaintingRuntimeProgress) => void;
+  },
+  packages: string[],
+): Promise<void> {
+  await runCommand(
+    options.python.command,
+    [
+      ...options.python.args,
+      "-m",
+      "pip",
+      "install",
+      "--target",
+      options.packageDir,
+      ...packages,
+    ],
+    {
+      signal: options.signal,
+      env: options.env,
+      onLine: (line) =>
+        options.onProgress?.({
+          progressText: "말풍선 최고 품질 런타임 설치 중",
+          detail: "RT-DETR + SAM",
+          progressMode: "indeterminate",
+          installLogLine: line,
+        }),
+    },
+  );
+}
+
+async function isCurrentRuntime(
+  markerPath: string,
+  packageDir: string,
+  signature: object,
+): Promise<boolean> {
+  try {
+    const marker = JSON.parse(await readFile(markerPath, "utf8"));
+    return (
+      JSON.stringify(marker) === JSON.stringify(signature) &&
+      ["torch", "transformers", "PIL", "numpy"].every((name) =>
+        existsSync(join(packageDir, name)),
+      )
+    );
+  } catch (_error) {
+    return false;
+  }
+}
+
+async function ensureModelSnapshot(options: {
+  env: NodeJS.ProcessEnv;
+  label: string;
+  model: { repo: string; revision: string; files: string[] };
+  modelDir: string;
+  onProgress?: (progress: InpaintingRuntimeProgress) => void;
+  python: PythonCommand;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const markerPath = join(options.modelDir, ".snapshot.json");
+  const signature = {
+    repo: options.model.repo,
+    revision: options.model.revision,
+    files: options.model.files,
+  };
+  try {
+    const marker = JSON.parse(await readFile(markerPath, "utf8"));
+    if (
+      JSON.stringify(marker) === JSON.stringify(signature) &&
+      options.model.files.every((file) =>
+        existsSync(join(options.modelDir, file)),
+      )
+    ) {
+      return options.modelDir;
+    }
+  } catch (_error) {
+    // Prepare or repair the pinned snapshot below.
+  }
+  await mkdir(options.modelDir, { recursive: true });
+  options.onProgress?.({
+    progressText: `${options.label} 다운로드 중`,
+    detail: options.model.repo,
+    progressMode: "indeterminate",
+    installLogLine: `${options.model.repo}@${options.model.revision.slice(0, 12)} 버전을 준비합니다.`,
+  });
+  const script = [
+    "from huggingface_hub import snapshot_download",
+    "import json, sys",
+    "snapshot_download(repo_id=sys.argv[1], revision=sys.argv[2], local_dir=sys.argv[3], allow_patterns=json.loads(sys.argv[4]), token=None)",
+  ].join("\n");
+  await runCommand(
+    options.python.command,
+    [
+      ...options.python.args,
+      "-c",
+      script,
+      options.model.repo,
+      options.model.revision,
+      options.modelDir,
+      JSON.stringify(options.model.files),
+    ],
+    {
+      signal: options.signal,
+      env: options.env,
+      onLine: (line) =>
+        options.onProgress?.({
+          progressText: `${options.label} 다운로드 중`,
+          detail: options.model.repo,
+          progressMode: "indeterminate",
+          installLogLine: line,
+        }),
+    },
+  );
+  await writeFile(
+    markerPath,
+    `${JSON.stringify(signature, null, 2)}\n`,
+    "utf8",
+  );
+  return options.modelDir;
+}
+
+function buildRuntimeEnv(
+  packageDir: string,
+  modelsDir: string,
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PYTHONPATH: [packageDir, process.env.PYTHONPATH]
+      .filter(Boolean)
+      .join(delimiter),
+    HF_HOME: modelsDir,
+    HUGGINGFACE_HUB_CACHE: join(modelsDir, "hub"),
+    HF_HUB_DISABLE_SYMLINKS_WARNING: "1",
+    HF_HUB_DISABLE_PROGRESS_BARS: "1",
+  };
+}

--- a/src/main/inpainting/bubbleQualityRuntime.ts
+++ b/src/main/inpainting/bubbleQualityRuntime.ts
@@ -298,7 +298,7 @@ async function ensureModelSnapshot(options: {
       return options.modelDir;
     }
   } catch (_error) {
-    // Prepare or repair the pinned snapshot below.
+    // error-policy-allow: A missing or stale marker is repaired from the pinned snapshot below.
   }
   await mkdir(options.modelDir, { recursive: true });
   options.onProgress?.({

--- a/src/main/inpainting/bubbleQualityWorker.ts
+++ b/src/main/inpainting/bubbleQualityWorker.ts
@@ -1,0 +1,213 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { once } from "node:events";
+import { basename, delimiter, dirname } from "node:path";
+import type { BubbleRecoveryHint } from "./bubbleQualityRecovery";
+import type { BubbleQualityWorkerLaunch } from "./bubbleQualityRuntime";
+import {
+  logInpaintingRuntimeInfo,
+  logInpaintingRuntimeWarn,
+} from "./inpaintingRuntimeLogger";
+
+type PendingRequest = {
+  reject: (error: Error) => void;
+  resolve: () => void;
+};
+
+type WorkerResponse = {
+  elapsed_ms?: unknown;
+  error?: string;
+  id?: string;
+  matched?: unknown;
+  ok?: boolean;
+};
+
+export class BubbleQualityWorker {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly stderrTail: string[] = [];
+  private closed = false;
+  private nextId = 1;
+  private stdoutBuffer = "";
+
+  constructor(private readonly launch: BubbleQualityWorkerLaunch) {
+    this.child = spawn(launch.executable, launch.args, {
+      windowsHide: true,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: buildWorkerEnv(launch),
+    });
+    this.child.stdout.on("data", (chunk: Buffer) => this.handleStdout(chunk));
+    this.child.stderr.on("data", (chunk: Buffer) =>
+      this.rememberStderr(chunk.toString("utf8")),
+    );
+    this.child.on("error", (error) => this.rejectAll(error));
+    this.child.on("exit", (code) => {
+      this.closed = true;
+      this.rejectAll(
+        new Error(
+          `말풍선 최고 품질 런타임이 종료되었습니다 (${code}). ${this.runtimeDetail()}`,
+        ),
+      );
+    });
+    logInpaintingRuntimeInfo("Bubble quality worker starting", {
+      backend: launch.backend,
+      model: launch.model,
+      pid: this.child.pid ?? null,
+    });
+  }
+
+  async refine(
+    request: { input: string; output: string; hints: BubbleRecoveryHint[] },
+    signal?: AbortSignal,
+  ): Promise<void> {
+    throwIfAborted(signal);
+    if (this.closed || !this.child.stdin.writable) {
+      throw new Error(
+        `말풍선 최고 품질 런타임이 실행 중이 아닙니다. ${this.runtimeDetail()}`,
+      );
+    }
+    const id = String(this.nextId++);
+    const payload = JSON.stringify({
+      type: "refine",
+      id,
+      input: request.input,
+      output: request.output,
+      hints: request.hints.map(({ rect }) => rect),
+    });
+    logInpaintingRuntimeInfo("Conditional bubble recovery request started", {
+      backend: this.launch.backend,
+      model: this.launch.model,
+      hints: request.hints.length,
+      inputFile: basename(request.input),
+    });
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        this.pending.delete(id);
+        this.closed = true;
+        this.child.kill("SIGTERM");
+        const error = new DOMException("Aborted", "AbortError") as Error;
+        this.rejectAll(error);
+        reject(error);
+      };
+      const finish = (error?: Error) => {
+        signal?.removeEventListener("abort", onAbort);
+        if (error) reject(error);
+        else resolve();
+      };
+      this.pending.set(id, {
+        reject: finish,
+        resolve: () => finish(),
+      });
+      signal?.addEventListener("abort", onAbort, { once: true });
+      this.child.stdin.write(`${payload}\n`, "utf8", (error) => {
+        if (!error) return;
+        this.pending.delete(id);
+        finish(error);
+      });
+    });
+  }
+
+  isHealthy(): boolean {
+    return (
+      !this.closed &&
+      this.child.exitCode === null &&
+      this.child.signalCode === null &&
+      this.child.stdin.writable
+    );
+  }
+
+  async dispose(): Promise<void> {
+    if (this.closed) return;
+    try {
+      this.child.stdin.write(`${JSON.stringify({ type: "shutdown" })}\n`);
+      this.child.stdin.end();
+      await Promise.race([
+        once(this.child, "exit"),
+        new Promise((resolve) => setTimeout(resolve, 1500)),
+      ]);
+    } finally {
+      if (!this.closed) this.child.kill("SIGTERM");
+      this.closed = true;
+    }
+  }
+
+  private handleStdout(chunk: Buffer): void {
+    this.stdoutBuffer += chunk.toString("utf8");
+    while (true) {
+      const newlineIndex = this.stdoutBuffer.indexOf("\n");
+      if (newlineIndex < 0) return;
+      const line = this.stdoutBuffer.slice(0, newlineIndex).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line) this.handleResponseLine(line);
+    }
+  }
+
+  private handleResponseLine(line: string): void {
+    let response: WorkerResponse;
+    try {
+      response = JSON.parse(line) as WorkerResponse;
+    } catch (_error) {
+      this.rememberStderr(`Unexpected quality worker stdout: ${line}\n`);
+      return;
+    }
+    const pending = response.id ? this.pending.get(response.id) : undefined;
+    if (!pending || !response.id) return;
+    this.pending.delete(response.id);
+    if (response.ok) {
+      logInpaintingRuntimeInfo("Conditional bubble recovery completed", {
+        backend: this.launch.backend,
+        model: this.launch.model,
+        matched: Number(response.matched) || 0,
+        elapsedMs: Number(response.elapsed_ms) || undefined,
+      });
+      pending.resolve();
+      return;
+    }
+    const message = response.error ?? "알 수 없는 오류";
+    logInpaintingRuntimeWarn("Conditional bubble recovery failed", {
+      backend: this.launch.backend,
+      model: this.launch.model,
+      error: message,
+    });
+    pending.reject(
+      new Error(
+        `RT-DETR + SAM 말풍선 복구 실패: ${message} ${this.runtimeDetail()}`,
+      ),
+    );
+  }
+
+  private rememberStderr(text: string): void {
+    this.stderrTail.push(text);
+    if (this.stderrTail.length > 80) {
+      this.stderrTail.splice(0, this.stderrTail.length - 80);
+    }
+  }
+
+  private runtimeDetail(): string {
+    const detail = this.stderrTail
+      .join("")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(-1600);
+    return detail ? `detail=${detail}` : "";
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}
+
+function buildWorkerEnv(launch: BubbleQualityWorkerLaunch): NodeJS.ProcessEnv {
+  return {
+    ...launch.env,
+    PATH: [launch.env.PATH, dirname(launch.executable), process.env.PATH]
+      .filter(Boolean)
+      .join(delimiter),
+    PYTHONIOENCODING: "utf-8",
+    PYTHONUNBUFFERED: "1",
+  };
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+}

--- a/src/main/inpainting/bubbleRenderLayout.ts
+++ b/src/main/inpainting/bubbleRenderLayout.ts
@@ -1,0 +1,282 @@
+import {
+  bboxToPixels,
+  clamp,
+  normalizeBboxTo1000,
+  pixelsToBbox,
+} from "../../shared/geometry";
+import type { MangaPage } from "../../shared/libraryTypes";
+import type { TranslationBlock } from "../../shared/textTypes";
+import {
+  buildBubbleConstraintMask,
+  resolveBubbleIdForRect,
+} from "./bubbleMaskDetection";
+import type { PixelRect } from "./maskGeometry";
+
+export type BubbleRenderLayoutResult = {
+  blocks: TranslationBlock[];
+  expandedBlocks: number;
+};
+
+export function applyBubbleRenderLayouts(
+  page: MangaPage,
+  bubbleMask: Uint8Array,
+): BubbleRenderLayoutResult {
+  if (bubbleMask.length !== page.width * page.height) {
+    return { blocks: page.blocks, expandedBlocks: 0 };
+  }
+  let expandedBlocks = 0;
+  const blocks = page.blocks.map((block) => {
+    const renderBbox = resolveAutomaticRenderBbox(page, block, bubbleMask);
+    if (!renderBbox) return block;
+    expandedBlocks += 1;
+    return {
+      ...block,
+      renderBbox,
+      renderBboxSpace: "normalized_1000" as const,
+      autoFitText: true,
+    };
+  });
+  return { blocks, expandedBlocks };
+}
+
+export function resolveAutomaticRenderBbox(
+  page: MangaPage,
+  block: TranslationBlock,
+  bubbleMask: Uint8Array,
+): TranslationBlock["renderBbox"] | null {
+  if (!isEligibleForAutomaticLayout(block)) return null;
+  const sourceRect = resolveSourcePixelRect(page, block);
+  const bubbleId = resolveBubbleIdForRect(bubbleMask, page.width, sourceRect);
+  if (!bubbleId) return null;
+  const bubbleBounds = findBubbleBounds(
+    bubbleMask,
+    page.width,
+    page.height,
+    bubbleId,
+  );
+  if (!bubbleBounds) return null;
+  const erosionRadius = clamp(
+    Math.round(Math.min(bubbleBounds.w, bubbleBounds.h) * 0.025),
+    3,
+    10,
+  );
+  const safeMask = buildBubbleConstraintMask(
+    bubbleMask,
+    page.width,
+    page.height,
+    bubbleBounds,
+    bubbleId,
+    erosionRadius,
+  );
+  const anchor = findNearestSafePixel(safeMask, bubbleBounds, sourceRect);
+  if (!anchor) return null;
+  const candidate = findBestAnchoredRectangle(
+    safeMask,
+    bubbleBounds.w,
+    bubbleBounds.h,
+    anchor,
+    block.fontSizePx,
+  );
+  if (!candidate) return null;
+  const padded = insetLayoutRect(
+    {
+      x: bubbleBounds.x + candidate.x,
+      y: bubbleBounds.y + candidate.y,
+      w: candidate.w,
+      h: candidate.h,
+    },
+    block.fontSizePx,
+  );
+  if (!hasUsefulHorizontalGrowth(sourceRect, padded, block.fontSizePx)) {
+    return null;
+  }
+  return pixelsToBbox(padded, page.width, page.height);
+}
+
+function isEligibleForAutomaticLayout(block: TranslationBlock): boolean {
+  return (
+    !block.renderBbox &&
+    !block.inpaintExcluded &&
+    block.renderDirection === "horizontal" &&
+    Boolean(block.translatedText.trim()) &&
+    block.bbox.w > 0 &&
+    block.bbox.h > 0
+  );
+}
+
+function resolveSourcePixelRect(
+  page: MangaPage,
+  block: TranslationBlock,
+): PixelRect {
+  const normalized = normalizeBboxTo1000(
+    block.bbox,
+    { width: page.width, height: page.height },
+    block.bboxSpace,
+  );
+  const pixels = bboxToPixels(normalized, page.width, page.height);
+  const x = clamp(Math.floor(pixels.x), 0, Math.max(0, page.width - 1));
+  const y = clamp(Math.floor(pixels.y), 0, Math.max(0, page.height - 1));
+  const right = clamp(Math.ceil(pixels.x + pixels.w), x + 1, page.width);
+  const bottom = clamp(Math.ceil(pixels.y + pixels.h), y + 1, page.height);
+  return { x, y, w: right - x, h: bottom - y };
+}
+
+function findBubbleBounds(
+  mask: Uint8Array,
+  width: number,
+  height: number,
+  bubbleId: number,
+): PixelRect | null {
+  let left = width;
+  let top = height;
+  let right = -1;
+  let bottom = -1;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (mask[y * width + x] !== bubbleId) continue;
+      left = Math.min(left, x);
+      top = Math.min(top, y);
+      right = Math.max(right, x);
+      bottom = Math.max(bottom, y);
+    }
+  }
+  return right >= left && bottom >= top
+    ? { x: left, y: top, w: right - left + 1, h: bottom - top + 1 }
+    : null;
+}
+
+function findNearestSafePixel(
+  mask: Uint8Array,
+  bounds: PixelRect,
+  sourceRect: PixelRect,
+): { x: number; y: number } | null {
+  const targetX = sourceRect.x + sourceRect.w / 2 - bounds.x;
+  const targetY = sourceRect.y + sourceRect.h / 2 - bounds.y;
+  let best: { x: number; y: number } | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let y = 0; y < bounds.h; y += 1) {
+    for (let x = 0; x < bounds.w; x += 1) {
+      if (!mask[y * bounds.w + x]) continue;
+      const distance = (x - targetX) ** 2 + (y - targetY) ** 2;
+      if (distance < bestDistance) {
+        best = { x, y };
+        bestDistance = distance;
+      }
+    }
+  }
+  return best;
+}
+
+type HorizontalRun = { left: number; right: number };
+
+function findBestAnchoredRectangle(
+  mask: Uint8Array,
+  width: number,
+  height: number,
+  anchor: { x: number; y: number },
+  fontSizePx: number,
+): PixelRect | null {
+  const runs = Array.from({ length: height }, (_, y) =>
+    findHorizontalRun(mask, width, y, anchor.x),
+  );
+  if (!runs[anchor.y]) return null;
+  const minimumHeight = Math.max(8, Math.round(fontSizePx * 1.35));
+  let best: { rect: PixelRect; score: number } | null = null;
+  let topLeft = 0;
+  let topRight = width - 1;
+  for (let top = anchor.y; top >= 0; top -= 1) {
+    const topRun = runs[top];
+    if (!topRun) break;
+    topLeft = Math.max(topLeft, topRun.left);
+    topRight = Math.min(topRight, topRun.right);
+    best = expandCandidateDown({
+      anchorY: anchor.y,
+      best,
+      fontSizePx,
+      minimumHeight,
+      runs,
+      top,
+      topLeft,
+      topRight,
+    });
+  }
+  return best?.rect ?? null;
+}
+
+function expandCandidateDown(options: {
+  anchorY: number;
+  best: { rect: PixelRect; score: number } | null;
+  fontSizePx: number;
+  minimumHeight: number;
+  runs: Array<HorizontalRun | null>;
+  top: number;
+  topLeft: number;
+  topRight: number;
+}): { rect: PixelRect; score: number } | null {
+  let best = options.best;
+  let left = options.topLeft;
+  let right = options.topRight;
+  for (
+    let bottom = options.anchorY;
+    bottom < options.runs.length;
+    bottom += 1
+  ) {
+    const run = options.runs[bottom];
+    if (!run) break;
+    left = Math.max(left, run.left);
+    right = Math.min(right, run.right);
+    const rect = {
+      x: left,
+      y: options.top,
+      w: right - left + 1,
+      h: bottom - options.top + 1,
+    };
+    if (rect.w <= 0 || rect.h < options.minimumHeight) continue;
+    const score = scoreHorizontalLayout(rect, options.fontSizePx);
+    if (!best || score > best.score) best = { rect, score };
+  }
+  return best;
+}
+
+function findHorizontalRun(
+  mask: Uint8Array,
+  width: number,
+  y: number,
+  x: number,
+): HorizontalRun | null {
+  if (!mask[y * width + x]) return null;
+  let left = x;
+  let right = x;
+  while (left > 0 && mask[y * width + left - 1]) left -= 1;
+  while (right + 1 < width && mask[y * width + right + 1]) right += 1;
+  return { left, right };
+}
+
+function scoreHorizontalLayout(rect: PixelRect, fontSizePx: number): number {
+  const area = rect.w * rect.h;
+  const aspectRatio = rect.w / Math.max(1, rect.h);
+  const widthBonus = 0.8 + Math.min(2.5, aspectRatio) * 0.2;
+  const shallowPenalty = Math.min(1, rect.h / Math.max(1, fontSizePx * 1.8));
+  return area * widthBonus * shallowPenalty;
+}
+
+function insetLayoutRect(rect: PixelRect, fontSizePx: number): PixelRect {
+  const inset = clamp(Math.round(fontSizePx * 0.12), 1, 4);
+  if (rect.w <= inset * 2 + 1 || rect.h <= inset * 2 + 1) return rect;
+  return {
+    x: rect.x + inset,
+    y: rect.y + inset,
+    w: rect.w - inset * 2,
+    h: rect.h - inset * 2,
+  };
+}
+
+function hasUsefulHorizontalGrowth(
+  source: PixelRect,
+  candidate: PixelRect,
+  fontSizePx: number,
+): boolean {
+  const minimumWidth = Math.max(source.w * 1.15, fontSizePx * 3.2);
+  const minimumHeight = Math.max(fontSizePx * 1.15, 8);
+  return candidate.w >= minimumWidth && candidate.h >= minimumHeight;
+}

--- a/src/main/inpainting/bubbleSegmentationEnginePool.ts
+++ b/src/main/inpainting/bubbleSegmentationEnginePool.ts
@@ -14,11 +14,13 @@ import {
   logInpaintingRuntimeWarn,
 } from "./inpaintingRuntimeLogger";
 import { LeasedIdleResourcePool } from "./leasedIdleResource";
+import type { BubbleQualityRefiner } from "./bubbleQualityRefiner";
 
 const BUBBLE_SEGMENTATION_IDLE_TTL_MS = 30 * 1000;
 
 export type BubbleSegmentationEngineLease = {
   engine: BubbleSegmentationEngine;
+  qualityRefiner?: BubbleQualityRefiner;
   release: () => void;
 };
 

--- a/src/main/inpainting/fluxAssets/pythonBootstrap.ts
+++ b/src/main/inpainting/fluxAssets/pythonBootstrap.ts
@@ -18,6 +18,7 @@ export { ensureEmbeddedPythonPackagePath } from "./pythonPathFile";
 
 type PythonBootstrapOptions = {
   runtimeDir: string;
+  runtimeLabel?: string;
   signal?: AbortSignal;
   onProgress?: (progress: FluxAssetProgress) => void;
 };
@@ -30,6 +31,7 @@ type ManagedBootstrapPythonConfig = {
 
 export async function findPythonCommand(options: {
   runtimeDir: string;
+  runtimeLabel?: string;
   signal?: AbortSignal;
   onProgress?: (progress: FluxAssetProgress) => void;
 }): Promise<PythonCommand> {
@@ -50,6 +52,16 @@ export async function findPythonCommand(options: {
     }
   } else {
     candidates.push(
+      {
+        command: join(
+          process.resourcesPath,
+          "tools",
+          "python",
+          "bin",
+          "python3",
+        ),
+        args: [],
+      },
       { command: "python3", args: [] },
       { command: "python", args: [] },
     );
@@ -65,7 +77,7 @@ export async function findPythonCommand(options: {
     }
   }
   throw new Error(
-    "Flux Python 런타임을 만들 Python 3 실행 파일을 찾지 못했습니다. 앱 데이터 Python 준비에 실패했거나 MGT_FLUX_PYTHON 경로가 올바르지 않습니다.",
+    `${options.runtimeLabel ?? "Flux"} Python 런타임을 만들 Python 3 실행 파일을 찾지 못했습니다. 앱 데이터 Python 준비에 실패했거나 Python 경로가 올바르지 않습니다.`,
   );
 }
 
@@ -151,24 +163,25 @@ async function installBootstrapPythonArchive(
   zipPath: string,
   config: ManagedBootstrapPythonConfig,
 ): Promise<void> {
+  const label = options.runtimeLabel ?? "Flux";
   await downloadToFile({
     url: config.pythonUrl,
     outputPath: zipPath,
     signal: options.signal,
-    progressText: "Flux Python 다운로드 중",
+    progressText: `${label} Python 다운로드 중`,
     label: zipName,
     onProgress: options.onProgress,
   });
   options.onProgress?.({
-    progressText: "Flux Python 압축 해제 중",
+    progressText: `${label} Python 압축 해제 중`,
     detail: zipName,
     progressMode: "indeterminate",
-    installLogLine: "Flux 런타임용 Python을 앱 데이터 폴더에 풀고 있습니다.",
+    installLogLine: `${label} 런타임용 Python을 앱 데이터 폴더에 풀고 있습니다.`,
   });
   extractZipSafely(zipPath, pythonDir);
   if (!isExecutableFile(pythonExe)) {
     throw new Error(
-      "Flux 런타임용 Python 압축을 풀었지만 python.exe를 찾지 못했습니다.",
+      `${label} 런타임용 Python 압축을 풀었지만 python.exe를 찾지 못했습니다.`,
     );
   }
   sanitizeStandaloneEmbeddedPythonPathFile(pythonDir);
@@ -180,19 +193,20 @@ async function installBootstrapPythonPip(
   getPipPath: string,
   config: ManagedBootstrapPythonConfig,
 ): Promise<void> {
+  const label = options.runtimeLabel ?? "Flux";
   await downloadToFile({
     url: config.getPipUrl,
     outputPath: getPipPath,
     signal: options.signal,
-    progressText: "Flux pip 다운로드 중",
+    progressText: `${label} pip 다운로드 중`,
     label: "get-pip.py",
     onProgress: options.onProgress,
   });
   options.onProgress?.({
-    progressText: "Flux pip 설치 중",
+    progressText: `${label} pip 설치 중`,
     detail: `Python ${config.version}`,
     progressMode: "indeterminate",
-    installLogLine: "Flux 런타임용 Python에 pip를 설치합니다.",
+    installLogLine: `${label} 런타임용 Python에 pip를 설치합니다.`,
   });
   await runCommand(pythonExe, [getPipPath, "--no-warn-script-location"], {
     signal: options.signal,

--- a/src/main/inpainting/hybridBubbleCleaning.ts
+++ b/src/main/inpainting/hybridBubbleCleaning.ts
@@ -3,9 +3,18 @@ import { readRgb } from "./rasterMasks";
 
 type Rgb = { r: number; g: number; b: number };
 
+type LinearChannel = { x: number; y: number; offset: number };
+
 export type FlatBubbleFill = {
   color: Rgb;
   kind: "black" | "white";
+};
+
+export type LightweightBubbleFill = {
+  channels: { r: LinearChannel; g: LinearChannel; b: LinearChannel };
+  inlierRatio: number;
+  rmse: number;
+  sampleCount: number;
 };
 
 export function resolveFlatBubbleFill(
@@ -60,6 +69,229 @@ export function applyFlatBubbleFill(
       bitmap[offset + 3] = 255;
     }
   }
+}
+
+export function resolveLightweightBubbleFill(
+  bitmap: Buffer,
+  pageWidth: number,
+  rect: PixelRect,
+  textMask: Uint8Array,
+  constraintMask?: Uint8Array,
+): LightweightBubbleFill | null {
+  const samples = collectPlaneSamples(
+    bitmap,
+    pageWidth,
+    rect,
+    textMask,
+    constraintMask,
+  );
+  if (samples.length < 24) return null;
+
+  const initial = fitRgbPlane(samples);
+  if (!initial) return null;
+  const residuals = samples.map((sample) =>
+    planeResidual(initial, sample.x, sample.y, sample.color),
+  );
+  const medianResidual = median([...residuals]);
+  const inlierThreshold = Math.max(10, medianResidual * 2.5);
+  const inliers = samples.filter(
+    (_, index) =>
+      (residuals[index] ?? Number.POSITIVE_INFINITY) <= inlierThreshold,
+  );
+  const inlierRatio = inliers.length / samples.length;
+  if (inliers.length < 24 || inlierRatio < 0.78) return null;
+
+  const channels = fitRgbPlane(inliers);
+  if (!channels || !planeStaysWithinBubbleRange(channels)) return null;
+  const acceptedResiduals = inliers.map((sample) =>
+    planeResidual(channels, sample.x, sample.y, sample.color),
+  );
+  const rmse = Math.sqrt(
+    acceptedResiduals.reduce((sum, value) => sum + value * value, 0) /
+      acceptedResiduals.length,
+  );
+  const sortedResiduals = [...acceptedResiduals].sort(
+    (left, right) => left - right,
+  );
+  const p90 = sortedResiduals[Math.floor(sortedResiduals.length * 0.9)] ?? 0;
+  if (rmse > 9 || p90 > 15) return null;
+
+  return {
+    channels,
+    inlierRatio,
+    rmse,
+    sampleCount: samples.length,
+  };
+}
+
+export function applyLightweightBubbleFill(
+  bitmap: Buffer,
+  pageWidth: number,
+  rect: PixelRect,
+  mask: Uint8Array,
+  fill: LightweightBubbleFill,
+): void {
+  const widthScale = Math.max(1, rect.w - 1);
+  const heightScale = Math.max(1, rect.h - 1);
+  for (let y = 0; y < rect.h; y += 1) {
+    for (let x = 0; x < rect.w; x += 1) {
+      if (!mask[y * rect.w + x]) continue;
+      const normalizedX = x / widthScale;
+      const normalizedY = y / heightScale;
+      const offset = ((rect.y + y) * pageWidth + rect.x + x) * 4;
+      bitmap[offset] = predictChannel(
+        fill.channels.b,
+        normalizedX,
+        normalizedY,
+      );
+      bitmap[offset + 1] = predictChannel(
+        fill.channels.g,
+        normalizedX,
+        normalizedY,
+      );
+      bitmap[offset + 2] = predictChannel(
+        fill.channels.r,
+        normalizedX,
+        normalizedY,
+      );
+      bitmap[offset + 3] = 255;
+    }
+  }
+}
+
+type PlaneSample = { x: number; y: number; color: Rgb };
+
+function collectPlaneSamples(
+  bitmap: Buffer,
+  pageWidth: number,
+  rect: PixelRect,
+  textMask: Uint8Array,
+  constraintMask?: Uint8Array,
+): PlaneSample[] {
+  const samples: PlaneSample[] = [];
+  const step = Math.max(1, Math.floor(Math.max(rect.w, rect.h) / 80));
+  const widthScale = Math.max(1, rect.w - 1);
+  const heightScale = Math.max(1, rect.h - 1);
+  for (let y = 0; y < rect.h; y += step) {
+    for (let x = 0; x < rect.w; x += step) {
+      const index = y * rect.w + x;
+      if (textMask[index] || (constraintMask && !constraintMask[index])) {
+        continue;
+      }
+      samples.push({
+        x: x / widthScale,
+        y: y / heightScale,
+        color: readRgb(bitmap, pageWidth, rect.x + x, rect.y + y),
+      });
+    }
+  }
+  return samples;
+}
+
+function fitRgbPlane(
+  samples: PlaneSample[],
+): LightweightBubbleFill["channels"] | null {
+  let sx = 0;
+  let sy = 0;
+  let sxx = 0;
+  let sxy = 0;
+  let syy = 0;
+  for (const sample of samples) {
+    sx += sample.x;
+    sy += sample.y;
+    sxx += sample.x * sample.x;
+    sxy += sample.x * sample.y;
+    syy += sample.y * sample.y;
+  }
+  const matrix = [
+    [sxx, sxy, sx],
+    [sxy, syy, sy],
+    [sx, sy, samples.length],
+  ];
+  const fitChannel = (channel: keyof Rgb): LinearChannel | null => {
+    let sxv = 0;
+    let syv = 0;
+    let sv = 0;
+    for (const sample of samples) {
+      const value = sample.color[channel];
+      sxv += sample.x * value;
+      syv += sample.y * value;
+      sv += value;
+    }
+    const solved = solveThreeByThree(matrix, [sxv, syv, sv]);
+    return solved ? { x: solved[0], y: solved[1], offset: solved[2] } : null;
+  };
+  const r = fitChannel("r");
+  const g = fitChannel("g");
+  const b = fitChannel("b");
+  return r && g && b ? { r, g, b } : null;
+}
+
+function solveThreeByThree(
+  source: number[][],
+  right: number[],
+): [number, number, number] | null {
+  const matrix = source.map((row, index) => [...row, right[index] ?? 0]);
+  for (let column = 0; column < 3; column += 1) {
+    let pivot = column;
+    for (let row = column + 1; row < 3; row += 1) {
+      if (Math.abs(matrix[row][column]) > Math.abs(matrix[pivot][column])) {
+        pivot = row;
+      }
+    }
+    if (Math.abs(matrix[pivot][column]) < 1e-8) return null;
+    [matrix[column], matrix[pivot]] = [matrix[pivot], matrix[column]];
+    const divisor = matrix[column][column];
+    for (let index = column; index < 4; index += 1) {
+      matrix[column][index] /= divisor;
+    }
+    for (let row = 0; row < 3; row += 1) {
+      if (row === column) continue;
+      const factor = matrix[row][column];
+      for (let index = column; index < 4; index += 1) {
+        matrix[row][index] -= factor * matrix[column][index];
+      }
+    }
+  }
+  return [matrix[0][3], matrix[1][3], matrix[2][3]];
+}
+
+function planeResidual(
+  channels: LightweightBubbleFill["channels"],
+  x: number,
+  y: number,
+  color: Rgb,
+): number {
+  return Math.hypot(
+    predictRaw(channels.r, x, y) - color.r,
+    predictRaw(channels.g, x, y) - color.g,
+    predictRaw(channels.b, x, y) - color.b,
+  );
+}
+
+function planeStaysWithinBubbleRange(
+  channels: LightweightBubbleFill["channels"],
+): boolean {
+  const corners = [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [1, 1],
+  ] as const;
+  for (const channel of Object.values(channels)) {
+    const values = corners.map(([x, y]) => predictRaw(channel, x, y));
+    if (Math.min(...values) < -8 || Math.max(...values) > 263) return false;
+    if (Math.max(...values) - Math.min(...values) > 110) return false;
+  }
+  return true;
+}
+
+function predictRaw(channel: LinearChannel, x: number, y: number): number {
+  return channel.x * x + channel.y * y + channel.offset;
+}
+
+function predictChannel(channel: LinearChannel, x: number, y: number): number {
+  return Math.max(0, Math.min(255, Math.round(predictRaw(channel, x, y))));
 }
 
 function medianColor(samples: Rgb[]): Rgb {

--- a/src/main/inpainting/patternPage.ts
+++ b/src/main/inpainting/patternPage.ts
@@ -9,17 +9,23 @@ import {
   type BubbleMaskDetectionResult,
 } from "./bubbleMaskDetection";
 import type { BubbleSegmentationEngine } from "./bubbleSegmentationEngine";
+import { applyBubbleRenderLayouts } from "./bubbleRenderLayout";
+import type { BubbleQualityRefiner } from "./bubbleQualityRefiner";
 import {
-  FLUX_INPAINT_CONTEXT_PX,
-  FLUX_INPAINT_FEATHER_PX,
-  FLUX_INPAINT_MASK_PADDING_PX,
-  FLUX_INPAINT_MAX_PIXELS,
-} from "./fluxEngine";
+  findBubbleRecoveryHints,
+  mergeRecoveredBubbleMask,
+} from "./bubbleQualityRecovery";
 import type { InpaintingEngine } from "./inpaintingEngine";
 import { hasUsableBbox } from "./maskGeometry";
-import { logInpaintingRuntimeInfo } from "./inpaintingRuntimeLogger";
+import {
+  logInpaintingRuntimeInfo,
+  logInpaintingRuntimeWarn,
+} from "./inpaintingRuntimeLogger";
 import { loadPageImage, resolveInpaintedImagePath } from "./imageIO";
-import { resolvePatternInpaintWindows } from "./patternWindowPolicy";
+import {
+  resolveInpaintingBackendPolicy,
+  resolvePatternInpaintWindows,
+} from "./patternWindowPolicy";
 import {
   buildPatternPageMask,
   type PatternMaskContext,
@@ -37,6 +43,7 @@ export async function inpaintPatternPage(
     inpaintingEngine?: InpaintingEngine;
     bubbleDetectionMode?: BubbleDetectionMode;
     bubbleSegmentationEngine?: BubbleSegmentationEngine;
+    bubbleQualityRefiner?: BubbleQualityRefiner;
   } = {},
 ): Promise<PatternPageInpaintingResult> {
   const patternBlocks = page.blocks.filter(
@@ -63,6 +70,7 @@ export async function inpaintPatternPage(
   const bubbleDetection = await detectPageBubbles({
     bitmap,
     bubbleDetectionMode: options.bubbleDetectionMode ?? "auto",
+    bubbleQualityRefiner: options.bubbleQualityRefiner,
     bubbleSegmentationEngine: options.bubbleSegmentationEngine,
     page,
     signal: options.signal,
@@ -93,12 +101,34 @@ export async function inpaintPatternPage(
     options.inpaintingEngine,
     options.bubbleDetectionMode ?? "auto",
   );
+  const renderLayout = applyBubbleRenderLayouts(page, bubbleDetection.mask);
+  if (renderLayout.expandedBlocks > 0) {
+    logInpaintingRuntimeInfo("Bubble-aware render layouts applied", {
+      page: page.name,
+      expandedBlocks: renderLayout.expandedBlocks,
+    });
+  }
 
   const outputPath = await writePatternInpaintedImage(page, bitmap, size);
+  return buildInpaintedPageResult(
+    page,
+    renderLayout.blocks,
+    outputPath,
+    maskContext.blocksErased,
+  );
+}
+
+function buildInpaintedPageResult(
+  page: MangaPage,
+  blocks: MangaPage["blocks"],
+  outputPath: string,
+  blocksErased: number,
+): PatternPageInpaintingResult {
   return {
-    blocksErased: maskContext.blocksErased,
+    blocksErased,
     page: {
       ...page,
+      blocks,
       inpaintedImagePath: outputPath,
       updatedAt: new Date().toISOString(),
     },
@@ -118,6 +148,7 @@ async function runPatternInpaintingEngine(options: {
   if (!options.engine) {
     throw new Error("원문 지우기 엔진이 준비되지 않았습니다.");
   }
+  const policy = resolveInpaintingBackendPolicy(options.engine);
   await options.engine.inpaint(
     options.bitmap,
     options.width,
@@ -129,19 +160,15 @@ async function runPatternInpaintingEngine(options: {
     ),
     {
       signal: options.signal,
-      featherPx: FLUX_INPAINT_FEATHER_PX,
-      contextPx: FLUX_INPAINT_CONTEXT_PX,
-      maskPaddingPx: FLUX_INPAINT_MASK_PADDING_PX,
-      maxPixels: FLUX_INPAINT_MAX_PIXELS,
+      featherPx: policy.featherPx,
+      contextPx: policy.contextPx,
+      maskPaddingPx: policy.maskPaddingPx,
+      maxPixels: policy.maxPixels,
       bubbleMask:
-        options.engine.model === "flux-klein"
+        policy.bubbleMaskStrategy === "omit"
           ? undefined
           : options.bubbleDetection.mask,
-      windowMasks:
-        options.engine.model === "flux-klein" &&
-        options.engine.backend === "metal-native"
-          ? options.maskContext.inpaintWindowMasks
-          : undefined,
+      windowMasks: options.maskContext.inpaintWindowMasks,
     },
   );
 }
@@ -154,26 +181,49 @@ function logPatternInpaintingResult(
 ): void {
   logInpaintingRuntimeInfo("Selected inpainting model processing completed", {
     model: engine?.model,
+    backend: engine?.backend,
     blocks: mask.blocksErased,
+    windows: mask.inpaintWindows.length,
     engineBlocks: mask.engineBlocks,
     otsuBlocks: mask.otsuBlocks,
     directFillBlocks: mask.directFillBlocks,
+    lightweightFillBlocks: mask.lightweightFillBlocks,
+    directFillRatio:
+      mask.blocksErased > 0
+        ? Number((mask.directFillBlocks / mask.blocksErased).toFixed(4))
+        : 0,
+    lightweightFillRatio:
+      mask.blocksErased > 0
+        ? Number((mask.lightweightFillBlocks / mask.blocksErased).toFixed(4))
+        : 0,
+    generationFreeRatio:
+      mask.blocksErased > 0
+        ? Number(
+            (
+              (mask.directFillBlocks + mask.lightweightFillBlocks) /
+              mask.blocksErased
+            ).toFixed(4),
+          )
+        : 0,
     bubbleDetectionMode: mode,
     bubbleRegions: bubbles.regions,
     bubbleMatchedBlocks: bubbles.matchedBlocks,
     bubbleSplitRegions: bubbles.splitRegions,
+    bubbleRecoveryCandidates: bubbles.recoveryCandidates ?? 0,
+    bubbleRecoveredBlocks: bubbles.recoveredBlocks ?? 0,
   });
 }
 
 async function detectPageBubbles(options: {
   bitmap: Buffer;
   bubbleDetectionMode: BubbleDetectionMode;
+  bubbleQualityRefiner?: BubbleQualityRefiner;
   bubbleSegmentationEngine?: BubbleSegmentationEngine;
   page: MangaPage;
   signal?: AbortSignal;
 }): Promise<BubbleMaskDetectionResult> {
   if (
-    options.bubbleDetectionMode === "precise" &&
+    options.bubbleDetectionMode !== "auto" &&
     options.bubbleSegmentationEngine
   ) {
     const preciseMask = await options.bubbleSegmentationEngine.segment(
@@ -182,9 +232,79 @@ async function detectPageBubbles(options: {
       options.page.height,
       { signal: options.signal },
     );
-    return refinePreciseBubbleMask(preciseMask, options.bitmap, options.page);
+    const precise = refinePreciseBubbleMask(
+      preciseMask,
+      options.bitmap,
+      options.page,
+    );
+    if (
+      options.bubbleDetectionMode === "precise" ||
+      !options.bubbleQualityRefiner
+    ) {
+      return precise;
+    }
+    return recoverWeakBubbleMasks(options, precise);
   }
   return buildLightweightBubbleMask(options.bitmap, options.page);
+}
+
+async function recoverWeakBubbleMasks(
+  options: {
+    bitmap: Buffer;
+    bubbleQualityRefiner?: BubbleQualityRefiner;
+    page: MangaPage;
+    signal?: AbortSignal;
+  },
+  precise: BubbleMaskDetectionResult,
+): Promise<BubbleMaskDetectionResult> {
+  const refiner = options.bubbleQualityRefiner;
+  if (!refiner) return precise;
+  const hints = findBubbleRecoveryHints(options.page, precise.mask);
+  if (hints.length === 0) {
+    return { ...precise, recoveryCandidates: 0, recoveredBlocks: 0 };
+  }
+  try {
+    const recoveredMask = await refiner.refine(
+      options.bitmap,
+      options.page.width,
+      options.page.height,
+      hints,
+      { signal: options.signal },
+    );
+    const recovered = mergeRecoveredBubbleMask(
+      precise.mask,
+      recoveredMask,
+      options.page,
+      hints,
+    );
+    return {
+      ...precise,
+      mask: recovered.mask,
+      regions: countBubbleRegions(recovered.mask),
+      recoveryCandidates: hints.length,
+      recoveredBlocks: recovered.recoveredBlocks,
+    };
+  } catch (error) {
+    logInpaintingRuntimeWarn(
+      "Conditional RT-DETR + SAM bubble recovery failed; precise mask retained",
+      {
+        page: options.page.name,
+        recoveryCandidates: hints.length,
+        model: refiner.model,
+        error,
+      },
+    );
+    return {
+      ...precise,
+      recoveryCandidates: hints.length,
+      recoveredBlocks: 0,
+    };
+  }
+}
+
+function countBubbleRegions(mask: Uint8Array): number {
+  const ids = new Set(mask);
+  return ids.size - (ids.has(0) ? 1 : 0);
 }
 
 async function writePatternInpaintedImage(

--- a/src/main/inpainting/patternPageMask.ts
+++ b/src/main/inpainting/patternPageMask.ts
@@ -5,7 +5,9 @@ import {
 } from "./bubbleMaskDetection";
 import {
   applyFlatBubbleFill,
+  applyLightweightBubbleFill,
   resolveFlatBubbleFill,
+  resolveLightweightBubbleFill,
 } from "./hybridBubbleCleaning";
 import {
   bboxToPixelRect,
@@ -29,6 +31,7 @@ export type PatternMaskContext = {
   engineBlocks: number;
   otsuBlocks: number;
   directFillBlocks: number;
+  lightweightFillBlocks: number;
 };
 
 export function buildPatternPageMask(options: {
@@ -47,6 +50,7 @@ export function buildPatternPageMask(options: {
     engineBlocks: 0,
     otsuBlocks: 0,
     directFillBlocks: 0,
+    lightweightFillBlocks: 0,
   };
   for (const block of options.page.blocks) {
     if (!hasUsableBbox(block.bbox) || block.inpaintExcluded) continue;
@@ -75,6 +79,8 @@ function mergePatternBlock(
   });
   if (detection.directFilled) {
     context.directFillBlocks += 1;
+  } else if (detection.lightweightFilled) {
+    context.lightweightFillBlocks += 1;
   } else {
     if (!detection.windowMask) {
       throw new Error("Pattern mask detection did not return an engine mask.");
@@ -147,6 +153,7 @@ function mergePatternDetectionMask(options: {
   }
   return {
     directFilled: false,
+    lightweightFilled: false,
     usedOtsu: false,
     windowMask: buildPatternFallbackMask({
       ...options,
@@ -164,26 +171,49 @@ function mergeDetectedPatternMask(options: {
   strategy: "adaptive" | "otsu" | "none";
   width: number;
 }): PatternMaskDetectionResult {
-  const fill = resolveFlatBubbleFill(
+  const usableConstraint = hasMaskPixels(options.constraintMask)
+    ? options.constraintMask
+    : undefined;
+  const directFill = resolveFlatBubbleFill(
     options.bitmap,
     options.width,
     options.detectRect,
     options.constrainedMask,
-    hasMaskPixels(options.constraintMask) ? options.constraintMask : undefined,
+    usableConstraint,
   );
-  if (fill) {
+  if (directFill) {
     applyFlatBubbleFill(
       options.bitmap,
       options.width,
       options.detectRect,
       options.constrainedMask,
-      fill.color,
+      directFill.color,
     );
   }
+  const lightweightFill = directFill
+    ? null
+    : resolveLightweightBubbleFill(
+        options.bitmap,
+        options.width,
+        options.detectRect,
+        options.constrainedMask,
+        usableConstraint,
+      );
+  if (lightweightFill) {
+    applyLightweightBubbleFill(
+      options.bitmap,
+      options.width,
+      options.detectRect,
+      options.constrainedMask,
+      lightweightFill,
+    );
+  }
+  const filledWithoutEngine = Boolean(directFill || lightweightFill);
   return {
-    directFilled: Boolean(fill),
+    directFilled: Boolean(directFill),
+    lightweightFilled: Boolean(lightweightFill),
     usedOtsu: options.strategy === "otsu",
-    windowMask: fill
+    windowMask: filledWithoutEngine
       ? undefined
       : {
           bounds: options.detectRect,
@@ -221,6 +251,7 @@ function buildPatternFallbackMask(options: {
 
 type PatternMaskDetectionResult = {
   directFilled: boolean;
+  lightweightFilled: boolean;
   usedOtsu: boolean;
   windowMask?: InpaintingWindowMask;
 };

--- a/src/main/inpainting/patternWindowPolicy.ts
+++ b/src/main/inpainting/patternWindowPolicy.ts
@@ -1,11 +1,68 @@
 import type { InpaintingEngine } from "./inpaintingEngine";
+import {
+  FLUX_INPAINT_CONTEXT_PX,
+  FLUX_INPAINT_FEATHER_PX,
+  FLUX_INPAINT_MASK_PADDING_PX,
+  FLUX_INPAINT_MAX_PIXELS,
+  FLUX_METAL_INPAINT_CONTEXT_PX,
+  FLUX_METAL_TILE_SIZE_PX,
+} from "./fluxEngineConstants";
 import { mergeRects, type PixelRect } from "./maskGeometry";
+
+export type InpaintingBackendPolicy = Readonly<{
+  enginePath: "flux" | "koharu";
+  windowStrategy: "merge" | "preserve";
+  maskStrategy: "owned" | "page";
+  bubbleMaskStrategy: "omit" | "forward";
+  contextPx: number;
+  maxContextPx: number | null;
+  featherPx: number;
+  maskPaddingPx: number;
+  maxPixels: number;
+  cropStrategy: "scaled-to-budget" | "tiled-native" | "whole-page";
+  maxCropSizePx: number | null;
+}>;
+
+export function resolveInpaintingBackendPolicy(
+  engine: Pick<InpaintingEngine, "model" | "backend">,
+): InpaintingBackendPolicy {
+  if (engine.model !== "flux-klein") {
+    return {
+      enginePath: "koharu",
+      windowStrategy: "merge",
+      maskStrategy: "owned",
+      bubbleMaskStrategy: "forward",
+      contextPx: FLUX_INPAINT_CONTEXT_PX,
+      maxContextPx: null,
+      featherPx: FLUX_INPAINT_FEATHER_PX,
+      maskPaddingPx: FLUX_INPAINT_MASK_PADDING_PX,
+      maxPixels: FLUX_INPAINT_MAX_PIXELS,
+      cropStrategy: "whole-page",
+      maxCropSizePx: null,
+    };
+  }
+
+  const metal = engine.backend === "metal-native";
+  return {
+    enginePath: "flux",
+    windowStrategy: "preserve",
+    maskStrategy: "owned",
+    bubbleMaskStrategy: "omit",
+    contextPx: metal ? FLUX_METAL_INPAINT_CONTEXT_PX : FLUX_INPAINT_CONTEXT_PX,
+    maxContextPx: metal ? FLUX_METAL_INPAINT_CONTEXT_PX : null,
+    featherPx: FLUX_INPAINT_FEATHER_PX,
+    maskPaddingPx: FLUX_INPAINT_MASK_PADDING_PX,
+    maxPixels: FLUX_INPAINT_MAX_PIXELS,
+    cropStrategy: metal ? "tiled-native" : "scaled-to-budget",
+    maxCropSizePx: metal ? FLUX_METAL_TILE_SIZE_PX : null,
+  };
+}
 
 export function resolvePatternInpaintWindows(
   windows: PixelRect[],
-  engine: InpaintingEngine,
+  engine: Pick<InpaintingEngine, "model" | "backend">,
 ): PixelRect[] {
-  if (engine.model === "flux-klein" && engine.backend === "metal-native") {
+  if (resolveInpaintingBackendPolicy(engine).windowStrategy === "preserve") {
     return windows.map((window) => ({ ...window }));
   }
   return mergeRects(windows);

--- a/src/main/jobs/inpaintingBubbleSegmentation.ts
+++ b/src/main/jobs/inpaintingBubbleSegmentation.ts
@@ -4,6 +4,8 @@ import {
   acquireBubbleSegmentationEngine,
   type BubbleSegmentationEngineLease,
 } from "../inpainting/bubbleSegmentationEnginePool";
+import { acquireBubbleQualityRefiner } from "../inpainting/bubbleQualityRefinerPool";
+import { logInpaintingRuntimeWarn } from "../inpainting/inpaintingRuntimeLogger";
 import { getAppSettings } from "../settingsStore";
 import type { InpaintingJobContext } from "./inpaintingJobTypes";
 
@@ -23,30 +25,84 @@ export async function prepareBubbleSegmentation(options: {
   }
   const appSettings = await getAppSettings(options.context.appPaths);
   const mode = appSettings.inpainting?.bubbleDetectionMode ?? "auto";
-  if (mode !== "precise") {
+  if (mode === "auto") {
     return { lease: null, mode };
   }
   const lease = await acquireBubbleSegmentationEngine({
     appPaths: options.context.appPaths,
     backend: appSettings.inpainting?.koharuBackend ?? "auto",
     signal: options.abortController.signal,
-    onProgress: (progress) =>
-      options.emit({
-        id: options.id,
-        kind: "inpainting",
-        status: "starting",
-        progressText: progress.progressText,
-        phase: "model_downloading",
-        progressCurrent: 0,
-        progressTotal: options.pageCount,
-        pageTotal: options.pageCount,
-        detail: progress.detail,
-        progressMode: progress.progressMode,
-        progressPercent: progress.progressPercent,
-        progressBytes: progress.progressBytes,
-        progressTotalBytes: progress.progressTotalBytes,
-        installLogLine: progress.installLogLine,
-      }),
+    onProgress: (progress) => emitModelProgress(options, progress),
   });
-  return { lease, mode };
+  if (mode === "precise") {
+    return { lease, mode };
+  }
+  try {
+    const qualityLease = await acquireBubbleQualityRefiner({
+      appPaths: options.context.appPaths,
+      backend: normalizePreparedBackend(lease.engine.backend),
+      requestedModel: mode === "sam3-experimental" ? "sam3" : "sam2.1",
+      signal: options.abortController.signal,
+      onProgress: (progress) => emitModelProgress(options, progress),
+    });
+    return {
+      lease: {
+        engine: lease.engine,
+        qualityRefiner: qualityLease.refiner,
+        release: () => {
+          qualityLease.release();
+          lease.release();
+        },
+      },
+      mode,
+    };
+  } catch (error) {
+    logInpaintingRuntimeWarn(
+      "Highest-quality bubble runtime unavailable; precise detection retained",
+      { mode, error },
+    );
+    return { lease, mode };
+  }
+}
+
+function emitModelProgress(
+  options: {
+    emit: (event: JobEvent) => void;
+    id: string;
+    pageCount: number;
+  },
+  progress: {
+    progressText: string;
+    detail?: string;
+    progressMode?: "indeterminate" | "determinate" | "log-only";
+    progressPercent?: number;
+    progressBytes?: number;
+    progressTotalBytes?: number;
+    installLogLine?: string;
+  },
+): void {
+  options.emit({
+    id: options.id,
+    kind: "inpainting",
+    status: "starting",
+    progressText: progress.progressText,
+    phase: "model_downloading",
+    progressCurrent: 0,
+    progressTotal: options.pageCount,
+    pageTotal: options.pageCount,
+    detail: progress.detail,
+    progressMode: progress.progressMode,
+    progressPercent: progress.progressPercent,
+    progressBytes: progress.progressBytes,
+    progressTotalBytes: progress.progressTotalBytes,
+    installLogLine: progress.installLogLine,
+  });
+}
+
+function normalizePreparedBackend(
+  backend: string,
+): "cuda-native" | "zluda-native" | "metal-native" | "cpu" {
+  return ["cuda-native", "zluda-native", "metal-native"].includes(backend)
+    ? (backend as "cuda-native" | "zluda-native" | "metal-native")
+    : "cpu";
 }

--- a/src/main/jobs/inpaintingJobRunner.ts
+++ b/src/main/jobs/inpaintingJobRunner.ts
@@ -392,6 +392,8 @@ async function processInpaintingPage({
       })
     : await inpaintPatternPage(page, {
         bubbleDetectionMode: state.bubbleDetectionMode,
+        bubbleQualityRefiner:
+          state.bubbleSegmentationEngineLease?.qualityRefiner,
         bubbleSegmentationEngine: state.bubbleSegmentationEngineLease?.engine,
         signal: abortController.signal,
         decodeFallback: context.decodeImage,

--- a/src/main/runtime/bubble-quality-worker.py
+++ b/src/main/runtime/bubble-quality-worker.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers import (
+    RTDetrImageProcessor,
+    RTDetrV2ForObjectDetection,
+    Sam2Model,
+    Sam2Processor,
+    Sam3TrackerModel,
+    Sam3TrackerProcessor,
+)
+from transformers import logging as transformers_logging
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rtdetr-model-dir", required=True)
+    parser.add_argument("--sam-model-dir", required=True)
+    parser.add_argument("--sam-model", choices=("sam2.1", "sam3"), required=True)
+    parser.add_argument("--device", choices=("cpu", "cuda", "mps"), required=True)
+    return parser.parse_args()
+
+
+def resolve_device(name: str) -> torch.device:
+    if name == "cuda" and torch.cuda.is_available():
+        return torch.device("cuda")
+    if name == "mps" and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+class BubbleQualityModels:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.device = resolve_device(args.device)
+        self.detector_processor = RTDetrImageProcessor.from_pretrained(
+            args.rtdetr_model_dir, local_files_only=True
+        )
+        self.detector = RTDetrV2ForObjectDetection.from_pretrained(
+            args.rtdetr_model_dir, local_files_only=True
+        ).to(self.device)
+        self.detector.eval()
+        if args.sam_model == "sam3":
+            self.sam_processor = Sam3TrackerProcessor.from_pretrained(
+                args.sam_model_dir, local_files_only=True
+            )
+            self.sam = Sam3TrackerModel.from_pretrained(
+                args.sam_model_dir,
+                local_files_only=True,
+                torch_dtype=self._preferred_dtype(),
+            ).to(self.device)
+        else:
+            self.sam_processor = Sam2Processor.from_pretrained(
+                args.sam_model_dir, local_files_only=True
+            )
+            self.sam = Sam2Model.from_pretrained(
+                args.sam_model_dir,
+                local_files_only=True,
+                torch_dtype=self._preferred_dtype(),
+            ).to(self.device)
+        self.sam.eval()
+
+    def _preferred_dtype(self) -> torch.dtype:
+        return torch.float32 if self.device.type == "cpu" else torch.float16
+
+    def _detect_bubbles(self, image: Image.Image) -> tuple[np.ndarray, np.ndarray]:
+        inputs = self.detector_processor(
+            images=image,
+            size={"height": 640, "width": 640},
+            return_tensors="pt",
+        )
+        inputs = {key: value.to(self.device) for key, value in inputs.items()}
+        with torch.inference_mode():
+            outputs = self.detector(**inputs)
+        result = self.detector_processor.post_process_object_detection(
+            outputs,
+            threshold=0.25,
+            target_sizes=[(image.height, image.width)],
+            use_focal_loss=bool(getattr(self.detector.config, "use_focal_loss", True)),
+        )[0]
+        labels = result["labels"].detach().cpu().numpy()
+        keep = labels == 0
+        return (
+            result["boxes"].detach().cpu().numpy()[keep],
+            result["scores"].detach().cpu().numpy()[keep],
+        )
+
+    def _segment_boxes(self, image: Image.Image, boxes: list[list[float]]) -> list[np.ndarray]:
+        input_boxes = torch.tensor([boxes], dtype=torch.float32)
+        inputs = self.sam_processor(
+            image, input_boxes=input_boxes, return_tensors="pt"
+        )
+        for key in inputs:
+            value = inputs[key]
+            if isinstance(value, torch.Tensor) and value.is_floating_point():
+                inputs[key] = value.to(self.sam.dtype)
+        inputs = inputs.to(self.device)
+        with torch.inference_mode():
+            outputs = self.sam(multimask_output=False, **inputs)
+        masks = self.sam_processor.post_process_masks(
+            outputs.pred_masks, inputs["original_sizes"]
+        )[0][:, 0]
+        return [(mask > 0).detach().cpu().numpy() for mask in masks]
+
+
+def match_hints_to_boxes(
+    hints: list[dict], boxes: np.ndarray, scores: np.ndarray
+) -> list[int | None]:
+    matches: list[int | None] = []
+    for hint in hints:
+        hint_box = rect_to_xyxy(hint)
+        best_index = None
+        best_score = float("-inf")
+        for index, box in enumerate(boxes):
+            coverage = intersection_area(hint_box, box) / max(1.0, box_area(hint_box))
+            center_inside = point_in_box(box_center(hint_box), box)
+            if coverage < 0.15 and not center_inside:
+                continue
+            area_ratio = box_area(box) / max(1.0, box_area(hint_box))
+            candidate_score = float(scores[index]) * 2.0 + coverage
+            candidate_score -= max(0.0, area_ratio - 30.0) * 0.01
+            if candidate_score > best_score:
+                best_index = index
+                best_score = candidate_score
+        matches.append(best_index)
+    return matches
+
+
+def group_matched_boxes(
+    matches: list[int | None], boxes: np.ndarray
+) -> tuple[list[list[float]], list[list[int]]]:
+    # Filled by caller-facing indices after stable grouping.
+    box_order: list[int] = []
+    groups: list[list[int]] = []
+    for hint_index, box_index in enumerate(matches):
+        if box_index is None:
+            continue
+        if box_index in box_order:
+            groups[box_order.index(box_index)].append(hint_index)
+        else:
+            box_order.append(box_index)
+            groups.append([hint_index])
+    return [boxes[index].tolist() for index in box_order], groups
+
+
+def paint_owned_masks(
+    output: np.ndarray,
+    masks: list[np.ndarray],
+    boxes: list[list[float]],
+    hint_groups: list[list[int]],
+    hints: list[dict],
+) -> None:
+    best_distances = np.full(output.shape, np.inf, dtype=np.float32)
+    yy, xx = np.indices(output.shape)
+    for mask, box, hint_indices in zip(masks, boxes, hint_groups):
+        clipped = clip_mask_to_box(mask, box, output.shape[1], output.shape[0])
+        for hint_index in hint_indices:
+            hint = hints[hint_index]
+            center_x = float(hint["x"]) + float(hint["w"]) / 2.0
+            center_y = float(hint["y"]) + float(hint["h"]) / 2.0
+            distances = (xx - center_x) ** 2 + (yy - center_y) ** 2
+            owned = clipped & (distances < best_distances)
+            output[owned] = min(255, hint_index + 1)
+            best_distances[owned] = distances[owned]
+
+
+def clip_mask_to_box(
+    mask: np.ndarray, box: list[float], width: int, height: int
+) -> np.ndarray:
+    x0, y0, x1, y1 = box
+    left = max(0, min(width, int(np.floor(x0))))
+    top = max(0, min(height, int(np.floor(y0))))
+    right = max(0, min(width, int(np.ceil(x1))))
+    bottom = max(0, min(height, int(np.ceil(y1))))
+    allowed = np.zeros((height, width), dtype=bool)
+    allowed[top:bottom, left:right] = True
+    return np.asarray(mask, dtype=bool) & allowed
+
+
+def rect_to_xyxy(rect: dict) -> np.ndarray:
+    x = float(rect["x"])
+    y = float(rect["y"])
+    return np.array([x, y, x + float(rect["w"]), y + float(rect["h"])])
+
+
+def box_area(box: np.ndarray | list[float]) -> float:
+    return max(0.0, float(box[2]) - float(box[0])) * max(
+        0.0, float(box[3]) - float(box[1])
+    )
+
+
+def intersection_area(left: np.ndarray, right: np.ndarray) -> float:
+    width = max(0.0, min(left[2], right[2]) - max(left[0], right[0]))
+    height = max(0.0, min(left[3], right[3]) - max(left[1], right[1]))
+    return float(width * height)
+
+
+def box_center(box: np.ndarray) -> tuple[float, float]:
+    return ((float(box[0]) + float(box[2])) / 2, (float(box[1]) + float(box[3])) / 2)
+
+
+def point_in_box(point: tuple[float, float], box: np.ndarray) -> bool:
+    return box[0] <= point[0] <= box[2] and box[1] <= point[1] <= box[3]
+
+
+def respond(payload: dict) -> None:
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    transformers_logging.set_verbosity_error()
+    models = BubbleQualityModels(parse_args())
+    for line in sys.stdin:
+        try:
+            request = json.loads(line)
+            if request.get("type") == "shutdown":
+                return
+            if request.get("type") != "refine":
+                continue
+            started = time.monotonic()
+            image = Image.open(request["input"]).convert("RGB")
+            detection_boxes, scores = models._detect_bubbles(image)
+            matches = match_hints_to_boxes(
+                request.get("hints", []), detection_boxes, scores
+            )
+            matched_boxes, groups = group_matched_boxes(matches, detection_boxes)
+            output = np.zeros((image.height, image.width), dtype=np.uint8)
+            if matched_boxes:
+                masks = models._segment_boxes(image, matched_boxes)
+                paint_owned_masks(
+                    output,
+                    masks,
+                    matched_boxes,
+                    groups,
+                    request.get("hints", []),
+                )
+            Image.fromarray(output, mode="L").save(request["output"])
+            respond(
+                {
+                    "id": request.get("id"),
+                    "ok": True,
+                    "matched": sum(match is not None for match in matches),
+                    "elapsed_ms": round((time.monotonic() - started) * 1000),
+                }
+            )
+        except Exception as error:
+            respond(
+                {
+                    "id": request.get("id") if "request" in locals() else None,
+                    "ok": False,
+                    "error": f"{type(error).__name__}: {error}",
+                }
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main/settings/appSettingsResolvers.ts
+++ b/src/main/settings/appSettingsResolvers.ts
@@ -199,11 +199,17 @@ export function resolveBubbleDetectionMode(
   const normalized = String(value ?? "")
     .trim()
     .toLowerCase();
-  return normalized === "precise" || normalized === "정밀"
-    ? "precise"
-    : normalized === "auto" || normalized === "자동"
-      ? "auto"
-      : fallback;
+  if (["quality", "highest", "최고", "최고 품질"].includes(normalized)) {
+    return "quality";
+  }
+  if (
+    ["sam3", "sam-3", "sam3-experimental", "sam 3 실험"].includes(normalized)
+  ) {
+    return "sam3-experimental";
+  }
+  if (normalized === "precise" || normalized === "정밀") return "precise";
+  if (normalized === "auto" || normalized === "자동") return "auto";
+  return fallback;
 }
 
 export function resolveKoharuInpaintingBackend(

--- a/src/renderer/src/components/settingsModal/BubbleDetectionSettings.tsx
+++ b/src/renderer/src/components/settingsModal/BubbleDetectionSettings.tsx
@@ -7,6 +7,7 @@ export function BubbleDetectionSettings({
   clearTestState,
   controlsBusy,
   setBubbleDetectionMode,
+  usesNvidiaHardware,
 }: {
   bubbleDetectionMode: BubbleDetectionMode;
   clearTestState: () => void;
@@ -14,9 +15,15 @@ export function BubbleDetectionSettings({
   setBubbleDetectionMode: React.Dispatch<
     React.SetStateAction<BubbleDetectionMode>
   >;
+  usesNvidiaHardware: boolean;
 }): React.JSX.Element {
   const { t } = useTranslation("components");
-  const options: BubbleDetectionMode[] = ["auto", "precise"];
+  const options: BubbleDetectionMode[] = [
+    "auto",
+    "precise",
+    "quality",
+    "sam3-experimental",
+  ];
   return (
     <div className="settings-field-stack">
       <span>{t("settings.hardware.bubbleDetection")}</span>
@@ -30,7 +37,10 @@ export function BubbleDetectionSettings({
             key={option}
             type="button"
             className={`settings-preset-button ${bubbleDetectionMode === option ? "active" : ""}`}
-            disabled={controlsBusy}
+            disabled={
+              controlsBusy ||
+              (option === "sam3-experimental" && !usesNvidiaHardware)
+            }
             aria-pressed={bubbleDetectionMode === option}
             onClick={() => {
               clearTestState();

--- a/src/shared/i18n/locales/en/components.json
+++ b/src/shared/i18n/locales/en/components.json
@@ -1182,6 +1182,14 @@
         "precise": {
           "label": "Precise",
           "description": "Detects bubbles with a dedicated segmentation model. Downloads an approximately 104 MB model on first use."
+        },
+        "quality": {
+          "label": "Highest quality",
+          "description": "Runs RT-DETR only on bubbles missed or weakly bounded by precise detection, then refines those outlines with SAM 2.1. Automatically prepares about 1.1 GB of models on first use."
+        },
+        "sam3-experimental": {
+          "label": "SAM 3 experimental",
+          "description": "Experimental NVIDIA-only mode. It refines only failed regions with RT-DETR + SAM 3 and safely falls back to SAM 2.1 without an approved Hugging Face token."
         }
       },
       "amdOcrExperimental": "AMD GPU OCR is experimental. If it fails, you can switch only OCR to the CPU.",

--- a/src/shared/i18n/locales/ja/components.json
+++ b/src/shared/i18n/locales/ja/components.json
@@ -1172,6 +1172,14 @@
         "precise": {
           "label": "高精度",
           "description": "専用セグメンテーションモデルで吹き出しを検出します。初回に約104MBのモデルをダウンロードします。"
+        },
+        "quality": {
+          "label": "最高品質",
+          "description": "高精度検出で見逃した、または境界が不安定な吹き出しだけをRT-DETRで再検出し、SAM 2.1で輪郭を補正します。初回に約1.1GBのモデルを自動準備します。"
+        },
+        "sam3-experimental": {
+          "label": "SAM 3 実験",
+          "description": "NVIDIA専用の実験モードです。失敗領域のみRT-DETR + SAM 3で補正し、承認済みHugging Faceトークンがない場合はSAM 2.1へ安全に切り替えます。"
         }
       },
       "amdOcrExperimental": "AMD GPU OCRは実験機能です。失敗した場合はOCRだけをCPUに切り替えられます。",

--- a/src/shared/i18n/locales/ko/components.json
+++ b/src/shared/i18n/locales/ko/components.json
@@ -1166,6 +1166,14 @@
         "precise": {
           "label": "정밀",
           "description": "전용 세그멘테이션 모델로 말풍선을 감지합니다. 처음 사용할 때 약 104MB 모델을 내려받습니다."
+        },
+        "quality": {
+          "label": "최고 품질",
+          "description": "정밀 감지에서 놓치거나 경계가 불안정한 말풍선만 RT-DETR로 다시 찾고 SAM 2.1로 외곽선을 보정합니다. 처음 사용할 때 약 1.1GB 모델을 자동으로 준비합니다."
+        },
+        "sam3-experimental": {
+          "label": "SAM 3 실험",
+          "description": "NVIDIA 전용 실험 모드입니다. 실패 구간만 RT-DETR + SAM 3로 보정하며, 모델 사용 승인을 받은 Hugging Face 토큰이 없으면 SAM 2.1로 안전하게 전환합니다."
         }
       },
       "amdOcrExperimental": "AMD OCR GPU는 실험 기능입니다. 실패하면 OCR만 CPU로 바꿀 수 있습니다.",

--- a/src/shared/i18n/locales/zh-Hans/components.json
+++ b/src/shared/i18n/locales/zh-Hans/components.json
@@ -1135,6 +1135,14 @@
         "precise": {
           "label": "精确",
           "description": "使用专用分割模型检测气泡。首次使用时下载约 104MB 的模型。"
+        },
+        "quality": {
+          "label": "最高质量",
+          "description": "仅对精确检测遗漏或边界不稳定的气泡运行 RT-DETR，并用 SAM 2.1 优化轮廓。首次使用时自动准备约 1.1GB 的模型。"
+        },
+        "sam3-experimental": {
+          "label": "SAM 3 实验",
+          "description": "仅限 NVIDIA 的实验模式。只用 RT-DETR + SAM 3 修复失败区域；没有获批的 Hugging Face 令牌时会安全切换到 SAM 2.1。"
         }
       },
       "amdOcrExperimental": "AMD GPU OCR为实验功能。如失败，可仅将OCR切换到CPU。",

--- a/src/shared/i18n/locales/zh-Hant/components.json
+++ b/src/shared/i18n/locales/zh-Hant/components.json
@@ -1138,6 +1138,14 @@
         "precise": {
           "label": "精確",
           "description": "使用專用分割模型偵測對話框。首次使用時會下載約 104MB 的模型。"
+        },
+        "quality": {
+          "label": "最高品質",
+          "description": "僅對精確偵測遺漏或邊界不穩定的對話框執行 RT-DETR，並以 SAM 2.1 修正輪廓。首次使用時會自動準備約 1.1GB 的模型。"
+        },
+        "sam3-experimental": {
+          "label": "SAM 3 實驗",
+          "description": "僅限 NVIDIA 的實驗模式。只以 RT-DETR + SAM 3 修復失敗區域；沒有獲准的 Hugging Face 權杖時會安全切換至 SAM 2.1。"
         }
       },
       "amdOcrExperimental": "AMD GPU OCR 為實驗功能。如失敗，可僅將 OCR 切換到 CPU。",

--- a/src/shared/inpaintingSettingsTypes.ts
+++ b/src/shared/inpaintingSettingsTypes.ts
@@ -6,7 +6,11 @@ export type FluxBackend =
 
 export type InpaintingModel = "flux-klein" | "lama-manga" | "aot-inpainting";
 
-export type BubbleDetectionMode = "auto" | "precise";
+export type BubbleDetectionMode =
+  | "auto"
+  | "precise"
+  | "quality"
+  | "sam3-experimental";
 
 export type KoharuInpaintingBackend =
   | "auto"

--- a/src/shared/ipcSettingsSchemas.ts
+++ b/src/shared/ipcSettingsSchemas.ts
@@ -116,7 +116,9 @@ export const AppSettingsSchema = z
       .optional(),
     inpainting: z
       .object({
-        bubbleDetectionMode: z.enum(["auto", "precise"]).optional(),
+        bubbleDetectionMode: z
+          .enum(["auto", "precise", "quality", "sam3-experimental"])
+          .optional(),
         model: InpaintingModelSchema.optional(),
         fluxBackend: FluxBackendSchema.optional(),
         koharuBackend: KoharuInpaintingBackendSchema.optional(),

--- a/tests/bubbleDetectionSettings.test.ts
+++ b/tests/bubbleDetectionSettings.test.ts
@@ -6,10 +6,18 @@ import {
 import { AppSettingsSchema } from "../src/shared/ipcSettingsSchemas";
 
 describe("speech bubble detection settings", () => {
-  it("defaults to auto and restores precise mode", () => {
+  it("defaults to auto and restores precise and highest-quality modes", () => {
     const defaults = resolveDefaultAppSettings();
     const precise = parseStoredAppSettings(
       '{"inpainting":{"bubbleDetectionMode":"precise"}}',
+      defaults,
+    );
+    const quality = parseStoredAppSettings(
+      '{"inpainting":{"bubbleDetectionMode":"quality"}}',
+      defaults,
+    );
+    const sam3 = parseStoredAppSettings(
+      '{"inpainting":{"bubbleDetectionMode":"sam3-experimental"}}',
       defaults,
     );
 
@@ -18,6 +26,8 @@ describe("speech bubble detection settings", () => {
     expect(
       AppSettingsSchema.parse(precise).inpainting?.bubbleDetectionMode,
     ).toBe("precise");
+    expect(quality.inpainting?.bubbleDetectionMode).toBe("quality");
+    expect(sam3.inpainting?.bubbleDetectionMode).toBe("sam3-experimental");
   });
 
   it("falls back to auto for an unknown stored value", () => {

--- a/tests/bubbleQualityRecovery.test.ts
+++ b/tests/bubbleQualityRecovery.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  findBubbleRecoveryHints,
+  mergeRecoveredBubbleMask,
+} from "../src/main/inpainting/bubbleQualityRecovery";
+import type { MangaPage } from "../src/shared/libraryTypes";
+
+describe("conditional highest-quality bubble recovery", () => {
+  it("selects only missing or undersized precise masks", () => {
+    const page = createPage();
+    const mask = new Uint8Array(page.width * page.height);
+    fillMask(mask, page.width, 1, { x: 3, y: 3, w: 34, h: 34 });
+    fillMask(mask, page.width, 2, { x: 49, y: 17, w: 9, h: 18 });
+
+    const hints = findBubbleRecoveryHints(page, mask);
+
+    expect(hints.map((hint) => hint.blockId)).toEqual(["weak", "missing"]);
+  });
+
+  it("replaces only recovered failed regions and keeps good masks intact", () => {
+    const page = createPage();
+    const base = new Uint8Array(page.width * page.height);
+    fillMask(base, page.width, 1, { x: 3, y: 3, w: 34, h: 34 });
+    fillMask(base, page.width, 2, { x: 49, y: 17, w: 9, h: 18 });
+    const hints = findBubbleRecoveryHints(page, base);
+    const recovered = new Uint8Array(base.length);
+    fillMask(recovered, page.width, 1, { x: 42, y: 5, w: 34, h: 38 });
+    fillMask(recovered, page.width, 2, { x: 79, y: 5, w: 19, h: 38 });
+
+    const result = mergeRecoveredBubbleMask(base, recovered, page, hints);
+
+    expect(result.recoveredBlocks).toBe(2);
+    expect(result.mask[10 * page.width + 10]).toBe(1);
+    expect(result.mask[20 * page.width + 50]).not.toBe(2);
+    expect(result.mask[10 * page.width + 50]).toBeGreaterThan(2);
+    expect(result.mask[10 * page.width + 90]).toBeGreaterThan(2);
+  });
+
+  it("ignores an empty recovery result", () => {
+    const page = createPage();
+    const base = new Uint8Array(page.width * page.height);
+    const hints = findBubbleRecoveryHints(page, base);
+
+    const result = mergeRecoveredBubbleMask(
+      base,
+      new Uint8Array(base.length),
+      page,
+      hints,
+    );
+
+    expect(result.recoveredBlocks).toBe(0);
+    expect(result.mask).toEqual(base);
+  });
+});
+
+function createPage(): MangaPage {
+  return {
+    id: "page",
+    name: "page.png",
+    imagePath: "page.png",
+    dataUrl: "",
+    width: 100,
+    height: 50,
+    blocks: [
+      createBlock("good", 15),
+      createBlock("weak", 50),
+      createBlock("missing", 86),
+    ],
+    analysisStatus: "idle",
+    createdAt: "2026-07-20T00:00:00.000Z",
+    updatedAt: "2026-07-20T00:00:00.000Z",
+  };
+}
+
+function createBlock(id: string, x: number): MangaPage["blocks"][number] {
+  return {
+    id,
+    type: "nonsolid",
+    bbox: { x, y: 18, w: 8, h: 16 },
+    bboxSpace: "pixels",
+    sourceText: "text",
+    translatedText: "번역",
+    confidence: 1,
+    sourceDirection: "vertical",
+    renderDirection: "horizontal",
+    fontSizePx: 12,
+    lineHeight: 1.2,
+    textAlign: "center",
+    textColor: "#000000",
+    backgroundColor: "#ffffff",
+    opacity: 1,
+  };
+}
+
+function fillMask(
+  mask: Uint8Array,
+  width: number,
+  id: number,
+  rect: { x: number; y: number; w: number; h: number },
+): void {
+  for (let y = rect.y; y < rect.y + rect.h; y += 1) {
+    mask.fill(id, y * width + rect.x, y * width + rect.x + rect.w);
+  }
+}

--- a/tests/bubbleQualityRuntime.test.ts
+++ b/tests/bubbleQualityRuntime.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveAvailableBubbleQualityModel,
+  resolveBubbleQualityTorchDevice,
+} from "../src/main/inpainting/bubbleQualityRuntime";
+
+const originalToken = process.env.HF_TOKEN;
+
+afterEach(() => {
+  if (originalToken === undefined) delete process.env.HF_TOKEN;
+  else process.env.HF_TOKEN = originalToken;
+});
+
+describe("bubble highest-quality runtime policy", () => {
+  it("uses SAM 2.1 for the normal highest-quality mode on every backend", () => {
+    expect(resolveAvailableBubbleQualityModel("sam2.1", "cuda-native")).toBe(
+      "sam2.1",
+    );
+    expect(resolveAvailableBubbleQualityModel("sam2.1", "metal-native")).toBe(
+      "sam2.1",
+    );
+  });
+
+  it("allows experimental SAM 3 only with NVIDIA and an explicit token", () => {
+    process.env.HF_TOKEN = "approved-token";
+    expect(resolveAvailableBubbleQualityModel("sam3", "cuda-native")).toBe(
+      "sam3",
+    );
+    expect(resolveAvailableBubbleQualityModel("sam3", "metal-native")).toBe(
+      "sam2.1",
+    );
+
+    delete process.env.HF_TOKEN;
+    expect(resolveAvailableBubbleQualityModel("sam3", "cuda-native")).toBe(
+      "sam2.1",
+    );
+  });
+
+  it("maps native backends to safe PyTorch devices", () => {
+    expect(resolveBubbleQualityTorchDevice("cuda-native")).toBe("cuda");
+    expect(resolveBubbleQualityTorchDevice("metal-native")).toBe("mps");
+    expect(resolveBubbleQualityTorchDevice("zluda-native")).toBe("cpu");
+    expect(resolveBubbleQualityTorchDevice("cpu")).toBe("cpu");
+  });
+});

--- a/tests/bubbleRenderLayout.test.ts
+++ b/tests/bubbleRenderLayout.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { bboxToPixels } from "../src/shared/geometry";
+import type { MangaPage } from "../src/shared/libraryTypes";
+import type { BBox, TranslationBlock } from "../src/shared/textTypes";
+import {
+  applyBubbleRenderLayouts,
+  resolveAutomaticRenderBbox,
+} from "../src/main/inpainting/bubbleRenderLayout";
+
+describe("bubble-aware translation layout", () => {
+  it("expands a narrow vertical source block into a wide horizontal bubble area", () => {
+    const page = createPage([
+      createBlock("vertical-source", { x: 45, y: 28, w: 10, h: 40 }),
+    ]);
+    const mask = createMask(page.width, page.height, [
+      { id: 1, x: 8, y: 10, w: 84, h: 72 },
+    ]);
+
+    const result = applyBubbleRenderLayouts(page, mask);
+    const block = result.blocks[0];
+    expect(block.renderBbox).toBeDefined();
+    if (!block.renderBbox) throw new Error("render bbox was not generated");
+    const renderPixels = bboxToPixels(
+      block.renderBbox,
+      page.width,
+      page.height,
+    );
+
+    expect(result.expandedBlocks).toBe(1);
+    expect(block.bbox).toEqual(page.blocks[0].bbox);
+    expect(block.renderBboxSpace).toBe("normalized_1000");
+    expect(block.autoFitText).toBe(true);
+    expect(renderPixels.w).toBeGreaterThan(70);
+    expect(renderPixels.w).toBeGreaterThan(renderPixels.h);
+    expect(renderPixels.x).toBeGreaterThanOrEqual(10);
+    expect(renderPixels.x + renderPixels.w).toBeLessThanOrEqual(90);
+  });
+
+  it("preserves a manually adjusted render box", () => {
+    const manual = { x: 100, y: 200, w: 500, h: 250 };
+    const page = createPage([
+      {
+        ...createBlock("manual", { x: 45, y: 28, w: 10, h: 40 }),
+        renderBbox: manual,
+        renderBboxSpace: "normalized_1000",
+      },
+    ]);
+    const mask = createMask(page.width, page.height, [
+      { id: 1, x: 8, y: 10, w: 84, h: 72 },
+    ]);
+
+    const result = applyBubbleRenderLayouts(page, mask);
+
+    expect(result.expandedBlocks).toBe(0);
+    expect(result.blocks[0]).toBe(page.blocks[0]);
+    expect(result.blocks[0].renderBbox).toEqual(manual);
+  });
+
+  it("keeps adjacent split-bubble layouts inside their assigned regions", () => {
+    const page = createPage([
+      {
+        ...createBlock("left", { x: 22, y: 30, w: 8, h: 32 }),
+        fontSizePx: 10,
+      },
+      {
+        ...createBlock("right", { x: 70, y: 30, w: 8, h: 32 }),
+        fontSizePx: 10,
+      },
+    ]);
+    const mask = createMask(page.width, page.height, [
+      { id: 1, x: 4, y: 12, w: 44, h: 68 },
+      { id: 2, x: 52, y: 12, w: 44, h: 68 },
+    ]);
+
+    const result = applyBubbleRenderLayouts(page, mask);
+    const renderBoxes = result.blocks.map((block) => block.renderBbox);
+    expect(renderBoxes.every(Boolean)).toBe(true);
+    if (!renderBoxes[0] || !renderBoxes[1]) {
+      throw new Error("split bubble render boxes were not generated");
+    }
+    const left = bboxToPixels(renderBoxes[0], page.width, page.height);
+    const right = bboxToPixels(renderBoxes[1], page.width, page.height);
+
+    expect(result.expandedBlocks).toBe(2);
+    expect(left.x + left.w).toBeLessThan(right.x);
+    expect(left.x).toBeGreaterThanOrEqual(6);
+    expect(right.x + right.w).toBeLessThanOrEqual(94);
+  });
+
+  it("does not create a render box without translated horizontal text", () => {
+    const mask = createMask(100, 100, [{ id: 1, x: 8, y: 10, w: 84, h: 72 }]);
+    const emptyText = createBlock("empty", { x: 45, y: 28, w: 10, h: 40 });
+    emptyText.translatedText = "";
+    const vertical = {
+      ...createBlock("vertical", { x: 45, y: 28, w: 10, h: 40 }),
+      renderDirection: "vertical" as const,
+    };
+
+    expect(
+      resolveAutomaticRenderBbox(createPage([emptyText]), emptyText, mask),
+    ).toBeNull();
+    expect(
+      resolveAutomaticRenderBbox(createPage([vertical]), vertical, mask),
+    ).toBeNull();
+  });
+});
+
+function createPage(blocks: TranslationBlock[]): MangaPage {
+  return {
+    id: "page",
+    name: "page.png",
+    imagePath: "page.png",
+    dataUrl: "",
+    width: 100,
+    height: 100,
+    blocks,
+    analysisStatus: "idle",
+    createdAt: "2026-07-20T00:00:00.000Z",
+    updatedAt: "2026-07-20T00:00:00.000Z",
+  };
+}
+
+function createBlock(id: string, bbox: BBox): TranslationBlock {
+  return {
+    id,
+    type: "nonsolid",
+    bbox,
+    bboxSpace: "pixels",
+    sourceText: "縦書き",
+    translatedText: "가로로 자연스럽게 번역된 문장",
+    confidence: 1,
+    sourceDirection: "vertical",
+    renderDirection: "horizontal",
+    fontSizePx: 12,
+    lineHeight: 1.2,
+    textAlign: "center",
+    textColor: "#000000",
+    backgroundColor: "#ffffff",
+    opacity: 1,
+  };
+}
+
+function createMask(
+  width: number,
+  height: number,
+  regions: Array<{
+    id: number;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  }>,
+): Uint8Array {
+  const mask = new Uint8Array(width * height);
+  for (const region of regions) {
+    for (let y = region.y; y < region.y + region.h; y += 1) {
+      mask.fill(
+        region.id,
+        y * width + region.x,
+        y * width + region.x + region.w,
+      );
+    }
+  }
+  return mask;
+}

--- a/tests/hardwareSettingsPanel.test.tsx
+++ b/tests/hardwareSettingsPanel.test.tsx
@@ -1,7 +1,13 @@
 /** @vitest-environment jsdom */
 
 import React from "react";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HardwareSettingsPanel } from "../src/renderer/src/components/settingsModal/HardwareSettingsPanel";
 
@@ -45,5 +51,43 @@ describe("HardwareSettingsPanel", () => {
     expect(
       buttons.every((button) => (button as HTMLButtonElement).disabled),
     ).toBe(true);
+  });
+
+  it("shows highest quality and restricts experimental SAM 3 to NVIDIA", () => {
+    const setBubbleDetectionMode = vi.fn();
+    render(
+      <HardwareSettingsPanel
+        allowUnsafeLowMemoryFlux={false}
+        bubbleDetectionMode="quality"
+        clearTestState={vi.fn()}
+        controlsBusy={false}
+        fluxBackend="metal-native"
+        inpaintingModel="flux-klein"
+        isFluxBackendOptionDisabled={() => false}
+        ocrDevice="cpu"
+        ocrGpuBackend="cuda"
+        ocrQualityMode="minimum"
+        setFluxBackend={vi.fn()}
+        setAllowUnsafeLowMemoryFlux={vi.fn()}
+        setBubbleDetectionMode={setBubbleDetectionMode}
+        setInpaintingModel={vi.fn()}
+        setOcrDevice={vi.fn()}
+        setOcrGpuBackend={vi.fn()}
+        setOcrQualityMode={vi.fn()}
+        usesAmdHardware={false}
+        usesAppleHardware
+        usesAmdOcrContext={false}
+        usesNvidiaHardware={false}
+        usesNvidiaOcrContext={false}
+        unifiedMemoryMb={24_576}
+      />,
+    );
+
+    const highest = screen.getByRole("button", { name: "최고 품질" });
+    const sam3 = screen.getByRole("button", { name: "SAM 3 실험" });
+    expect(highest.getAttribute("aria-pressed")).toBe("true");
+    expect((sam3 as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(highest);
+    expect(setBubbleDetectionMode).toHaveBeenCalledWith("quality");
   });
 });

--- a/tests/hybridBubbleCleaning.test.ts
+++ b/tests/hybridBubbleCleaning.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyLightweightBubbleFill,
+  resolveFlatBubbleFill,
+  resolveLightweightBubbleFill,
+} from "../src/main/inpainting/hybridBubbleCleaning";
+
+describe("lightweight bubble fill", () => {
+  it("reconstructs a smooth color gradient without a generative engine", () => {
+    const width = 64;
+    const height = 48;
+    const bitmap = createBitmap(width, height, (x, y) => ({
+      r: 90 + (60 * x) / (width - 1) + (10 * y) / (height - 1),
+      g: 110 + (20 * x) / (width - 1) + (30 * y) / (height - 1),
+      b: 150 - (20 * x) / (width - 1) + (10 * y) / (height - 1),
+    }));
+    const mask = centerMask(width, height);
+    paintMask(bitmap, width, mask, { r: 0, g: 0, b: 0 });
+
+    expect(
+      resolveFlatBubbleFill(
+        bitmap,
+        width,
+        { x: 0, y: 0, w: width, h: height },
+        mask,
+      ),
+    ).toBeNull();
+    const fill = resolveLightweightBubbleFill(
+      bitmap,
+      width,
+      { x: 0, y: 0, w: width, h: height },
+      mask,
+    );
+    expect(fill).toMatchObject({ inlierRatio: 1, sampleCount: 2880 });
+    expect(fill?.rmse).toBeLessThan(1);
+    if (!fill) throw new Error("Expected a lightweight fill.");
+
+    applyLightweightBubbleFill(
+      bitmap,
+      width,
+      { x: 0, y: 0, w: width, h: height },
+      mask,
+      fill,
+    );
+    expect(readRgb(bitmap, width, 32, 24)).toEqual({
+      r: 126,
+      g: 135,
+      b: 145,
+    });
+  });
+
+  it("rejects textured backgrounds so they are promoted to the engine", () => {
+    const width = 64;
+    const height = 48;
+    const bitmap = createBitmap(width, height, (x, y) => {
+      const value = (x + y) % 2 === 0 ? 30 : 220;
+      return { r: value, g: 255 - value, b: value };
+    });
+    const mask = centerMask(width, height);
+    paintMask(bitmap, width, mask, { r: 0, g: 0, b: 0 });
+
+    expect(
+      resolveLightweightBubbleFill(
+        bitmap,
+        width,
+        { x: 0, y: 0, w: width, h: height },
+        mask,
+      ),
+    ).toBeNull();
+  });
+});
+
+function createBitmap(
+  width: number,
+  height: number,
+  colorAt: (x: number, y: number) => { r: number; g: number; b: number },
+): Buffer {
+  const bitmap = Buffer.alloc(width * height * 4);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      writeRgb(bitmap, width, x, y, colorAt(x, y));
+    }
+  }
+  return bitmap;
+}
+
+function centerMask(width: number, height: number): Uint8Array {
+  const mask = new Uint8Array(width * height);
+  for (let y = 18; y < 30; y += 1) {
+    for (let x = 24; x < 40; x += 1) mask[y * width + x] = 1;
+  }
+  return mask;
+}
+
+function paintMask(
+  bitmap: Buffer,
+  width: number,
+  mask: Uint8Array,
+  color: { r: number; g: number; b: number },
+): void {
+  for (let index = 0; index < mask.length; index += 1) {
+    if (!mask[index]) continue;
+    writeRgb(bitmap, width, index % width, Math.floor(index / width), color);
+  }
+}
+
+function writeRgb(
+  bitmap: Buffer,
+  width: number,
+  x: number,
+  y: number,
+  color: { r: number; g: number; b: number },
+): void {
+  const offset = (y * width + x) * 4;
+  bitmap[offset] = Math.round(color.b);
+  bitmap[offset + 1] = Math.round(color.g);
+  bitmap[offset + 2] = Math.round(color.r);
+  bitmap[offset + 3] = 255;
+}
+
+function readRgb(
+  bitmap: Buffer,
+  width: number,
+  x: number,
+  y: number,
+): { r: number; g: number; b: number } {
+  const offset = (y * width + x) * 4;
+  return {
+    r: bitmap[offset + 2],
+    g: bitmap[offset + 1],
+    b: bitmap[offset],
+  };
+}

--- a/tests/patternPageMask.test.ts
+++ b/tests/patternPageMask.test.ts
@@ -42,6 +42,35 @@ describe("pattern page block-owned masks", () => {
     expect(context.pageMask[centers[0].y * width + centers[0].x]).toBe(1);
     expect(context.pageMask[centers[1].y * width + centers[1].x]).toBe(1);
   });
+
+  it("finishes smooth gradient text removal in the lightweight stage", () => {
+    const width = 128;
+    const height = 96;
+    const page = createSingleBlockPage(width, height);
+    const bitmap = createGradientBitmap(width, height);
+    for (let y = 38; y < 58; y += 1) {
+      for (let x = 54; x < 74; x += 1) {
+        if (x % 5 < 2 || y % 7 < 2) writeRgb(bitmap, width, x, y, 0, 0, 0);
+      }
+    }
+
+    const context = buildPatternPageMask({
+      page,
+      bitmap,
+      width,
+      height,
+      bubbleMask: new Uint8Array(width * height),
+    });
+
+    expect(context).toMatchObject({
+      blocksErased: 1,
+      directFillBlocks: 0,
+      lightweightFillBlocks: 1,
+      engineBlocks: 0,
+    });
+    expect(context.inpaintWindows).toHaveLength(0);
+    expect(readRgb(bitmap, width, 64, 48)).not.toEqual({ r: 0, g: 0, b: 0 });
+  });
 });
 
 function createPage(width: number, height: number): MangaPage {
@@ -56,6 +85,66 @@ function createPage(width: number, height: number): MangaPage {
     analysisStatus: "idle",
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function createSingleBlockPage(width: number, height: number): MangaPage {
+  return {
+    ...createPage(width, height),
+    blocks: [
+      {
+        ...createBlock("block-gradient", 420),
+        bbox: { x: 420, y: 360, w: 160, h: 280 },
+      },
+    ],
+  };
+}
+
+function createGradientBitmap(width: number, height: number): Buffer {
+  const bitmap = Buffer.alloc(width * height * 4);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      writeRgb(
+        bitmap,
+        width,
+        x,
+        y,
+        90 + (60 * x) / (width - 1),
+        110 + (30 * y) / (height - 1),
+        150 - (20 * x) / (width - 1),
+      );
+    }
+  }
+  return bitmap;
+}
+
+function writeRgb(
+  bitmap: Buffer,
+  width: number,
+  x: number,
+  y: number,
+  r: number,
+  g: number,
+  b: number,
+): void {
+  const offset = (y * width + x) * 4;
+  bitmap[offset] = Math.round(b);
+  bitmap[offset + 1] = Math.round(g);
+  bitmap[offset + 2] = Math.round(r);
+  bitmap[offset + 3] = 255;
+}
+
+function readRgb(
+  bitmap: Buffer,
+  width: number,
+  x: number,
+  y: number,
+): { r: number; g: number; b: number } {
+  const offset = (y * width + x) * 4;
+  return {
+    r: bitmap[offset + 2],
+    g: bitmap[offset + 1],
+    b: bitmap[offset],
   };
 }
 

--- a/tests/patternWindowPolicy.test.ts
+++ b/tests/patternWindowPolicy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { InpaintingEngine } from "../src/main/inpainting/inpaintingEngine";
-import { resolvePatternInpaintWindows } from "../src/main/inpainting/patternWindowPolicy";
+import {
+  resolveInpaintingBackendPolicy,
+  resolvePatternInpaintWindows,
+} from "../src/main/inpainting/patternWindowPolicy";
 
 function createEngine(
   model: InpaintingEngine["model"],
@@ -32,19 +35,16 @@ describe("resolvePatternInpaintWindows", () => {
     expect(resolved[0]).not.toBe(touchingWindows[0]);
   });
 
-  it.each([
-    ["flux-klein", "cuda-native"],
-    ["lama-manga", "metal-native"],
-  ] as const)("merges windows for %s on %s", (model, backend) => {
+  it("keeps Flux CUDA windows separate for owned-mask processing", () => {
     expect(
       resolvePatternInpaintWindows(
         touchingWindows,
-        createEngine(model, backend),
+        createEngine("flux-klein", "cuda-native"),
       ),
-    ).toEqual([{ x: 0, y: 0, w: 40, h: 20 }]);
+    ).toEqual(touchingWindows);
   });
 
-  it("merges transitive overlap into a single window", () => {
+  it("merges transitive overlap for the Koharu whole-page path", () => {
     expect(
       resolvePatternInpaintWindows(
         [
@@ -52,8 +52,64 @@ describe("resolvePatternInpaintWindows", () => {
           { x: 20, y: 0, w: 10, h: 10 },
           { x: 9, y: 0, w: 12, h: 10 },
         ],
-        createEngine("flux-klein", "cuda-native"),
+        createEngine("lama-manga", "cuda"),
       ),
     ).toEqual([{ x: 0, y: 0, w: 30, h: 10 }]);
+  });
+
+  it("snapshots backend policies independently", () => {
+    expect({
+      cuda: resolveInpaintingBackendPolicy(
+        createEngine("flux-klein", "cuda-native"),
+      ),
+      koharu: resolveInpaintingBackendPolicy(
+        createEngine("lama-manga", "cuda"),
+      ),
+      metal: resolveInpaintingBackendPolicy(
+        createEngine("flux-klein", "metal-native"),
+      ),
+    }).toMatchInlineSnapshot(`
+      {
+        "cuda": {
+          "bubbleMaskStrategy": "omit",
+          "contextPx": 160,
+          "cropStrategy": "scaled-to-budget",
+          "enginePath": "flux",
+          "featherPx": 8,
+          "maskPaddingPx": 16,
+          "maskStrategy": "owned",
+          "maxContextPx": null,
+          "maxCropSizePx": null,
+          "maxPixels": 1048576,
+          "windowStrategy": "preserve",
+        },
+        "koharu": {
+          "bubbleMaskStrategy": "forward",
+          "contextPx": 160,
+          "cropStrategy": "whole-page",
+          "enginePath": "koharu",
+          "featherPx": 8,
+          "maskPaddingPx": 16,
+          "maskStrategy": "owned",
+          "maxContextPx": null,
+          "maxCropSizePx": null,
+          "maxPixels": 1048576,
+          "windowStrategy": "merge",
+        },
+        "metal": {
+          "bubbleMaskStrategy": "omit",
+          "contextPx": 96,
+          "cropStrategy": "tiled-native",
+          "enginePath": "flux",
+          "featherPx": 8,
+          "maskPaddingPx": 16,
+          "maskStrategy": "owned",
+          "maxContextPx": 96,
+          "maxCropSizePx": 512,
+          "maxPixels": 1048576,
+          "windowStrategy": "preserve",
+        },
+      }
+    `);
   });
 });


### PR DESCRIPTION
## Summary
- add a Highest quality mode above Precise that runs the existing precise segmenter first
- invoke RT-DETR plus SAM 2.1 only for missing or undersized bubble regions, preserving successful precise masks
- expose SAM 3 as an NVIDIA-only experimental mode with gated-token checks and a safe SAM 2.1 fallback
- expand horizontal translation render regions inside detected speech bubbles while preserving manual render boxes
- include hybrid flat/gradient cleaning, Otsu recovery, and speech-bubble boundary protection
- automatically prepare the packaged Python runtime, dependencies, and pinned Hugging Face model revisions on first use

## References
- https://github.com/meangrinch/MangaTranslator
- https://huggingface.co/ogkalu/comic-text-and-bubble-detector
- https://huggingface.co/facebook/sam2.1-hiera-large
- https://huggingface.co/facebook/sam3

## Verification
- full test suite: 1,038 passed, 136 skipped
- npm run build
- npm run lint -- --no-cache
- npm run arch:deps
- npm run check:generated
- responsive production-component UI QA at wide and narrow viewports