### PR TITLE
feat(mac): accelerate PaddleOCR-VL with Apple MLX

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - 인터넷: 설치와 첫 모델 다운로드, Codex/API 사용에 필요합니다. 로컬 모델은 준비가 끝난 뒤 오프라인 작업이 가능합니다.
 - GPU가 없어도 일부 CPU 경로를 쓸 수 있지만 OCR, 로컬 번역, Flux 인페인팅은 크게 느릴 수 있습니다.
 
-Windows 설치 파일은 비교적 작게 유지됩니다. Apple Silicon 정식판에는 arm64 FFmpeg, Paddle OCR CPU용 Python 런타임과 Metal 실행 런타임이 포함되며 Gemma·OCR·인페인팅 모델 가중치만 첫 사용 시 체크섬 검증 후 내려받습니다. v1.6.5 macOS 빌드는 인증서 없이 ad-hoc 서명되어 Gatekeeper가 처음 실행을 차단하면 `시스템 설정 → 개인정보 보호 및 보안`에서 수동으로 승인해야 할 수 있습니다. macOS 데이터는 `~/Library/Application Support/manga-gemma-translator`에 저장됩니다.
+Windows 설치 파일은 비교적 작게 유지됩니다. Apple Silicon 정식판에는 arm64 FFmpeg, Paddle OCR·MLX-VLM Python 런타임과 Metal 실행 런타임이 포함되며 Gemma·OCR·인페인팅 모델 가중치만 첫 사용 시 체크섬 검증 후 내려받습니다. v1.6.5 macOS 빌드는 인증서 없이 ad-hoc 서명되어 Gatekeeper가 처음 실행을 차단하면 `시스템 설정 → 개인정보 보호 및 보안`에서 수동으로 승인해야 할 수 있습니다. macOS 데이터는 `~/Library/Application Support/manga-gemma-translator`에 저장됩니다.
 
 ## 빠른 시작
 
@@ -178,7 +178,7 @@ Gemma 프리셋은 대략 다음 순서로 시도할 수 있습니다.
 - VRAM 24GB 이상: `31B 풀로드`
 - 특수 구성: `커스텀`
 
-OCR 품질은 `최소`, `절약`, `풀로드`입니다. CPU에서는 `절약`부터 시작하는 편이 안정적이고, `풀로드` PaddleOCR-VL은 지원되는 GPU와 함께 쓰는 것을 권장합니다.
+OCR 품질은 `최소`, `절약`, `풀로드`입니다. CPU에서는 `절약`부터 시작하는 편이 안정적이고, `풀로드` PaddleOCR-VL은 NVIDIA CUDA 또는 Apple Silicon MLX/Metal GPU와 함께 쓰는 것을 권장합니다.
 
 <details>
 <summary><strong>OpenAI Codex 엔진 준비</strong></summary>
@@ -223,13 +223,13 @@ API 엔진은 Base URL에 `/chat/completions`를 붙여 이미지와 OCR 힌트�
 </details>
 
 <details>
-<summary><strong>NVIDIA와 AMD 경로</strong></summary>
+<summary><strong>GPU별 실행 경로</strong></summary>
 
-| 작업       | NVIDIA                      | AMD                   | 사용자가 고를 수 있는 대안 |
-| ---------- | --------------------------- | --------------------- | -------------------------- |
-| Gemma      | CUDA 12, RTX 50 전용 런타임 | ROCm 또는 Vulkan      | 더 작은 모델 프리셋        |
-| Paddle OCR | NVIDIA CUDA                 | 지원 GPU에서 AMD ROCm | CPU 최소/절약              |
-| Flux       | NVIDIA CUDA                 | ZLUDA + AMD HIP SDK   | CPU                        |
+| 작업       | NVIDIA                      | AMD                   | Apple Silicon                   | 사용자가 고를 수 있는 대안 |
+| ---------- | --------------------------- | --------------------- | ------------------------------- | -------------------------- |
+| Gemma      | CUDA 12, RTX 50 전용 런타임 | ROCm 또는 Vulkan      | Metal                           | 더 작은 모델 프리셋        |
+| Paddle OCR | NVIDIA CUDA                 | 지원 GPU에서 AMD ROCm | 풀로드 MLX/Metal, 최소·절약 CPU | CPU 최소/절약              |
+| Flux       | NVIDIA CUDA                 | ZLUDA + AMD HIP SDK   | Metal 네이티브                  | CPU                        |
 
 AMD Gemma는 GPU와 드라이버에 맞는 ROCm target을 자동으로 찾습니다. 자동 감지가 틀리면 고급 사용자는 예를 들어 다음처럼 지정할 수 있습니다.
 

--- a/docs/MAC_ALPHA_TEST_CHECKLIST.md
+++ b/docs/MAC_ALPHA_TEST_CHECKLIST.md
@@ -31,6 +31,7 @@
 ## OCR과 인페인팅
 
 - [ ] Paddle OCR CPU로 실제 만화 이미지 인식
+- [ ] PaddleOCR-VL 풀로드를 Apple GPU(MLX/Metal)로 실제 만화 이미지 인식
 - [ ] AOT Metal 실행, 실패 시 알림 후 CPU 재시도
 - [ ] LaMa Manga Metal 실행, 실패 시 알림 후 CPU 재시도
 - [ ] Flux Klein Metal 실행(다른 모델 또는 CPU로 몰래 변경되지 않음)

--- a/scripts/mac-runtime-manifest.cjs
+++ b/scripts/mac-runtime-manifest.cjs
@@ -15,6 +15,7 @@ const MAC_RUNTIME_MANIFEST = Object.freeze({
   ocrPackages: Object.freeze([
     "paddlepaddle==3.3.1",
     "paddleocr[doc-parser]==3.7.0",
+    "mlx-vlm==0.6.6",
   ]),
   llamaRuntimes: Object.freeze([
     Object.freeze({

--- a/scripts/prepare-mac-runtime.cjs
+++ b/scripts/prepare-mac-runtime.cjs
@@ -419,6 +419,34 @@ async function stagePythonAndPaddle() {
   const installRoot = path.dirname(path.dirname(extractedPython));
   await chmod(extractedPython, 0o755);
   assertArm64MachO(extractedPython);
+  const wheelhouse = path.join(workDir, "wheels-macos14-arm64");
+  await mkdir(wheelhouse, { recursive: true });
+  run(
+    extractedPython,
+    [
+      "-m",
+      "pip",
+      "download",
+      "--disable-pip-version-check",
+      "--no-cache-dir",
+      "--only-binary=:all:",
+      "--platform",
+      "macosx_14_0_arm64",
+      "--implementation",
+      "cp",
+      "--python-version",
+      "3.12",
+      "--abi",
+      "cp312",
+      "--dest",
+      wheelhouse,
+      ...MAC_RUNTIME_MANIFEST.ocrPackages,
+    ],
+    {
+      PYTHONNOUSERSITE: "1",
+      PIP_NO_CACHE_DIR: "1",
+    },
+  );
   run(
     extractedPython,
     [
@@ -427,6 +455,9 @@ async function stagePythonAndPaddle() {
       "install",
       "--disable-pip-version-check",
       "--no-cache-dir",
+      "--no-index",
+      "--find-links",
+      wheelhouse,
       ...MAC_RUNTIME_MANIFEST.ocrPackages,
     ],
     {
@@ -450,7 +481,7 @@ async function stagePythonAndPaddle() {
     stagedPython,
     [
       "-c",
-      "import importlib.metadata, platform, paddle; assert platform.machine() == 'arm64'; print(paddle.__version__, importlib.metadata.version('paddleocr'))",
+      "import importlib.metadata, platform, paddle; assert platform.machine() == 'arm64'; print(paddle.__version__, importlib.metadata.version('paddleocr'), importlib.metadata.version('mlx-vlm'))",
     ],
     { PYTHONNOUSERSITE: "1" },
   );

--- a/scripts/verify-mac-runtime-smokes.cjs
+++ b/scripts/verify-mac-runtime-smokes.cjs
@@ -231,6 +231,21 @@ async function verifyOcrImageSmoke(
   console.log(`[mac-smoke] Paddle OCR CPU detected ${hints.length} region(s)`);
 }
 
+/** @param {string} python @param {string} workRoot */
+function verifyMlxOcrRuntime(python, workRoot) {
+  const script = [
+    "import mlx.core as mx",
+    "import mlx_vlm.server",
+    "from paddleocr import PaddleOCRVL",
+    "assert mx.device_info(), 'MLX cannot access the Apple Metal device'",
+  ].join("; ");
+  run(python, ["-c", script], {
+    timeout: 5 * 60 * 1000,
+    env: buildSmokePythonEnv(workRoot),
+  });
+  console.log("[mac-smoke] Apple MLX-VLM OCR runtime import passed");
+}
+
 /** @param {string} runner @param {string} python @param {string} workRoot @param {ReturnType<typeof createSmokeImages>} images */
 async function verifyKoharuImageSmokes(runner, python, workRoot, images) {
   for (const asset of KOHARU_SMOKE_ASSETS) {
@@ -344,6 +359,7 @@ async function verifyMacRuntimeSmokes(options) {
   mkdirSync(workRoot, { recursive: true });
   try {
     const images = createSmokeImages(python, workRoot);
+    verifyMlxOcrRuntime(python, workRoot);
     await verifyOcrImageSmoke(
       options.appPath,
       toolsDir,

--- a/src/main/runtime/ocr/bbox-batch-pipeline.cjs
+++ b/src/main/runtime/ocr/bbox-batch-pipeline.cjs
@@ -184,10 +184,7 @@ async function runSingleProcessBatch(dependencies, context) {
 
 /** @param {Dependencies} dependencies @param {OcrBatchContext} context @param {unknown} error @returns {never} */
 function throwBatchGpuExecutionFailure(dependencies, context, error) {
-  if (
-    !dependencies.isOcrGpuRequested(context.batchOptions) ||
-    dependencies.resolveEffectiveOcrDevice(context.batchOptions) === "cpu"
-  ) {
+  if (!dependencies.isOcrGpuRequested(context.batchOptions)) {
     throw error;
   }
   const message = dependencies.buildPaddleOcrGpuFailureMessage(

--- a/src/main/runtime/ocr/bbox-single-pipeline.cjs
+++ b/src/main/runtime/ocr/bbox-single-pipeline.cjs
@@ -144,11 +144,7 @@ async function runProviderWithFailureHandling(
 
 /** @param {Dependencies} dependencies @param {string} provider @param {OcrBboxOptions} options */
 function isGpuExecutionFailure(dependencies, provider, options) {
-  return (
-    provider === "paddleocr-vl" &&
-    dependencies.isOcrGpuRequested(options) &&
-    dependencies.resolveEffectiveOcrDevice(options) !== "cpu"
-  );
+  return provider === "paddleocr-vl" && dependencies.isOcrGpuRequested(options);
 }
 
 /** @param {Dependencies} dependencies @param {OcrBboxOptions} options @param {unknown[]} diagnostics @param {unknown} error @returns {never} */

--- a/src/main/runtime/ocr/runtime-device.cjs
+++ b/src/main/runtime/ocr/runtime-device.cjs
@@ -21,6 +21,14 @@ const ROCM_BACKEND_ALIASES = new Set([
   "rocm-transformers",
   "transformers-rocm",
 ]);
+const MLX_BACKEND_ALIASES = new Set([
+  "mlx",
+  "metal",
+  "mps",
+  "apple",
+  "mlx-vlm",
+  "mlx-vlm-server",
+]);
 
 /** @param {RuntimeOptions} [options] @returns {boolean} */
 function isOcrGpuRequested(options = {}) {
@@ -35,7 +43,7 @@ function isOcrBlackwellCudaTag(options = {}) {
   );
 }
 
-/** @param {RuntimeOptions} [options] @returns {"cuda" | "rocm-transformers"} */
+/** @param {RuntimeOptions} [options] @returns {"cuda" | "rocm-transformers" | "mlx-vlm"} */
 function resolveOcrGpuBackend(options = /** @type {OcrConfigOptions} */ ({})) {
   const normalized = String(
     runtimeOverrideEnv("MANGA_TRANSLATOR_OCR_GPU_BACKEND", options) ??
@@ -47,7 +55,10 @@ function resolveOcrGpuBackend(options = /** @type {OcrConfigOptions} */ ({})) {
   if (CUDA_BACKEND_ALIASES.has(normalized)) {
     return "cuda";
   }
-  return ROCM_BACKEND_ALIASES.has(normalized) ? "rocm-transformers" : "cuda";
+  if (ROCM_BACKEND_ALIASES.has(normalized)) {
+    return "rocm-transformers";
+  }
+  return MLX_BACKEND_ALIASES.has(normalized) ? "mlx-vlm" : "cuda";
 }
 
 /** @param {RuntimeOptions} [options] @returns {string} */
@@ -87,6 +98,9 @@ function resolveOcrRuntimeVariant(options = {}) {
   if (resolveOcrGpuBackend(options) === "rocm-transformers") {
     return "gpu-rocm-transformers";
   }
+  if (resolveOcrGpuBackend(options) === "mlx-vlm") {
+    return "gpu-mlx-vlm";
+  }
   return `gpu-${resolveOcrGpuCudaTag(options)}`
     .replace(/[^a-z0-9._-]+/gi, "-")
     .toLowerCase();
@@ -120,11 +134,25 @@ function normalizeConfiguredOcrDevice(value) {
 function resolveEffectiveOcrDevice(
   options = /** @type {OcrConfigOptions} */ ({}),
 ) {
+  if (
+    isOcrGpuRequested(options) &&
+    resolveOcrGpuBackend(options) === "mlx-vlm"
+  ) {
+    // PaddlePaddle has no native Metal device. Layout/text detection stays on
+    // CPU while PaddleOCR-VL delegates vision-language recognition to MLX.
+    return "cpu";
+  }
   return resolveOcrDevice(options);
 }
 
 /** @param {RuntimeOptions} [options] @returns {string} */
 function resolveOcrDeviceLabel(options = {}) {
+  if (
+    isOcrGpuRequested(options) &&
+    resolveOcrGpuBackend(options) === "mlx-vlm"
+  ) {
+    return "APPLE GPU (MLX)";
+  }
   const device = resolveEffectiveOcrDevice(options);
   if (device !== "cpu") {
     return device.toUpperCase();
@@ -144,6 +172,9 @@ function resolvePaddleOcrImportCheckTimeoutMs(options = {}) {
     return 120000;
   }
   if (resolveOcrGpuBackend(options) === "rocm-transformers") {
+    return 300000;
+  }
+  if (resolveOcrGpuBackend(options) === "mlx-vlm") {
     return 300000;
   }
   return isOcrBlackwellCudaTag(options) ? 300000 : 180000;

--- a/src/main/runtime/ocr/runtime-environment.cjs
+++ b/src/main/runtime/ocr/runtime-environment.cjs
@@ -17,6 +17,7 @@
  *   hfHubCacheDir: string;
  *   dllSearchDirs: string[];
  *   ocrDevice: string;
+ *   effectiveOcrDevice: string;
  *   ocrGpuBackend: string;
  *   rocmGpuRequested: boolean;
  * }} OcrEnvContext
@@ -72,7 +73,7 @@ function buildOcrRuntimeEnv(
     ...buildHuggingFaceEnv(options, context),
     ...buildOcrDeviceEnv(options, context),
     ...buildPaddleOcrModeEnv(options, context.ocrDevice, context.ocrGpuBackend),
-    ...buildPaddleOcrCpuThreadEnv(options, context.ocrDevice),
+    ...buildPaddleOcrCpuThreadEnv(options, context.effectiveOcrDevice),
     ...buildRocmSafetyEnv(options, context.rocmGpuRequested),
     ...buildPythonRuntimeEnv(options, runtime, context),
   };
@@ -90,6 +91,7 @@ function createOcrEnvContext(options, runtime) {
   const includePackageDir =
     runtime?.includePackageDir ?? runtime?.usesTargetPackageDir ?? true;
   const ocrDevice = resolveOcrDevice(options);
+  const effectiveOcrDevice = resolveEffectiveOcrDevice(options);
   const ocrGpuBackend = resolveOcrGpuBackend(options);
   return {
     runtimeDir,
@@ -99,6 +101,7 @@ function createOcrEnvContext(options, runtime) {
     hfHubCacheDir,
     dllSearchDirs: buildOcrRuntimeDllSearchDirs(options, runtime, runtimeDir),
     ocrDevice,
+    effectiveOcrDevice,
     ocrGpuBackend,
     rocmGpuRequested:
       ocrGpuBackend === "rocm-transformers" && ocrDevice.startsWith("gpu"),

--- a/src/main/runtime/ocr/runtime-errors.cjs
+++ b/src/main/runtime/ocr/runtime-errors.cjs
@@ -11,6 +11,9 @@ const {
 
 /** @param {unknown} importMessage @param {RuntimeOptions} [options] @returns {string} */
 function buildPaddleOcrImportFailureMessage(importMessage, options = {}) {
+  if (isMlxGpu(options)) {
+    return buildMlxImportFailureMessage(importMessage);
+  }
   if (isRocmGpu(options)) {
     return buildRocmImportFailureMessage(importMessage);
   }
@@ -30,6 +33,21 @@ function buildPaddleOcrImportFailureMessage(importMessage, options = {}) {
     return `Paddle OCR 런타임 설치 후 검증이 시간 초과되었습니다.${resolvePaddleOcrTimeoutSuffix(options)} detail=${truncateText(importMessage, 1200)}`;
   }
   return buildGenericImportFailureMessage(importMessage, options);
+}
+
+/** @param {RuntimeOptions} options @returns {boolean} */
+function isMlxGpu(options) {
+  return (
+    isOcrGpuRequested(options) && resolveOcrGpuBackend(options) === "mlx-vlm"
+  );
+}
+
+/** @param {unknown} importMessage @returns {string} */
+function buildMlxImportFailureMessage(importMessage) {
+  const detail = importMessage
+    ? ` detail=${truncateText(importMessage, 1200)}`
+    : "";
+  return `Apple MLX OCR 런타임 검증에 실패했습니다. Apple Silicon, macOS 14 이상, 번들 MLX-VLM 런타임이 필요합니다. CPU로 처리하려면 설정에서 OCR 장치를 CPU로 직접 변경하세요.${detail}`;
 }
 
 /** @param {RuntimeOptions} options @returns {boolean} */
@@ -70,12 +88,18 @@ function resolvePaddleOcrTimeoutSuffix(options) {
   if (resolveOcrGpuBackend(options) === "rocm-transformers") {
     return " AMD ROCm/PyTorch GPU 검증이 제한 시간 안에 끝나지 않았습니다. Windows ROCm PyTorch 2.9.1/ROCm 7.2.1 지원 GPU와 드라이버를 확인하세요.";
   }
+  if (resolveOcrGpuBackend(options) === "mlx-vlm") {
+    return " Apple MLX/Metal GPU 검증이 제한 시간 안에 끝나지 않았습니다. macOS 14 이상과 사용 가능한 Apple Silicon GPU를 확인하세요.";
+  }
   return " CUDA GPU 검증이 제한 시간 안에 끝나지 않았습니다. RTX 50번대는 cu129 런타임을 사용하며 첫 실행 검증이 오래 걸릴 수 있지만, 반복되면 NVIDIA 드라이버/CUDA 12.9용 Paddle 런타임 호환성을 확인해야 합니다.";
 }
 
 /** @param {unknown} error @param {RuntimeOptions} [options] @returns {string} */
 function buildPaddleOcrGpuFailureMessage(error, options = {}) {
   const text = summarizeOcrErrorMessage(error);
+  if (resolveOcrGpuBackend(options) === "mlx-vlm") {
+    return buildMlxGpuFailureMessage(text);
+  }
   if (isGpuOutOfMemoryText(text)) {
     return `GPU 메모리(VRAM) 부족으로 OCR이 실패했습니다. 큰 페이지가 이어지거나 인페인팅 등 다른 GPU 작업과 겹치면 발생할 수 있습니다. GPU를 쓰는 다른 앱을 닫거나 설정에서 OCR 장치를 CPU로 직접 바꾸면 안정적입니다. detail=${truncateText(text, 1200)}`;
   }
@@ -92,6 +116,14 @@ function buildPaddleOcrGpuFailureMessage(error, options = {}) {
     return buildPaddleOcrBfloat16SafetensorsFailureMessage(text, options);
   }
   return `Paddle OCR GPU 실행에 실패했습니다. GPU 설정을 쓰려면 CUDA가 보이는 NVIDIA GPU Paddle 런타임이 필요합니다. CPU로 처리하려면 설정에서 OCR 장치를 CPU로 직접 바꾸거나, GPU를 계속 쓰려면 NVIDIA 드라이버/CUDA용 Paddle 런타임을 확인하세요. detail=${truncateText(text, 1200)}`;
+}
+
+/** @param {string} text @returns {string} */
+function buildMlxGpuFailureMessage(text) {
+  if (isGpuOutOfMemoryText(text)) {
+    return `Apple 통합 메모리 부족으로 MLX OCR이 실패했습니다. 다른 GPU 작업과 앱을 닫거나 설정에서 OCR 장치를 CPU로 직접 바꾸세요. detail=${truncateText(text, 1200)}`;
+  }
+  return `Apple MLX OCR 실행에 실패했습니다. Apple Silicon의 Metal 접근 권한과 번들 MLX-VLM 런타임을 확인하세요. CPU로 처리하려면 설정에서 OCR 장치를 CPU로 직접 변경하세요. detail=${truncateText(text, 1200)}`;
 }
 
 /** @param {string} text @returns {string} */
@@ -193,6 +225,9 @@ function summarizeOcrErrorMessage(error) {
 /** @param {RuntimeOptions} [options] @returns {string} */
 function buildPaddleOcrImportCheckScript(options = {}) {
   const device = resolveOcrDevice(options);
+  if (device.startsWith("gpu") && resolveOcrGpuBackend(options) === "mlx-vlm") {
+    return buildMlxImportCheckScript();
+  }
   if (
     device.startsWith("gpu") &&
     resolveOcrGpuBackend(options) === "rocm-transformers"
@@ -200,6 +235,19 @@ function buildPaddleOcrImportCheckScript(options = {}) {
     return buildRocmImportCheckScript();
   }
   return buildPaddleImportCheckScript(device);
+}
+
+/** @returns {string} */
+function buildMlxImportCheckScript() {
+  return [
+    "import importlib.util",
+    "missing = [name for name in ('paddle', 'paddlex', 'paddleocr', 'mlx', 'mlx_vlm') if importlib.util.find_spec(name) is None]",
+    "assert not missing, 'Missing Apple MLX OCR package(s): ' + ', '.join(missing)",
+    "import mlx.core as mx",
+    "assert mx.device_info(), 'Apple Metal device is not available to MLX'",
+    "from paddleocr import PaddleOCRVL, PaddleOCR",
+    "import mlx_vlm.server",
+  ].join("; ");
 }
 
 /** @returns {string} */

--- a/src/main/runtime/ocr/runtime-orchestrator.cjs
+++ b/src/main/runtime/ocr/runtime-orchestrator.cjs
@@ -29,6 +29,7 @@ const {
   isWindowsRocmOcrRuntimePathShortEnough,
   resolveBootstrapPython,
   resolveOcrDeviceLabel,
+  resolveOcrGpuBackend,
   resolveOcrInstallSignature,
   resolveOcrPipCacheDir,
   resolveOcrPythonPackageDir,
@@ -86,9 +87,11 @@ async function resolveBundledMacOcrRuntime(options) {
   if (process.platform !== "darwin" || process.arch !== "arm64") {
     return null;
   }
-  if (isOcrGpuRequested(options)) {
+  const mlxGpuRequested =
+    isOcrGpuRequested(options) && resolveOcrGpuBackend(options) === "mlx-vlm";
+  if (isOcrGpuRequested(options) && !mlxGpuRequested) {
     throw createOcrRuntimeError(
-      "Apple Silicon에는 GPU OCR 런타임이 없습니다. OCR 장치를 CPU로 직접 변경한 뒤 다시 실행하세요.",
+      "Apple Silicon에서는 Apple MLX OCR 백엔드만 GPU로 사용할 수 있습니다. OCR 장치를 Apple GPU (MLX)로 변경한 뒤 다시 실행하세요.",
       { step: "bundled-mac-gpu-ocr-unsupported" },
     );
   }
@@ -119,18 +122,16 @@ async function resolveBundledMacOcrRuntime(options) {
     options,
     "ocr_preparing",
     "Apple Silicon Paddle OCR 런타임 확인 중",
-    "번들된 CPU 런타임을 사용합니다.",
+    mlxGpuRequested
+      ? "번들된 Apple MLX/Metal 런타임을 사용합니다."
+      : "번들된 CPU 런타임을 사용합니다.",
   );
-  const importCheck = await checkPaddleOcrImport(
-    pythonPath,
-    { ...options, ocrDevice: "cpu" },
-    {
-      runtimeDir,
-      packageDir,
-      includePackageDir: false,
-      ...cachePaths,
-    },
-  );
+  const importCheck = await checkPaddleOcrImport(pythonPath, options, {
+    runtimeDir,
+    packageDir,
+    includePackageDir: false,
+    ...cachePaths,
+  });
   if (!importCheck.ok) {
     throw createOcrRuntimeError(
       `Apple Silicon용 번들 Paddle OCR 런타임을 불러오지 못했습니다: ${importCheck.message}`,
@@ -145,7 +146,9 @@ async function resolveBundledMacOcrRuntime(options) {
   }
   return finalizePaddleOcrRuntime(options, {
     runtimeDir,
-    runtimeVariant: "cpu-macos-arm64-bundled",
+    runtimeVariant: mlxGpuRequested
+      ? "gpu-mlx-vlm-macos-arm64-bundled"
+      : "cpu-macos-arm64-bundled",
     packageDir,
     pythonPath,
     prepared: true,

--- a/src/main/runtime/ocr/runtime-verification.cjs
+++ b/src/main/runtime/ocr/runtime-verification.cjs
@@ -108,6 +108,15 @@ function hasExpectedOcrPackages(packageDir, options = {}) {
       "safetensors",
     ]);
   }
+  if (isOcrGpuRequested(options) && backend === "mlx-vlm") {
+    return hasPackageDirectories(packageDir, [
+      "paddle",
+      "paddleocr",
+      "paddlex",
+      "mlx",
+      "mlx_vlm",
+    ]);
+  }
   const required = ["paddle", "paddleocr", "paddlex"];
   if (isOcrGpuRequested(options) && backend === "cuda") {
     required.push("nvidia");

--- a/src/main/runtime/paddleocr-vl-bboxes.py
+++ b/src/main/runtime/paddleocr-vl-bboxes.py
@@ -8,10 +8,18 @@ translation model still reads the source image as the authority.
 from __future__ import annotations
 
 import argparse
+import atexit
 import gc
 import json
 import os
+import socket
+import subprocess
 import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 try:
@@ -40,6 +48,7 @@ IGNORED_LABELS = {
 DLL_DIRECTORY_HANDLES = []
 TORCH_ROCM_SAFE_MODE_CONFIGURED = False
 SELECTED_CUDA_DEVICE_INDEX = None
+MLX_VLM_MODEL_REPO = "PaddlePaddle/PaddleOCR-VL-1.6"
 
 
 def configure_windows_dll_search_path() -> None:
@@ -58,7 +67,11 @@ def build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output", default=None, help="Output JSON path.")
     parser.add_argument("--batch", default=None, help="JSON batch manifest with image/output items.")
     parser.add_argument("--progress", default=None, help="Optional JSONL progress output path.")
-    parser.add_argument("--pipeline-version", default="v1.5", choices=["v1", "v1.5"])
+    parser.add_argument(
+        "--pipeline-version",
+        default="v1.5",
+        choices=["v1", "v1.5", "v1.6"],
+    )
     parser.add_argument("--device", default=None, help="Optional Paddle device, e.g. gpu:0 or cpu.")
     parser.add_argument(
         "--source-language",
@@ -133,25 +146,26 @@ def main() -> int:
           "or provide MANGA_TRANSLATOR_OCR_BBOX_CMD."
       ) from exc
 
-    pipeline = PaddleOCRVL(**build_pipeline_kwargs(args))
-    textline_detector = create_textline_detector(args)
-    try:
-      summaries = run_batch_pages(
-          args,
-          batch_items,
-          lambda item: write_page_bboxes(
-              image_path=Path(item["image"]),
-              output_path=Path(item["output"]),
-              pipeline=pipeline,
-              textline_detector=textline_detector,
-              args=args,
-          ),
-      )
-    finally:
-      close = getattr(pipeline, "close", None)
-      if callable(close):
-        close()
-      close_textline_detector(textline_detector)
+    with maybe_mlx_vlm_server(args) as mlx_server:
+      pipeline = PaddleOCRVL(**build_pipeline_kwargs(args, mlx_server))
+      textline_detector = create_textline_detector(args)
+      try:
+        summaries = run_batch_pages(
+            args,
+            batch_items,
+            lambda item: write_page_bboxes(
+                image_path=Path(item["image"]),
+                output_path=Path(item["output"]),
+                pipeline=pipeline,
+                textline_detector=textline_detector,
+                args=args,
+            ),
+        )
+      finally:
+        close = getattr(pipeline, "close", None)
+        if callable(close):
+          close()
+        close_textline_detector(textline_detector)
 
     print(json.dumps({"items": summaries, "count": len(summaries)}, ensure_ascii=False), flush=True)
     return 0
@@ -259,7 +273,7 @@ def load_batch_items(args: argparse.Namespace) -> list[dict]:
     return []
 
 
-def build_pipeline_kwargs(args: argparse.Namespace) -> dict:
+def build_pipeline_kwargs(args: argparse.Namespace, mlx_server=None) -> dict:
     if is_transformers_engine(args):
       raise RuntimeError("PaddleOCRVL bbox mode does not support the Transformers engine yet. Use --bbox-mode ocr.")
     pipeline_kwargs = {
@@ -275,7 +289,180 @@ def build_pipeline_kwargs(args: argparse.Namespace) -> dict:
     }
     if args.device:
       pipeline_kwargs["device"] = args.device
+    if is_mlx_vlm_backend():
+      if mlx_server is None:
+        raise RuntimeError("Apple MLX OCR requires a running MLX-VLM server.")
+      pipeline_kwargs.update(
+          {
+              "pipeline_version": "v1.6",
+              "vl_rec_backend": "mlx-vlm-server",
+              "vl_rec_server_url": mlx_server.url,
+              "vl_rec_api_model_name": mlx_server.model_name,
+          }
+      )
     return pipeline_kwargs
+
+
+def is_mlx_vlm_backend() -> bool:
+    return os.environ.get("MANGA_TRANSLATOR_OCR_GPU_BACKEND", "").strip().lower() in {
+        "mlx",
+        "metal",
+        "mps",
+        "apple",
+        "mlx-vlm",
+        "mlx-vlm-server",
+    }
+
+
+def resolve_mlx_vlm_model_name() -> str:
+    cache_home = os.environ.get("PADDLE_PDX_CACHE_HOME", "").strip()
+    if cache_home:
+      local_model = Path(cache_home) / "official_models" / "PaddleOCR-VL-1.6"
+      if (local_model / "config.json").is_file() and (local_model / "model.safetensors").is_file():
+        return str(local_model)
+    return MLX_VLM_MODEL_REPO
+
+
+def reserve_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+      listener.bind(("127.0.0.1", 0))
+      return int(listener.getsockname()[1])
+
+
+class MlxVlmServer:
+    def __init__(self) -> None:
+      self.port = reserve_loopback_port()
+      self.url = f"http://127.0.0.1:{self.port}/"
+      self.model_name = resolve_mlx_vlm_model_name()
+      self.process = None
+      self.log_file = None
+      self.log_path = None
+
+    def start(self) -> None:
+      temp_root = Path(os.environ.get("TMP") or tempfile.gettempdir())
+      temp_root.mkdir(parents=True, exist_ok=True)
+      self.log_file = tempfile.NamedTemporaryFile(
+          mode="w+",
+          encoding="utf-8",
+          prefix="manga-mlx-vlm-",
+          suffix=".log",
+          dir=temp_root,
+          delete=False,
+      )
+      self.log_path = Path(self.log_file.name)
+      command = [
+          sys.executable,
+          "-c",
+          build_mlx_server_watchdog_code(os.getpid()),
+          "--host",
+          "127.0.0.1",
+          "--port",
+          str(self.port),
+      ]
+      self.process = subprocess.Popen(
+          command,
+          stdin=subprocess.DEVNULL,
+          stdout=self.log_file,
+          stderr=subprocess.STDOUT,
+          env=os.environ.copy(),
+      )
+      atexit.register(self.close)
+      try:
+        self.wait_until_ready()
+      except Exception:
+        self.close()
+        raise
+
+    def wait_until_ready(self) -> None:
+      timeout_seconds = max(
+          10.0,
+          float(os.environ.get("MANGA_TRANSLATOR_MLX_VLM_START_TIMEOUT_SECONDS", "120")),
+      )
+      deadline = time.monotonic() + timeout_seconds
+      health_url = f"{self.url}health"
+      last_error = ""
+      while time.monotonic() < deadline:
+        if self.process is not None and self.process.poll() is not None:
+          raise RuntimeError(
+              f"MLX-VLM server exited before startup (code {self.process.returncode}). "
+              f"{self.read_log_tail()}"
+          )
+        try:
+          with urllib.request.urlopen(health_url, timeout=2) as response:
+            if 200 <= response.status < 300:
+              return
+        except (OSError, urllib.error.URLError) as exc:
+          last_error = str(exc)
+        time.sleep(0.2)
+      raise RuntimeError(
+          f"MLX-VLM server did not become ready within {timeout_seconds:.0f}s: {last_error}. "
+          f"{self.read_log_tail()}"
+      )
+
+    def read_log_tail(self) -> str:
+      if self.log_file is not None:
+        self.log_file.flush()
+      if self.log_path is None or not self.log_path.exists():
+        return "No MLX-VLM server log was produced."
+      text = self.log_path.read_text(encoding="utf-8", errors="replace")
+      return text[-4000:].strip()
+
+    def close(self) -> None:
+      process = self.process
+      self.process = None
+      if process is not None and process.poll() is None:
+        process.terminate()
+        try:
+          process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+          process.kill()
+          process.wait(timeout=5)
+      if self.log_file is not None:
+        self.log_file.close()
+        self.log_file = None
+      if self.log_path is not None:
+        try:
+          self.log_path.unlink(missing_ok=True)
+        except OSError:
+          pass
+        self.log_path = None
+      try:
+        atexit.unregister(self.close)
+      except Exception:
+        pass
+
+
+@contextmanager
+def maybe_mlx_vlm_server(args: argparse.Namespace):
+    if not is_mlx_vlm_backend():
+      yield None
+      return
+    if str(getattr(args, "device", "") or "").lower() != "cpu":
+      raise RuntimeError("Apple MLX OCR requires Paddle layout detection to use the CPU device.")
+    server = MlxVlmServer()
+    server.start()
+    try:
+      yield server
+    finally:
+      server.close()
+
+
+def build_mlx_server_watchdog_code(parent_pid: int) -> str:
+    """Stop the local server if the OCR worker is killed by its Node parent."""
+
+    return "\n".join(
+        [
+            "import os, threading, time",
+            f"parent_pid = {int(parent_pid)}",
+            "def watch_parent():",
+            "    while os.getppid() == parent_pid:",
+            "        time.sleep(1)",
+            "    os._exit(1)",
+            "threading.Thread(target=watch_parent, daemon=True).start()",
+            "from mlx_vlm.server.cli import main",
+            "main()",
+        ]
+    )
 
 
 def is_transformers_engine(args: argparse.Namespace) -> bool:

--- a/src/main/runtimeCapabilities.ts
+++ b/src/main/runtimeCapabilities.ts
@@ -53,7 +53,9 @@ export function buildRuntimeCapabilities({
     },
     ocr: {
       cpu: true,
-      gpu: platform === "win32",
+      gpu:
+        platform === "win32" ||
+        (platform === "darwin" && arch === "arm64" && supportsMetal),
     },
   };
 }

--- a/src/main/settings/appSettingsResolvers.ts
+++ b/src/main/settings/appSettingsResolvers.ts
@@ -100,6 +100,13 @@ export function resolveOcrGpuBackend(
   ) {
     return "rocm-transformers";
   }
+  if (
+    ["mlx", "metal", "mps", "apple", "mlx-vlm", "mlx-vlm-server"].includes(
+      normalized,
+    )
+  ) {
+    return "mlx-vlm";
+  }
   return fallback;
 }
 

--- a/src/main/settings/hardwareDefaults.ts
+++ b/src/main/settings/hardwareDefaults.ts
@@ -122,6 +122,12 @@ function resolveHardwareOcrDevice(
   if (!hasMinimumGemmaVram(info)) {
     return "cpu";
   }
+  if (info?.vendor === "apple") {
+    return resolveUnifiedMemoryMb(info) >= GEMMA_APPLE_FULL_UNIFIED_MEMORY_MB &&
+      ocrGpuBackend === "mlx-vlm"
+      ? "gpu"
+      : "cpu";
+  }
   return supportsHardwareOcrGpu(info, ocrGpuBackend) ? "gpu" : "cpu";
 }
 
@@ -131,7 +137,8 @@ function supportsHardwareOcrGpu(
 ): boolean {
   return (
     (info?.vendor !== "apple" && supportsNvidiaGpuDefaults(info)) ||
-    ocrGpuBackend === "rocm-transformers"
+    ocrGpuBackend === "rocm-transformers" ||
+    (info?.vendor === "apple" && ocrGpuBackend === "mlx-vlm")
   );
 }
 
@@ -218,6 +225,9 @@ function resolveHardwareOcrGpuCudaTag(info: DetectedGpuInfo | null): string {
 function resolveHardwareOcrGpuBackend(
   info: DetectedGpuInfo | null,
 ): OcrGpuBackend {
+  if (info?.vendor === "apple") {
+    return "mlx-vlm";
+  }
   // Only GPUs Windows PyTorch ROCm actually supports get the ROCm OCR
   // backend. Other AMD cards default to CPU OCR with the CUDA backend kept as
   // metadata; an explicit later GPU selection is preserved and fails loudly

--- a/src/renderer/src/components/settingsModal/HardwareSettingsPanel.tsx
+++ b/src/renderer/src/components/settingsModal/HardwareSettingsPanel.tsx
@@ -70,32 +70,19 @@ export function HardwareSettingsPanel({
   const { t } = useTranslation("components");
   return (
     <div className="settings-panel-stack">
-      <SettingsSection title={t("settings.hardware.ocrSection")}>
-        <div className="settings-subsection-stack">
-          <OcrQualitySettings
-            clearTestState={clearTestState}
-            controlsBusy={controlsBusy}
-            ocrQualityMode={ocrQualityMode}
-            setOcrDevice={setOcrDevice}
-            setOcrGpuBackend={setOcrGpuBackend}
-            setOcrQualityMode={setOcrQualityMode}
-            usesAmdOcrContext={usesAmdOcrContext}
-            usesAppleHardware={usesAppleHardware}
-            usesNvidiaOcrContext={usesNvidiaOcrContext}
-          />
-          <OcrDeviceSettings
-            clearTestState={clearTestState}
-            controlsBusy={controlsBusy}
-            ocrDevice={ocrDevice}
-            ocrGpuBackend={ocrGpuBackend}
-            setOcrDevice={setOcrDevice}
-            setOcrGpuBackend={setOcrGpuBackend}
-            usesAmdOcrContext={usesAmdOcrContext}
-            usesAppleHardware={usesAppleHardware}
-            usesNvidiaOcrContext={usesNvidiaOcrContext}
-          />
-        </div>
-      </SettingsSection>
+      <OcrSettingsSection
+        clearTestState={clearTestState}
+        controlsBusy={controlsBusy}
+        ocrDevice={ocrDevice}
+        ocrGpuBackend={ocrGpuBackend}
+        ocrQualityMode={ocrQualityMode}
+        setOcrDevice={setOcrDevice}
+        setOcrGpuBackend={setOcrGpuBackend}
+        setOcrQualityMode={setOcrQualityMode}
+        usesAmdOcrContext={usesAmdOcrContext}
+        usesAppleHardware={usesAppleHardware}
+        usesNvidiaOcrContext={usesNvidiaOcrContext}
+      />
       <SettingsSection title={t("settings.hardware.inpaintingSection")}>
         <div className="settings-subsection-stack">
           <InpaintingModelSettings
@@ -125,6 +112,33 @@ export function HardwareSettingsPanel({
   );
 }
 
+function OcrSettingsSection(
+  props: Pick<
+    HardwareSettingsPanelProps,
+    | "clearTestState"
+    | "controlsBusy"
+    | "ocrDevice"
+    | "ocrGpuBackend"
+    | "ocrQualityMode"
+    | "setOcrDevice"
+    | "setOcrGpuBackend"
+    | "setOcrQualityMode"
+    | "usesAmdOcrContext"
+    | "usesAppleHardware"
+    | "usesNvidiaOcrContext"
+  >,
+): React.JSX.Element {
+  const { t } = useTranslation("components");
+  return (
+    <SettingsSection title={t("settings.hardware.ocrSection")}>
+      <div className="settings-subsection-stack">
+        <OcrQualitySettings {...props} />
+        <OcrDeviceSettings {...props} />
+      </div>
+    </SettingsSection>
+  );
+}
+
 function OcrQualitySettings({
   clearTestState,
   controlsBusy,
@@ -151,9 +165,7 @@ function OcrQualitySettings({
   const activeOption = OCR_QUALITY_OPTIONS.find(
     (option) => option.id === ocrQualityMode,
   );
-  const visibleQualityOptions = usesAppleHardware
-    ? OCR_QUALITY_OPTIONS.filter((option) => option.id !== "full")
-    : OCR_QUALITY_OPTIONS;
+  const visibleQualityOptions = OCR_QUALITY_OPTIONS;
   return (
     <div className="settings-field-stack">
       <span>{t("settings.hardware.ocrQuality")}</span>
@@ -171,11 +183,15 @@ function OcrQualitySettings({
               clearTestState();
               if (option.id === "full") {
                 setOcrDevice("gpu");
-                if (usesAmdOcrContext) {
+                if (usesAppleHardware) {
+                  setOcrGpuBackend("mlx-vlm");
+                } else if (usesAmdOcrContext) {
                   setOcrGpuBackend("rocm-transformers");
                 } else if (usesNvidiaOcrContext) {
                   setOcrGpuBackend("cuda");
                 }
+              } else if (usesAppleHardware) {
+                setOcrDevice("cpu");
               }
               setOcrQualityMode(option.id);
             }}
@@ -193,36 +209,42 @@ function OcrQualitySettings({
   );
 }
 
-function OcrDeviceSettings({
-  clearTestState,
-  controlsBusy,
-  ocrDevice,
-  ocrGpuBackend,
-  setOcrDevice,
-  setOcrGpuBackend,
-  usesAmdOcrContext,
-  usesAppleHardware,
-  usesNvidiaOcrContext,
-}: Pick<
+type OcrDeviceSettingsProps = Pick<
   HardwareSettingsPanelProps,
   | "clearTestState"
   | "controlsBusy"
   | "ocrDevice"
   | "ocrGpuBackend"
+  | "ocrQualityMode"
   | "setOcrDevice"
   | "setOcrGpuBackend"
+  | "setOcrQualityMode"
   | "usesAmdOcrContext"
   | "usesAppleHardware"
   | "usesNvidiaOcrContext"
->): React.JSX.Element {
+>;
+
+function OcrDeviceSettings({
+  clearTestState,
+  controlsBusy,
+  ocrDevice,
+  ocrGpuBackend,
+  ocrQualityMode,
+  setOcrDevice,
+  setOcrGpuBackend,
+  setOcrQualityMode,
+  usesAmdOcrContext,
+  usesAppleHardware,
+  usesNvidiaOcrContext,
+}: OcrDeviceSettingsProps): React.JSX.Element {
   const { t } = useTranslation("components");
   const activeOcrOptionId = ocrDevice === "cpu" ? "cpu" : ocrGpuBackend;
   const activeOcrOption = OCR_DEVICE_OPTIONS.find(
     (option) => option.id === activeOcrOptionId,
   );
   const visibleOcrOptions = usesAppleHardware
-    ? OCR_DEVICE_OPTIONS.filter((option) => option.id === "cpu")
-    : OCR_DEVICE_OPTIONS;
+    ? OCR_DEVICE_OPTIONS.filter(({ id }) => id === "cpu" || id === "mlx-vlm")
+    : OCR_DEVICE_OPTIONS.filter((option) => option.id !== "mlx-vlm");
   const ocrDescription =
     usesAmdOcrContext && activeOcrOptionId === "rocm-transformers"
       ? t("settings.hardware.amdOcrExperimental")
@@ -244,11 +266,14 @@ function OcrDeviceSettings({
             type="button"
             className={`settings-preset-button ${activeOcrOptionId === option.id ? "active" : ""}`}
             onClick={() => {
-              clearTestState();
-              setOcrDevice(option.device);
-              if (option.gpuBackend) {
-                setOcrGpuBackend(option.gpuBackend);
-              }
+              selectOcrDeviceOption(option, {
+                clearTestState,
+                ocrQualityMode,
+                setOcrDevice,
+                setOcrGpuBackend,
+                setOcrQualityMode,
+                usesAppleHardware,
+              });
             }}
             disabled={isOcrOptionDisabled(
               option.id,
@@ -270,6 +295,32 @@ function OcrDeviceSettings({
       />
     </div>
   );
+}
+
+function selectOcrDeviceOption(
+  option: (typeof OCR_DEVICE_OPTIONS)[number],
+  context: Pick<
+    HardwareSettingsPanelProps,
+    | "clearTestState"
+    | "ocrQualityMode"
+    | "setOcrDevice"
+    | "setOcrGpuBackend"
+    | "setOcrQualityMode"
+    | "usesAppleHardware"
+  >,
+): void {
+  context.clearTestState();
+  context.setOcrDevice(option.device);
+  if (option.gpuBackend) context.setOcrGpuBackend(option.gpuBackend);
+  if (context.usesAppleHardware) {
+    context.setOcrQualityMode(
+      option.id === "mlx-vlm"
+        ? "full"
+        : context.ocrQualityMode === "full"
+          ? "economy"
+          : context.ocrQualityMode,
+    );
+  }
 }
 
 function FluxBackendSettings({

--- a/src/renderer/src/components/settingsModal/useSettingsRuntimeGuards.ts
+++ b/src/renderer/src/components/settingsModal/useSettingsRuntimeGuards.ts
@@ -52,7 +52,7 @@ export function useSettingsRuntimeGuards({
 
   useSettingsFocusEffect(values, refs);
   useOcrBackendGuard(values, setters, runtime);
-  useOcrQualityDeviceGuard(values, setters);
+  useOcrQualityDeviceGuard(values, setters, runtime);
   useLlamaRuntimeGuard(values, setters, initialSettings, runtime);
   useFluxBackendGuard(values, setters, initialSettings, runtime);
 
@@ -151,6 +151,14 @@ function useOcrBackendGuard(
   React.useEffect(() => {
     if (
       values.ocrDevice === "gpu" &&
+      runtime.usesAppleHardware &&
+      values.ocrGpuBackend !== "mlx-vlm"
+    ) {
+      setters.setOcrGpuBackend("mlx-vlm");
+      return;
+    }
+    if (
+      values.ocrDevice === "gpu" &&
       values.ocrGpuBackend === "cuda" &&
       runtime.usesAmdOcrContext
     ) {
@@ -159,13 +167,15 @@ function useOcrBackendGuard(
     }
     if (
       values.ocrDevice === "gpu" &&
-      values.ocrGpuBackend === "rocm-transformers" &&
+      (values.ocrGpuBackend === "rocm-transformers" ||
+        values.ocrGpuBackend === "mlx-vlm") &&
       runtime.usesNvidiaOcrContext
     ) {
       setters.setOcrGpuBackend("cuda");
     }
   }, [
     runtime.usesAmdOcrContext,
+    runtime.usesAppleHardware,
     runtime.usesNvidiaOcrContext,
     setters,
     values.ocrDevice,
@@ -176,14 +186,36 @@ function useOcrBackendGuard(
 function useOcrQualityDeviceGuard(
   values: SettingsFormValues,
   setters: SettingsFormSetters,
+  runtime: ReturnType<typeof resolveRuntimeContext>,
 ): void {
   React.useEffect(() => {
+    if (runtime.usesAppleHardware) {
+      if (values.ocrQualityMode === "full") {
+        if (values.ocrDevice !== "gpu") {
+          setters.setOcrDevice("gpu");
+        }
+        if (values.ocrGpuBackend !== "mlx-vlm") {
+          setters.setOcrGpuBackend("mlx-vlm");
+        }
+        return;
+      }
+      if (values.ocrDevice === "gpu" && values.ocrGpuBackend === "mlx-vlm") {
+        setters.setOcrDevice("cpu");
+      }
+      return;
+    }
     // 풀로드(PaddleOCR-VL) 품질은 CPU에서 못 쓸 만큼 느리므로 CPU 장치와
     // 조합되지 않도록 절약 품질로 강제한다.
     if (values.ocrDevice === "cpu" && values.ocrQualityMode === "full") {
       setters.setOcrQualityMode("economy");
     }
-  }, [setters, values.ocrDevice, values.ocrQualityMode]);
+  }, [
+    runtime.usesAppleHardware,
+    setters,
+    values.ocrDevice,
+    values.ocrGpuBackend,
+    values.ocrQualityMode,
+  ]);
 }
 
 function useLlamaRuntimeGuard(

--- a/src/renderer/src/components/settingsOptions.ts
+++ b/src/renderer/src/components/settingsOptions.ts
@@ -224,6 +224,13 @@ export const API_REASONING_OPTIONS: ApiReasoningOption[] = [
 
 export const OCR_DEVICE_OPTIONS: OcrDeviceOption[] = [
   {
+    id: "mlx-vlm",
+    labelKey: "settings.options.ocrDevices.mlx.label",
+    descriptionKey: "settings.options.ocrDevices.mlx.description",
+    device: "gpu",
+    gpuBackend: "mlx-vlm",
+  },
+  {
     id: "cuda",
     labelKey: "settings.options.ocrDevices.cuda.label",
     descriptionKey: "settings.options.ocrDevices.cuda.description",

--- a/src/shared/i18n/locales/en/components.json
+++ b/src/shared/i18n/locales/en/components.json
@@ -998,6 +998,10 @@
         "xhigh": "Very high"
       },
       "ocrDevices": {
+        "mlx": {
+          "label": "Apple GPU (MLX)",
+          "description": "Run PaddleOCR-VL recognition on the Apple Silicon GPU."
+        },
         "cuda": {
           "label": "NVIDIA CUDA",
           "description": "Run Paddle OCR on an NVIDIA GPU."
@@ -1191,7 +1195,7 @@
       "inpaintingModel": "Inpainting model",
       "amdOcrExperimental": "AMD GPU OCR is experimental. If it fails, you can switch only OCR to the CPU.",
       "ocrAmdNote": "NVIDIA CUDA OCR cannot be selected on AMD systems.",
-      "ocrAppleNote": "Paddle OCR uses the CPU runtime on Apple Silicon.",
+      "ocrAppleNote": "Minimum and Economy use the CPU; Full accelerates VL recognition with MLX/Metal.",
       "ocrNvidiaNote": "AMD ROCm OCR cannot be selected on NVIDIA systems.",
       "fluxAmdNote": "CUDA native is unavailable on the detected AMD GPU; choose ZLUDA or CPU.",
       "fluxAppleNote": "Only the native Metal backend is used on Apple Silicon. Flux recommends at least 16 GB unified memory.",

--- a/src/shared/i18n/locales/ja/components.json
+++ b/src/shared/i18n/locales/ja/components.json
@@ -988,6 +988,10 @@
         "xhigh": "非常に高い"
       },
       "ocrDevices": {
+        "mlx": {
+          "label": "Apple GPU (MLX)",
+          "description": "Apple Silicon GPUでPaddleOCR-VL認識を実行します。"
+        },
         "cuda": {
           "label": "NVIDIA CUDA",
           "description": "NVIDIA GPUでPaddle OCRを実行します。"
@@ -1181,7 +1185,7 @@
       "inpaintingModel": "インペインティングモデル",
       "amdOcrExperimental": "AMD GPU OCRは実験機能です。失敗した場合はOCRだけをCPUに切り替えられます。",
       "ocrAmdNote": "AMD環境ではNVIDIA CUDA OCRを選択できません。",
-      "ocrAppleNote": "Apple SiliconのPaddle OCRはCPUランタイムを使用します。",
+      "ocrAppleNote": "最小・節約はCPU、フルロードはMLX/MetalでVL認識を高速化します。",
       "ocrNvidiaNote": "NVIDIA環境ではAMD ROCm OCRを選択できません。",
       "fluxAmdNote": "検出されたAMD GPUではCUDAネイティブを使用できません。ZLUDAまたはCPUを選択してください。",
       "fluxAppleNote": "Apple SiliconではMetalネイティブのみ使用します。Fluxは16GB以上のユニファイドメモリを推奨します。",

--- a/src/shared/i18n/locales/ko/components.json
+++ b/src/shared/i18n/locales/ko/components.json
@@ -982,6 +982,10 @@
         "xhigh": "매우 높음"
       },
       "ocrDevices": {
+        "mlx": {
+          "label": "Apple GPU (MLX)",
+          "description": "Apple Silicon GPU에서 PaddleOCR-VL 인식을 실행합니다."
+        },
         "cuda": {
           "label": "NVIDIA CUDA",
           "description": "NVIDIA GPU에서 Paddle OCR을 실행합니다."
@@ -1175,7 +1179,7 @@
       "inpaintingModel": "인페인팅 모델",
       "amdOcrExperimental": "AMD OCR GPU는 실험 기능입니다. 실패하면 OCR만 CPU로 바꿀 수 있습니다.",
       "ocrAmdNote": "AMD 환경에서는 NVIDIA CUDA OCR을 선택할 수 없습니다.",
-      "ocrAppleNote": "Apple Silicon의 Paddle OCR은 CPU 런타임을 사용합니다.",
+      "ocrAppleNote": "최소·절약은 CPU, 풀로드는 MLX/Metal로 VL 인식을 가속합니다.",
       "ocrNvidiaNote": "NVIDIA 환경에서는 AMD ROCm OCR을 선택할 수 없습니다.",
       "fluxAmdNote": "감지된 AMD GPU에서는 CUDA 네이티브 백엔드를 쓸 수 없어 ZLUDA 또는 CPU 중에서 선택합니다.",
       "fluxAppleNote": "Apple Silicon에서는 Metal 네이티브 백엔드만 사용합니다. Flux는 통합 메모리 16GB 이상을 권장합니다.",

--- a/src/shared/i18n/locales/zh-Hans/components.json
+++ b/src/shared/i18n/locales/zh-Hans/components.json
@@ -966,6 +966,10 @@
         "xhigh": "非常高"
       },
       "ocrDevices": {
+        "mlx": {
+          "label": "Apple GPU (MLX)",
+          "description": "在Apple Silicon GPU上运行PaddleOCR-VL识别。"
+        },
         "cuda": {
           "label": "NVIDIA CUDA",
           "description": "在NVIDIA GPU上运行Paddle OCR。"
@@ -1144,7 +1148,7 @@
       "inpaintingModel": "图像修复模型",
       "amdOcrExperimental": "AMD GPU OCR为实验功能。如失败，可仅将OCR切换到CPU。",
       "ocrAmdNote": "AMD环境无法选择NVIDIA CUDA OCR。",
-      "ocrAppleNote": "Apple Silicon上的Paddle OCR使用CPU运行时。",
+      "ocrAppleNote": "最低和节省模式使用CPU；满载模式通过MLX/Metal加速VL识别。",
       "ocrNvidiaNote": "NVIDIA环境无法选择AMD ROCm OCR。",
       "fluxAmdNote": "检测到AMD GPU，无法使用CUDA原生后端；请选择ZLUDA或CPU。",
       "fluxAppleNote": "Apple Silicon仅使用原生Metal后端。Flux建议至少16GB统一内存。",

--- a/src/shared/i18n/locales/zh-Hant/components.json
+++ b/src/shared/i18n/locales/zh-Hant/components.json
@@ -966,6 +966,10 @@
         "xhigh": "非常高"
       },
       "ocrDevices": {
+        "mlx": {
+          "label": "Apple GPU (MLX)",
+          "description": "在Apple Silicon GPU上執行PaddleOCR-VL辨識。"
+        },
         "cuda": {
           "label": "NVIDIA CUDA",
           "description": "在 NVIDIA GPU 上執行 Paddle OCR。"
@@ -1147,7 +1151,7 @@
       "inpaintingModel": "影像修補模型",
       "amdOcrExperimental": "AMD GPU OCR 為實驗功能。如失敗，可僅將 OCR 切換到 CPU。",
       "ocrAmdNote": "AMD 環境無法選擇 NVIDIA CUDA OCR。",
-      "ocrAppleNote": "Apple Silicon 上的 Paddle OCR 使用 CPU 執行環境。",
+      "ocrAppleNote": "最低與節省模式使用CPU；滿載模式透過MLX/Metal加速VL辨識。",
       "ocrNvidiaNote": "NVIDIA 環境無法選擇 AMD ROCm OCR。",
       "fluxAmdNote": "偵測到 AMD GPU，無法使用 CUDA 原生後端；請選擇 ZLUDA 或 CPU。",
       "fluxAppleNote": "Apple Silicon 僅使用原生 Metal 後端。Flux 建議至少 16GB 統一記憶體。",

--- a/src/shared/ipcEnumSchemas.ts
+++ b/src/shared/ipcEnumSchemas.ts
@@ -189,9 +189,16 @@ export const OcrGpuBackendSchema = z.preprocess(
     ) {
       return "rocm-transformers";
     }
+    if (
+      ["mlx", "metal", "mps", "apple", "mlx-vlm", "mlx-vlm-server"].includes(
+        normalized,
+      )
+    ) {
+      return "mlx-vlm";
+    }
     return value;
   },
-  z.enum(["cuda", "rocm-transformers"]),
+  z.enum(["cuda", "rocm-transformers", "mlx-vlm"]),
 );
 
 export const OcrQualityModeSchema = z.preprocess(

--- a/src/shared/settingsTypes.ts
+++ b/src/shared/settingsTypes.ts
@@ -32,7 +32,7 @@ export type ApiReasoningEffort =
   | "high"
   | "xhigh";
 export type OcrDevice = "cpu" | "gpu";
-export type OcrGpuBackend = "cuda" | "rocm-transformers";
+export type OcrGpuBackend = "cuda" | "rocm-transformers" | "mlx-vlm";
 export type OcrQualityMode = "minimum" | "economy" | "full";
 export type TranslationWorkflowMode = "standard" | "cumulative" | "two-pass";
 export type LlamaRuntimeProfile =

--- a/tests/appSettings.test.ts
+++ b/tests/appSettings.test.ts
@@ -1587,9 +1587,8 @@ describeWindows("app settings helpers", () => {
     expect(resolveOcrGpuBackend("hip")).toBe("rocm-transformers");
     expect(resolveOcrGpuBackend("rocm-transformers")).toBe("rocm-transformers");
     expect(resolveOcrGpuBackend("transformers-rocm")).toBe("rocm-transformers");
-    expect(resolveOcrGpuBackend("mps", "rocm-transformers")).toBe(
-      "rocm-transformers",
-    );
+    expect(resolveOcrGpuBackend("mps", "rocm-transformers")).toBe("mlx-vlm");
+    expect(resolveOcrGpuBackend("mlx-vlm-server")).toBe("mlx-vlm");
     expect(resolveOcrQualityMode("min", "full")).toBe("minimum");
     expect(resolveOcrQualityMode("tiny", "full")).toBe("minimum");
     expect(resolveOcrQualityMode("small", "full")).toBe("economy");
@@ -1631,6 +1630,26 @@ describeWindows("app settings helpers", () => {
   });
 
   it("chooses first-run defaults from detected GPU generation and VRAM", () => {
+    expect(
+      resolveHardwareDefaults({
+        name: "Apple M2 Max",
+        memoryMb: 32 * 1024,
+        unifiedMemoryMb: 32 * 1024,
+        rtxGeneration: null,
+        computeCapability: null,
+        vendor: "apple",
+        supportsMetal: true,
+      }),
+    ).toEqual({
+      modelProvider: "gemma",
+      gemmaVramMode: "full31b",
+      ocrDevice: "gpu",
+      ocrQualityMode: "full",
+      ocrGpuCudaTag: DEFAULT_OCR_GPU_CUDA_TAG,
+      ocrGpuBackend: "mlx-vlm",
+      fluxBackend: "metal-native",
+      llamaRuntimeProfile: "metal",
+    });
     expect(
       resolveHardwareDefaults({
         name: "NVIDIA GeForce RTX 4090",

--- a/tests/hardwareSettingsPanel.test.tsx
+++ b/tests/hardwareSettingsPanel.test.tsx
@@ -85,4 +85,66 @@ describe("HardwareSettingsPanel", () => {
     expect(setOcrQualityMode).toHaveBeenCalledWith("economy");
     expect(setOcrDevice).not.toHaveBeenCalled();
   });
+
+  it("offers Apple MLX full-load OCR and keeps CPU modes explicit", () => {
+    const setOcrDevice = vi.fn();
+    const setOcrGpuBackend = vi.fn();
+    const setOcrQualityMode = vi.fn();
+    render(
+      <HardwareSettingsPanel
+        allowUnsafeLowMemoryFlux={false}
+        clearTestState={vi.fn()}
+        controlsBusy={false}
+        fluxBackend="metal-native"
+        inpaintingModel="flux-klein"
+        isFluxBackendOptionDisabled={() => false}
+        ocrDevice="cpu"
+        ocrGpuBackend="mlx-vlm"
+        ocrQualityMode="economy"
+        setFluxBackend={vi.fn()}
+        setAllowUnsafeLowMemoryFlux={vi.fn()}
+        setInpaintingModel={vi.fn()}
+        setOcrDevice={setOcrDevice}
+        setOcrGpuBackend={setOcrGpuBackend}
+        setOcrQualityMode={setOcrQualityMode}
+        usesAmdHardware={false}
+        usesAppleHardware
+        usesAmdOcrContext={false}
+        usesNvidiaHardware={false}
+        usesNvidiaOcrContext={false}
+        unifiedMemoryMb={32 * 1024}
+      />,
+    );
+
+    const qualityGroup = screen.getByRole("group", {
+      name: "Paddle OCR 품질",
+    });
+    expect(
+      (
+        within(qualityGroup).getByRole("button", {
+          name: "풀로드",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    const deviceGroup = screen.getByRole("group", {
+      name: "Paddle OCR 장치",
+    });
+    expect(
+      (
+        within(deviceGroup).getByRole("button", {
+          name: "Apple GPU (MLX)",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    expect(
+      within(deviceGroup).queryByRole("button", { name: "NVIDIA CUDA" }),
+    ).toBeNull();
+
+    fireEvent.click(
+      within(qualityGroup).getByRole("button", { name: "풀로드" }),
+    );
+    expect(setOcrDevice).toHaveBeenCalledWith("gpu");
+    expect(setOcrGpuBackend).toHaveBeenCalledWith("mlx-vlm");
+    expect(setOcrQualityMode).toHaveBeenCalledWith("full");
+  });
 });

--- a/tests/macOcrMlx.test.ts
+++ b/tests/macOcrMlx.test.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveOcrGpuBackend as resolveStoredOcrGpuBackend } from "../src/main/settings/appSettingsResolvers";
+import { resolveHardwareDefaults } from "../src/main/settings/hardwareDefaults";
+
+const runtimeConfig =
+  require("../src/main/runtime/simple-page-ocr-runtime-config.cjs") as {
+    buildOcrRuntimeEnv: (options: Record<string, unknown>) => NodeJS.ProcessEnv;
+    buildPaddleOcrGpuFailureMessage: (
+      error: unknown,
+      options: Record<string, unknown>,
+    ) => string;
+    buildPaddleOcrImportCheckScript: (
+      options: Record<string, unknown>,
+    ) => string;
+    resolveEffectiveOcrDevice: (options: Record<string, unknown>) => string;
+    resolveOcrGpuBackend: (options: Record<string, unknown>) => string;
+    resolveOcrRuntimeVariant: (options: Record<string, unknown>) => string;
+  };
+
+const { hasExpectedOcrPackages } =
+  require("../src/main/runtime/ocr/runtime-verification.cjs") as {
+    hasExpectedOcrPackages: (
+      packageDir: string,
+      options: Record<string, unknown>,
+    ) => boolean;
+  };
+
+describe("Apple MLX PaddleOCR-VL support", () => {
+  it("selects full-load MLX OCR on a 32 GB Apple Silicon machine", () => {
+    expect(
+      resolveHardwareDefaults({
+        name: "Apple M2 Max",
+        memoryMb: 32 * 1024,
+        unifiedMemoryMb: 32 * 1024,
+        rtxGeneration: null,
+        computeCapability: null,
+        vendor: "apple",
+        supportsMetal: true,
+      }),
+    ).toMatchObject({
+      ocrDevice: "gpu",
+      ocrGpuBackend: "mlx-vlm",
+      ocrQualityMode: "full",
+      llamaRuntimeProfile: "metal",
+    });
+  });
+
+  it("keeps Paddle layout on CPU while selecting MLX for VL recognition", () => {
+    const options = { ocrDevice: "gpu", ocrGpuBackend: "mlx-vlm" };
+    const env = runtimeConfig.buildOcrRuntimeEnv(options);
+
+    expect(resolveStoredOcrGpuBackend("metal")).toBe("mlx-vlm");
+    expect(runtimeConfig.resolveOcrGpuBackend(options)).toBe("mlx-vlm");
+    expect(runtimeConfig.resolveEffectiveOcrDevice(options)).toBe("cpu");
+    expect(runtimeConfig.resolveOcrRuntimeVariant(options)).toBe("gpu-mlx-vlm");
+    expect(env.MANGA_TRANSLATOR_OCR_DEVICE).toBe("gpu");
+    expect(env.MANGA_TRANSLATOR_OCR_GPU_BACKEND).toBe("mlx-vlm");
+    expect(env.MANGA_TRANSLATOR_PADDLEOCR_DEVICE).toBe("cpu");
+    expect(env.OMP_NUM_THREADS).toBe("2");
+  });
+
+  it("verifies MLX packages and returns Apple-specific failures", () => {
+    const options = { ocrDevice: "gpu", ocrGpuBackend: "mlx-vlm" };
+    const packageDir = mkdtempSync(join(tmpdir(), "carrot-mlx-packages-"));
+    try {
+      for (const name of ["paddle", "paddleocr", "paddlex", "mlx", "mlx_vlm"]) {
+        mkdirSync(join(packageDir, name));
+      }
+      expect(hasExpectedOcrPackages(packageDir, options)).toBe(true);
+      rmSync(join(packageDir, "mlx_vlm"), { recursive: true });
+      expect(hasExpectedOcrPackages(packageDir, options)).toBe(false);
+
+      const script = runtimeConfig.buildPaddleOcrImportCheckScript(options);
+      expect(script).toContain("import mlx.core as mx");
+      expect(script).toContain("import mlx_vlm.server");
+      expect(script).toContain("mx.device_info()");
+      expect(script).not.toContain("is_compiled_with_cuda");
+      expect(
+        runtimeConfig.buildPaddleOcrGpuFailureMessage(
+          new Error("MLX Metal device unavailable"),
+          options,
+        ),
+      ).toContain("Apple MLX OCR");
+    } finally {
+      rmSync(packageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/macPackaging.test.ts
+++ b/tests/macPackaging.test.ts
@@ -126,7 +126,11 @@ describe("Apple Silicon Alpha packaging", () => {
         sha256:
           "5a30271f8d345a5b02b0c9e4e31e0f1e1455a8e4a04fba95cd9762472abc3b17",
       },
-      ocrPackages: ["paddlepaddle==3.3.1", "paddleocr[doc-parser]==3.7.0"],
+      ocrPackages: [
+        "paddlepaddle==3.3.1",
+        "paddleocr[doc-parser]==3.7.0",
+        "mlx-vlm==0.6.6",
+      ],
     });
     expect(MAC_RUNTIME_MANIFEST.llamaRuntimes).toEqual([
       expect.objectContaining({
@@ -159,6 +163,9 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(runtimePreparer).toContain(
       "await thinUniversalMachOFiles(pythonTarget)",
     );
+    expect(runtimePreparer).toContain('"macosx_14_0_arm64"');
+    expect(runtimePreparer).toContain('"--only-binary=:all:"');
+    expect(runtimePreparer).toContain('"--no-index"');
   });
 
   it("rejects archive traversal and escaping symlinks", () => {
@@ -501,6 +508,8 @@ describe("Apple Silicon Alpha packaging", () => {
     expect(smokes).toContain('PYTHONDONTWRITEBYTECODE: "1"');
     expect(smokes).toContain('PYTHONPYCACHEPREFIX: join(workRoot, "pycache")');
     expect(smokes).toContain('ocrDevice: "cpu"');
+    expect(smokes).toContain("import mlx.core as mx");
+    expect(smokes).toContain("import mlx_vlm.server");
     expect(smokes).toContain('ocrBboxMode: "ocr"');
     expect(smokes).toContain('"PP-OCRv6_tiny_det"');
     expect(smokes).toContain('"PP-OCRv6_tiny_rec"');

--- a/tests/ocrRuntimeBoundaries.test.ts
+++ b/tests/ocrRuntimeBoundaries.test.ts
@@ -49,7 +49,7 @@ function replaceCachedExports(modulePath: string, exports: unknown): void {
 const describeWindows = process.platform === "win32" ? describe : describe.skip;
 
 describeWindows("OCR runtime boundary behavior", () => {
-  it("rejects Apple GPU OCR instead of opening the bundled CPU runtime", async () => {
+  it("rejects non-MLX Apple GPU OCR instead of opening the bundled CPU runtime", async () => {
     const platformDescriptor = Object.getOwnPropertyDescriptor(
       process,
       "platform",
@@ -67,8 +67,11 @@ describeWindows("OCR runtime boundary behavior", () => {
       });
 
       await expect(
-        manager.ensurePaddleOcrRuntime({ ocrDevice: "gpu" }),
-      ).rejects.toThrow("OCR 장치를 CPU로 직접 변경");
+        manager.ensurePaddleOcrRuntime({
+          ocrDevice: "gpu",
+          ocrGpuBackend: "cuda",
+        }),
+      ).rejects.toThrow("OCR 장치를 Apple GPU (MLX)로 변경");
     } finally {
       if (platformDescriptor) {
         Object.defineProperty(process, "platform", platformDescriptor);

--- a/tests/python/test_paddleocr_vl_bboxes.py
+++ b/tests/python/test_paddleocr_vl_bboxes.py
@@ -54,9 +54,58 @@ class CommandLineBehaviorTests(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--pipeline-version {v1,v1.5,v1.6}", result.stdout)
         self.assertIn("--bbox-mode {vl,ocr}", result.stdout)
         self.assertIn("--engine ENGINE", result.stdout)
         self.assertIn("--progress PROGRESS", result.stdout)
+
+    def test_mlx_backend_delegates_vl_recognition_to_the_local_server(self) -> None:
+        args = OCR.build_argument_parser().parse_args(["--device", "cpu"])
+        server = types.SimpleNamespace(
+            url="http://127.0.0.1:8123/",
+            model_name="/tmp/PaddleOCR-VL-1.6",
+        )
+
+        with patch.dict(
+            os.environ,
+            {"MANGA_TRANSLATOR_OCR_GPU_BACKEND": "mlx-vlm"},
+            clear=True,
+        ):
+            kwargs = OCR.build_pipeline_kwargs(args, server)
+
+        self.assertEqual(kwargs["device"], "cpu")
+        self.assertEqual(kwargs["pipeline_version"], "v1.6")
+        self.assertEqual(kwargs["vl_rec_backend"], "mlx-vlm-server")
+        self.assertEqual(kwargs["vl_rec_server_url"], server.url)
+        self.assertEqual(kwargs["vl_rec_api_model_name"], server.model_name)
+
+    def test_mlx_backend_reuses_the_downloaded_paddlex_model(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_dir = (
+                Path(temp_dir)
+                / "official_models"
+                / "PaddleOCR-VL-1.6"
+            )
+            model_dir.mkdir(parents=True)
+            (model_dir / "config.json").touch()
+            (model_dir / "model.safetensors").touch()
+
+            with patch.dict(
+                os.environ,
+                {"PADDLE_PDX_CACHE_HOME": temp_dir},
+                clear=True,
+            ):
+                model_name = OCR.resolve_mlx_vlm_model_name()
+
+        self.assertEqual(model_name, str(model_dir))
+
+    def test_mlx_server_watchdog_exits_if_the_ocr_parent_disappears(self) -> None:
+        script = OCR.build_mlx_server_watchdog_code(4321)
+
+        self.assertIn("parent_pid = 4321", script)
+        self.assertIn("while os.getppid() == parent_pid", script)
+        self.assertIn("os._exit(1)", script)
+        self.assertIn("from mlx_vlm.server.cli import main", script)
 
 
 class LanguageAdapterBehaviorTests(unittest.TestCase):

--- a/tests/runtimeCapabilities.test.ts
+++ b/tests/runtimeCapabilities.test.ts
@@ -37,7 +37,7 @@ describe("build channel", () => {
 });
 
 describe("runtime capabilities", () => {
-  it("reports Metal, CPU OCR, and unified-memory limits on Apple Silicon", () => {
+  it("reports Metal, MLX GPU OCR, and unified-memory limits on Apple Silicon", () => {
     const capabilities = buildRuntimeCapabilities({
       platform: "darwin",
       arch: "arm64",
@@ -65,7 +65,7 @@ describe("runtime capabilities", () => {
       cpuFallback: false,
       minimumUnifiedMemoryMb: 16 * 1024,
     });
-    expect(capabilities.ocr).toEqual({ cpu: true, gpu: false });
+    expect(capabilities.ocr).toEqual({ cpu: true, gpu: true });
   });
 
   it("preserves the existing Windows capability surface", () => {

--- a/tests/runtimeModelLaunch.test.ts
+++ b/tests/runtimeModelLaunch.test.ts
@@ -601,6 +601,12 @@ describeWindows("runtime model support helpers", () => {
         ocrGpuBackend: "rocm-transformers",
       }),
     ).toBe("gpu-rocm-transformers");
+    expect(
+      resolveOcrRuntimeVariant({
+        ocrDevice: "gpu",
+        ocrGpuBackend: "mlx-vlm",
+      }),
+    ).toBe("gpu-mlx-vlm");
   });
 
   it("keeps ROCm Transformers safe GPU defaults scoped to AMD OCR", () => {
@@ -802,6 +808,20 @@ describeWindows("runtime model support helpers", () => {
       resolveEffectiveOcrDevice({ ocrDevice: "gpu", ocrDeviceOverride: "cpu" }),
     ).toBe("gpu:0");
     expect(resolveEffectiveOcrDevice({ ocrDevice: "cpu" })).toBe("cpu");
+    expect(
+      resolveEffectiveOcrDevice({
+        ocrDevice: "gpu",
+        ocrGpuBackend: "mlx-vlm",
+      }),
+    ).toBe("cpu");
+
+    const mlxEnv = buildOcrRuntimeEnv({
+      ocrDevice: "gpu",
+      ocrGpuBackend: "mlx-vlm",
+    });
+    expect(mlxEnv.MANGA_TRANSLATOR_OCR_DEVICE).toBe("gpu");
+    expect(mlxEnv.MANGA_TRANSLATOR_PADDLEOCR_DEVICE).toBe("cpu");
+    expect(mlxEnv.OMP_NUM_THREADS).toBe("2");
 
     const runtime = { pythonPath: "python" };
     const gpuCommand = buildOcrBboxBatchCommand(
@@ -1480,6 +1500,19 @@ describeWindows("runtime model support helpers", () => {
     } finally {
       restoreEnv("MANGA_TRANSLATOR_OCR_IMPORT_TIMEOUT_MS", previous);
     }
+  });
+
+  it("verifies the Apple MLX-VLM runtime without requiring Paddle CUDA", () => {
+    const script = buildPaddleOcrImportCheckScript({
+      ocrDevice: "gpu",
+      ocrGpuBackend: "mlx-vlm",
+    });
+
+    expect(resolveOcrGpuBackend({ ocrGpuBackend: "metal" })).toBe("mlx-vlm");
+    expect(script).toContain("import mlx.core as mx");
+    expect(script).toContain("import mlx_vlm.server");
+    expect(script).toContain("mx.device_info()");
+    expect(script).not.toContain("paddle.device.is_compiled_with_cuda()");
   });
 
   it("prefers the bundled ffmpeg from the tools directory", () => {


### PR DESCRIPTION
## 목적

Apple Silicon macOS에서 지금까지 숨겨져 있던 **PaddleOCR-VL 풀로드**를 사용할 수 있게 하고, VL 인식 단계만 Apple GPU의 MLX/Metal로 가속합니다.

이 PR은 OCR 경로만 다룹니다. 인페인팅, Gemma 실행, AMD/NVIDIA 경로의 동작은 변경하지 않습니다.

## 동작 방식

PaddlePaddle에는 macOS Metal 장치가 없으므로 전체 파이프라인을 GPU로 보내지 않습니다.

1. PP-DocLayout 및 Paddle 텍스트 레이아웃/검출은 기존처럼 CPU에서 실행합니다.
2. 풀로드의 vision-language recognition은 PaddleOCR 3.7의 `mlx-vlm-server` backend를 사용합니다.
3. OCR worker가 loopback 전용 `127.0.0.1` 임시 포트에 `mlx_vlm.server`를 시작합니다.
4. 서버는 PaddleOCR-VL 1.6의 기존 PaddleX 캐시를 우선 재사용하고, 없으면 `PaddlePaddle/PaddleOCR-VL-1.6`을 사용합니다.
5. worker 종료/강제 종료 시 watchdog과 `atexit` 정리로 MLX 서버와 임시 로그를 종료·삭제합니다.
6. MLX 경로에서만 pipeline version을 v1.6으로 지정하고, 다른 OS/백엔드는 기존 기본값 v1.5를 유지합니다.

즉 설정과 진단에는 `gpu / full / mlx-vlm`으로 표시되지만, 실제 Paddle device는 의도적으로 `cpu`이고 VL recognition만 MLX가 담당합니다.

## 사용자 동작

- Apple Silicon 설정에 `Apple GPU (MLX)` 장치를 표시합니다.
- macOS에서도 `풀로드` 품질을 표시합니다.
- `풀로드`를 선택하면 `GPU + mlx-vlm`을 함께 선택합니다.
- `최소` 또는 `절약`을 선택하면 명시적으로 CPU를 사용합니다.
- 통합 메모리 32 GiB 이상 Apple Silicon의 최초 하드웨어 기본값은 `full + mlx-vlm`입니다.
- 실패 시 CPU로 조용히 우회하지 않고 Apple MLX 전용 진단을 보여 줍니다.

## 패키징

- macOS arm64 Python runtime에 `mlx-vlm==0.6.6`을 고정합니다.
- `macosx_14_0_arm64 / CPython 3.12` wheelhouse를 먼저 만든 뒤 offline install하여 다른 아키텍처 wheel이 섞이지 않게 합니다.
- 패키지 smoke에서 `mlx.core`, Metal device info, `mlx_vlm.server`, `PaddleOCRVL` import를 검증합니다.
- runtime verification은 `paddle/paddlex/paddleocr/mlx/mlx_vlm` 디렉터리를 모두 요구합니다.

## 범위 밖 / 기존 동작 보존

- Windows CUDA와 AMD ROCm OCR 선택 및 runtime variant는 그대로입니다.
- CPU 최소/절약 OCR은 그대로입니다.
- Paddle layout detection을 Metal로 옮기지 않습니다.
- 인페인팅·번역 모델·오버레이 파이프라인은 변경하지 않습니다.
- macOS Intel은 지원 대상이 아닙니다.

## 검증

- `npm run check`
  - 188 test files: 183 passed, 5 platform-skipped
  - 1,078 tests passed, 139 skipped
  - TypeScript/JS typecheck, Prettier, ESLint budgets, architecture, generated-file guard, dead code, production build, image protocol smoke, renderer/preload bundle guards passed
- `npm run test:flux-metal`: Metal QMatMul offset and CPU/Metal attention parity passed
- `python3 tests/python/test_paddleocr_vl_bboxes.py`: 15 passed
- focused MLX/settings/runtime/package tests: 27 passed, 53 platform-skipped
- production `HardwareSettingsPanel` rendered with the repository QA harness at 1100×1000 and 520×1100
  - CPU + Economy
  - Apple GPU (MLX) + Full
  - no clipping, overlap, horizontal overflow, or renderer error
- packaged mac-alpha manual run on Apple M4 Max:
  - runtime variant: `gpu-mlx-vlm-macos-arm64-bundled`
  - PaddleOCR-VL batch completed and produced 27 and 20 OCR hints on two pages
  - a later translation API model-load failure was unrelated to OCR

## 제한 및 확인 요청

- 실제 가속 대상은 VL recognition이며 Paddle layout stage는 CPU입니다.
- 최초 풀로드 실행은 PaddleOCR-VL model 준비 시간이 필요합니다.
- 이 PR은 Apple M4 Max에서 확인했습니다. 다른 Apple Silicon 세대의 실사용 결과는 mac alpha checklist로 추가 확인이 필요합니다.
- 최종 release DMG/ZIP은 maintainer의 `mac-alpha` workflow에서 다시 검증하는 것이 안전합니다.

## Maintainer / AI 재구현 계약

이 코드 형태를 그대로 병합하지 않더라도 같은 기능을 재구현하려면 다음 계약만 유지하면 됩니다.

1. `OcrGpuBackend` 및 IPC schema에 `mlx-vlm`을 추가하고 Apple aliases(`mlx/metal/mps/apple/mlx-vlm-server`)를 정규화합니다.
2. Apple Silicon에서 `gpu + mlx-vlm` 요청 시 runtime variant를 `gpu-mlx-vlm`으로 유지하되 Paddle effective device는 `cpu`로 설정합니다.
3. PaddleOCR-VL 생성 시 MLX server URL/model name과 `vl_rec_backend: mlx-vlm-server`를 전달합니다.
4. MLX 경로에만 PaddleOCR pipeline v1.6을 사용하고 기존 경로의 v1.5 기본값을 바꾸지 않습니다.
5. local server는 loopback에만 bind하고 parent-death cleanup, startup timeout, log-tail 진단을 포함합니다.
6. macOS bundled runtime에 pinned `mlx-vlm`을 넣고 Apple Metal import smoke를 수행합니다.
7. Apple 설정에서는 Full↔MLX, Minimum/Economy↔CPU 조합을 일관되게 유지합니다.
8. GPU 요청 실패는 MLX 오류로 보고하고 CPU로 암묵적 fallback하지 않습니다.

핵심 구현 파일:

- `src/main/runtime/paddleocr-vl-bboxes.py`: MLX server lifecycle 및 PaddleOCR-VL delegation
- `src/main/runtime/ocr/runtime-device.cjs`: requested GPU와 effective Paddle CPU 분리
- `src/main/runtime/ocr/runtime-orchestrator.cjs`: bundled mac runtime 선택
- `scripts/mac-runtime-manifest.cjs`, `scripts/prepare-mac-runtime.cjs`: pinned package 및 arm64 wheel staging
- `HardwareSettingsPanel.tsx`, `useSettingsRuntimeGuards.ts`: Apple 품질/장치 조합
- `tests/macOcrMlx.test.ts`, `tests/python/test_paddleocr_vl_bboxes.py`: 플랫폼 계약 회귀 테스트
