### PR TITLE
feat: rerun OCR and translation for selected block

### DIFF
--- a/src/main/jobs/selectedBlockOcr.ts
+++ b/src/main/jobs/selectedBlockOcr.ts
@@ -1,0 +1,87 @@
+import type { MangaPage } from "../../shared/libraryTypes";
+import type { TranslationBlock } from "../../shared/textTypes";
+import type { JobEvent } from "../../shared/jobTypes";
+import type { TranslationOptions } from "../appSettings";
+import type { ChapterRunPaths } from "../library";
+import type { ImageDecodeFallback } from "../regionCrop";
+import { prepareKeepBlockHints } from "../pipeline/keepBlocksOcr";
+import { prepareAnalysisRun } from "../pipeline/prepareAnalysisRun";
+import { tMain } from "./localization";
+
+export function resolveSelectedBlock(
+  page: MangaPage,
+  blockId?: string,
+): TranslationBlock | undefined {
+  if (!blockId) return undefined;
+  const block = page.blocks.find((candidate) => candidate.id === blockId);
+  if (!block) throw new Error(tMain("region.blockNotFound"));
+  return block;
+}
+
+function resolveSelectedBlockOcrMode(
+  options: Pick<TranslationOptions, "ocrQualityMode" | "ocrGpuBackend">,
+): "vl" | "ocr" {
+  return options.ocrQualityMode === "full" &&
+    options.ocrGpuBackend !== "rocm-transformers"
+    ? "vl"
+    : "ocr";
+}
+
+export async function recognizeSelectedBlock({
+  decodeImage,
+  emit,
+  jobId,
+  page,
+  runPaths,
+  signal,
+}: {
+  decodeImage: ImageDecodeFallback;
+  emit: (event: JobEvent) => void;
+  jobId: string;
+  page: MangaPage;
+  runPaths: ChapterRunPaths;
+  signal: AbortSignal;
+}): Promise<{ pages: MangaPage[]; warnings: string[] }> {
+  const run = await prepareAnalysisRun({
+    jobId,
+    emit,
+    pages: [page],
+    runPaths,
+    signal,
+    skipOcrPrepass: false,
+  });
+  const hintsByPageId = await prepareKeepBlockHints({
+    runtime: run.runtime,
+    baseOptions: {
+      ...run.baseOptions,
+      ocrBboxMode: resolveSelectedBlockOcrMode(run.baseOptions),
+    },
+    keepPages: [page],
+    pageCount: 1,
+    runPaths,
+    emit,
+    jobId,
+    signal,
+    decodeImage,
+  });
+  const sourceText = readFirstOcrText(hintsByPageId.get(page.id)?.hints);
+  const block = page.blocks[0];
+  if (!block || !sourceText) {
+    throw new Error(tMain("region.blockResultMissing"));
+  }
+  return {
+    pages: [
+      {
+        ...page,
+        blocks: [{ ...block, sourceText, reviewStatus: "draft" }],
+      },
+    ],
+    warnings: [],
+  };
+}
+
+function readFirstOcrText(hints: unknown[] | undefined): string {
+  const first = hints?.[0];
+  if (!first || typeof first !== "object" || Array.isArray(first)) return "";
+  return String((first as Record<string, unknown>).ocrText ?? "").trim();
+}

--- a/src/main/jobs/translationRegionJobRunner.ts
+++ b/src/main/jobs/translationRegionJobRunner.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../shared/analysisTypes";
 import type { JobEvent } from "../../shared/jobTypes";
 import type { MangaPage } from "../../shared/libraryTypes";
+import { normalizedRegionToPixelRect } from "../../shared/region";
 import {
   createRegionCropPage,
   mapRegionBlocksToPageBlocks,
@@ -12,12 +13,17 @@ import {
   appendAnalyzedPageBlocks,
   getRunPaths,
   openChapter,
+  replaceAnalyzedPageBlockText,
   resolveWorkContextForChapter,
 } from "../library";
 import { logError } from "../logger";
 import { tMain } from "./localization";
 import { runWholePagePipeline } from "../wholePagePipeline";
 import { isAbortError } from "./jobEvents";
+import {
+  recognizeSelectedBlock,
+  resolveSelectedBlock,
+} from "./selectedBlockOcr";
 import type { TranslationJobContext } from "./translationJobTypes";
 
 type EmitJobEvent = (event: JobEvent) => void;
@@ -57,26 +63,47 @@ export async function runRegionTranslationJob({
   }
 
   state.runPaths = await getRunPaths(request.chapterId, id);
-  const { cropPage, cropRect } = await createRegionCropPage(
-    page,
-    request.bbox,
-    id,
-    state.runPaths.runDir,
-    context.decodeImage,
-  );
-  emitRegionStarting(id, emit, cropRect);
-  const result = await runRegionPipeline({
-    abortController,
-    context,
-    cropPage,
-    cropRect,
-    emit,
-    id,
-    page,
-    pageIndex: Math.max(0, pageIndex),
-    request,
-    runPaths: state.runPaths,
-  });
+  const targetBlock = resolveSelectedBlock(page, request.targetBlockId);
+  const regionCrop = targetBlock
+    ? {
+        cropPage: { ...page, blocks: [targetBlock] },
+        cropRect: normalizedRegionToPixelRect(
+          targetBlock.bbox,
+          { width: page.width, height: page.height },
+          8,
+        ),
+      }
+    : await createRegionCropPage(
+        page,
+        request.bbox,
+        id,
+        state.runPaths.runDir,
+        context.decodeImage,
+      );
+  const { cropPage, cropRect } = regionCrop;
+  emitRegionStarting(id, emit, cropRect, request.targetBlockOperation);
+  const result =
+    request.targetBlockOperation === "ocr"
+      ? await recognizeSelectedBlock({
+          decodeImage: context.decodeImage,
+          emit,
+          jobId: id,
+          page: cropPage,
+          runPaths: state.runPaths,
+          signal: abortController.signal,
+        })
+      : await runRegionPipeline({
+          abortController,
+          context,
+          cropPage,
+          cropRect,
+          emit,
+          id,
+          page,
+          pageIndex: Math.max(0, pageIndex),
+          request,
+          runPaths: state.runPaths,
+        });
 
   if (abortController.signal.aborted) {
     throw new DOMException("Aborted", "AbortError");
@@ -139,12 +166,18 @@ function emitRegionStarting(
   id: string,
   emit: EmitJobEvent,
   cropRect: { w: number; h: number },
+  operation?: RegionAnalysisRequest["targetBlockOperation"],
 ): void {
   emit({
     id,
     kind: "gemma-analysis",
     status: "starting",
-    progressText: tMain("region.preparing"),
+    progressText:
+      operation === "ocr"
+        ? tMain("region.blockOcrPreparing")
+        : operation === "translate"
+          ? tMain("region.blockTranslationPreparing")
+          : tMain("region.preparing"),
     phase: "booting",
     progressCurrent: 0,
     progressTotal: 1,
@@ -184,13 +217,17 @@ function runRegionPipeline({
         context.jobs.setCleanup(id, cleanup);
       },
       pages: [cropPage],
+      blockMode: request.targetBlockId ? "keep" : undefined,
+      skipOcrPrepass: request.targetBlockOperation === "translate",
       runPaths,
       signal: abortController.signal,
-      regionContext: {
-        sourcePage: page,
-        sourcePageIndex: pageIndex,
-        cropRect,
-      },
+      regionContext: request.targetBlockId
+        ? undefined
+        : {
+            sourcePage: page,
+            sourcePageIndex: pageIndex,
+            cropRect,
+          },
       workContext: {
         ...workContext,
         chapterId: request.chapterId,
@@ -217,6 +254,29 @@ async function completeRegionTranslation({
   result: PipelineResult;
 }): Promise<RegionAnalysisResult> {
   const analyzedCrop = result.pages[0];
+  if (request.targetBlockId) {
+    const analyzedBlock = analyzedCrop?.blocks[0];
+    if (!analyzedBlock) {
+      throw new Error(tMain("region.blockResultMissing"));
+    }
+    const saved = await replaceAnalyzedPageBlockText(
+      request.chapterId,
+      request.pageId,
+      request.targetBlockId,
+      analyzedBlock,
+      request.targetBlockOperation,
+    );
+    emitRegionCompleted(id, emit, 1, request.targetBlockOperation);
+    return {
+      status: "completed",
+      chapter: saved,
+      warnings: result.warnings,
+      pageId: request.pageId,
+      blockIds: [request.targetBlockId],
+      replacedBlockId: request.targetBlockId,
+      targetBlockOperation: request.targetBlockOperation,
+    };
+  }
   const mappedBlocks = analyzedCrop
     ? mapRegionBlocksToPageBlocks(analyzedCrop.blocks, page, cropRect)
     : [];
@@ -241,12 +301,18 @@ function emitRegionCompleted(
   id: string,
   emit: EmitJobEvent,
   blockCount: number,
+  operation?: RegionAnalysisRequest["targetBlockOperation"],
 ): void {
   emit({
     id,
     kind: "gemma-analysis",
     status: "completed",
-    progressText: tMain("region.completed"),
+    progressText:
+      operation === "ocr"
+        ? tMain("region.blockOcrCompleted")
+        : operation === "translate"
+          ? tMain("region.blockTranslationCompleted")
+          : tMain("region.completed"),
     phase: "done",
     progressCurrent: 1,
     progressTotal: 1,

--- a/src/main/jobs/translationRegionJobRunner.ts
+++ b/src/main/jobs/translationRegionJobRunner.ts
@@ -219,6 +219,10 @@ function runRegionPipeline({
       pages: [cropPage],
       blockMode: request.targetBlockId ? "keep" : undefined,
       skipOcrPrepass: request.targetBlockOperation === "translate",
+      selectedBlockTranslationSourceText:
+        request.targetBlockOperation === "translate"
+          ? cropPage.blocks[0]?.sourceText
+          : undefined,
       runPaths,
       signal: abortController.signal,
       regionContext: request.targetBlockId

--- a/src/main/library.ts
+++ b/src/main/library.ts
@@ -22,6 +22,7 @@ export {
   renameWork,
   reorderChapters,
   reorderPages,
+  replaceAnalyzedPageBlockText,
   savePageBlocks,
   setPageInpaintingResult,
   updatePageAfterAnalysis,

--- a/src/main/library/libraryMutationFacade.ts
+++ b/src/main/library/libraryMutationFacade.ts
@@ -3,6 +3,7 @@ import type {
   LibraryIndex,
   MangaPage,
 } from "../../shared/libraryTypes";
+import type { TargetBlockOperation } from "../../shared/analysisTypes";
 import type { SavePageBlocksRequest } from "../../shared/shareTypes";
 import {
   cleanupLibraryOrphansUnlocked,
@@ -19,6 +20,7 @@ import {
   renameWorkUnlocked,
   reorderChaptersUnlocked,
   reorderPagesUnlocked,
+  replaceAnalyzedPageBlockTextUnlocked,
   savePageBlocksUnlocked,
   setPageInpaintingResultUnlocked,
   updatePageAfterAnalysisUnlocked,
@@ -42,6 +44,24 @@ export async function appendAnalyzedPageBlocks(
 ): Promise<ChapterSnapshot> {
   return withLibraryMutation(() =>
     appendAnalyzedPageBlocksUnlocked(chapterId, pageId, blocks),
+  );
+}
+
+export async function replaceAnalyzedPageBlockText(
+  chapterId: string,
+  pageId: string,
+  blockId: string,
+  analyzedBlock: MangaPage["blocks"][number],
+  operation?: TargetBlockOperation,
+): Promise<ChapterSnapshot> {
+  return withLibraryMutation(() =>
+    replaceAnalyzedPageBlockTextUnlocked(
+      chapterId,
+      pageId,
+      blockId,
+      analyzedBlock,
+      operation,
+    ),
   );
 }
 

--- a/src/main/libraryStore/libraryAnalysisMutations.ts
+++ b/src/main/libraryStore/libraryAnalysisMutations.ts
@@ -1,4 +1,5 @@
 import { hydrateChapter } from "./chapterSnapshots";
+import type { TargetBlockOperation } from "../../shared/analysisTypes";
 import { resolveChapterStatus } from "./chapterRecords";
 import {
   findChapterLocation,
@@ -35,6 +36,75 @@ export async function appendAnalyzedPageBlocksUnlocked(
       ? {
           ...candidate,
           blocks: [...candidate.blocks, ...blocks],
+          analysisStatus: "completed" as const,
+          lastError: undefined,
+          updatedAt: now,
+        }
+      : candidate,
+  );
+  const nextChapter: ChapterFile = {
+    ...chapter,
+    pages,
+    status: resolveChapterStatus(pages),
+    updatedAt: now,
+  };
+  await writeChapterFile(nextChapter);
+  await touchWork(locator.workId, now);
+  return hydrateChapter(nextChapter);
+}
+
+export async function replaceAnalyzedPageBlockTextUnlocked(
+  chapterId: string,
+  pageId: string,
+  blockId: string,
+  analyzedBlock: PageBlocks[number],
+  operation?: TargetBlockOperation,
+): Promise<ChapterSnapshot> {
+  const locator = await findChapterLocation(chapterId);
+  if (!locator) {
+    throw new Error("저장할 화를 찾지 못했습니다.");
+  }
+  const chapter = await readChapterFile(locator.workId, locator.chapterId);
+  if (!chapter) {
+    throw new Error("저장할 화를 찾지 못했습니다.");
+  }
+  const page = chapter.pages.find((candidate) => candidate.id === pageId);
+  if (!page) {
+    throw new Error("저장할 페이지를 찾지 못했습니다.");
+  }
+  if (!page.blocks.some((block) => block.id === blockId)) {
+    throw new Error("OCR·번역할 블록을 찾지 못했습니다.");
+  }
+
+  const now = new Date().toISOString();
+  const pages = chapter.pages.map((candidate) =>
+    candidate.id === pageId
+      ? {
+          ...candidate,
+          blocks: candidate.blocks.map((block) =>
+            block.id === blockId
+              ? {
+                  ...block,
+                  sourceText:
+                    operation === "translate"
+                      ? block.sourceText
+                      : analyzedBlock.sourceText,
+                  translatedText:
+                    operation === "ocr"
+                      ? block.translatedText
+                      : analyzedBlock.translatedText,
+                  confidence:
+                    operation === "translate"
+                      ? block.confidence
+                      : analyzedBlock.confidence,
+                  sourceDirection:
+                    operation === "translate"
+                      ? block.sourceDirection
+                      : analyzedBlock.sourceDirection,
+                  reviewStatus: "draft" as const,
+                }
+              : block,
+          ),
           analysisStatus: "completed" as const,
           lastError: undefined,
           updatedAt: now,

--- a/src/main/libraryStore/libraryMutations.ts
+++ b/src/main/libraryStore/libraryMutations.ts
@@ -34,7 +34,10 @@ import { sanitizeTitle } from "./titles";
 import { logLibraryWarning } from "./libraryLogger";
 import { syncChapterStoryMemoryPages } from "./workContextFiles";
 
-export { appendAnalyzedPageBlocksUnlocked } from "./libraryAnalysisMutations";
+export {
+  appendAnalyzedPageBlocksUnlocked,
+  replaceAnalyzedPageBlockTextUnlocked,
+} from "./libraryAnalysisMutations";
 export {
   setPageInpaintingResultUnlocked,
   updatePagesAfterInpaintingUnlocked,

--- a/src/main/pipeline/types.ts
+++ b/src/main/pipeline/types.ts
@@ -21,6 +21,8 @@ export type PipelineOptions = {
   signal: AbortSignal;
   skipOcrPrepass?: boolean;
   blockMode?: "auto" | "keep";
+  /** Locks one selected block's current source text as the translation authority. */
+  selectedBlockTranslationSourceText?: string;
   /** webp 등 nativeImage가 못 읽는 이미지의 PNG 디코더 (keep 모드 블록 크롭 OCR용). */
   decodeImage?: (filePath: string) => Promise<Buffer | null>;
   onCleanupReady?: (cleanup: () => Promise<void>) => void;

--- a/src/main/runtime/prompts/overlay-prompt.cjs
+++ b/src/main/runtime/prompts/overlay-prompt.cjs
@@ -102,6 +102,9 @@ function insertOptionalSection(sections, section, anchorTitles) {
  * @returns {string}
  */
 function buildOverlayPrompt(baseSections, options = {}, imageVariants = []) {
+  if (hasSelectedBlockTranslationSource(options)) {
+    return buildSelectedBlockTranslationPrompt(options, imageVariants);
+  }
   if (options.regionCropMode) {
     return buildRegionOverlayPrompt(options, imageVariants);
   }
@@ -147,6 +150,64 @@ function buildOverlayPrompt(baseSections, options = {}, imageVariants = []) {
   }
 
   return localizeSections(sections, options);
+}
+
+/**
+ * @param {PromptOptions} options
+ * @param {ImageVariant[]} imageVariants
+ * @returns {string}
+ */
+function buildSelectedBlockTranslationPrompt(options, imageVariants) {
+  const sections = [
+    buildTaskSection(options, imageVariants),
+    buildCoordinateCalibrationSection(options, imageVariants),
+    buildWorkContextSection(options),
+    buildPreviousPassSection(options, imageVariants),
+    buildSelectedBlockOutputSection(options),
+  ].filter((section) => section.length > 1);
+  return localizeSections(sections, options);
+}
+
+/**
+ * @param {PromptOptions} options
+ * @returns {PromptSection}
+ */
+function buildSelectedBlockOutputSection(options) {
+  const profile = resolvePromptLanguageProfile(options);
+  return [
+    "Output",
+    "Return exactly one record for selected block id 1 and no other records.",
+    "Return plain text only. Do not output JSON, markdown, bullets, commentary, alternatives, or code fences.",
+    `Use exactly these keys, one per line: id, type, textRole, x1, y1, x2, y2, direction, angle, fontSize, confidence, ${profile.sourceKey}, ${profile.targetKey}.`,
+    "Set id to 1, type to nonsolid, and copy textRole and bbox from the Selected block section without changing or recomputing them.",
+    "direction, angle, and fontSize are required compatibility fields; they do not authorize changing the selected block or its sourceText.",
+    "confidence describes translation confidence only, not confidence in re-reading the source image.",
+    `Copy the authoritative sourceText exactly into ${profile.sourceKey}, including its words, punctuation, numbers, and omissions.`,
+    `Write only a faithful translation of that sourceText in ${profile.targetKey}. Context may disambiguate the same words but must not add unrelated content.`,
+    "Put no text before or after the single record.",
+    "Record template:",
+    "id: 1",
+    "type: nonsolid",
+    "textRole: <ordinary|sound>",
+    "x1: <selected block x1>",
+    "y1: <selected block y1>",
+    "x2: <selected block x2>",
+    "y2: <selected block y2>",
+    "direction: <horizontal|vertical>",
+    "angle: <integer>",
+    "fontSize: <integer>",
+    "confidence: <0.00-1.00>",
+    `${profile.sourceKey}: <authoritative sourceText copied exactly>`,
+    `${profile.targetKey}: <translation of authoritative sourceText only>`,
+  ];
+}
+
+/** @param {PromptOptions} options @returns {boolean} */
+function hasSelectedBlockTranslationSource(options) {
+  return (
+    typeof options.selectedBlockTranslationSourceText === "string" &&
+    options.selectedBlockTranslationSourceText.trim().length > 0
+  );
 }
 
 /**

--- a/src/main/runtime/prompts/previous-pass.cjs
+++ b/src/main/runtime/prompts/previous-pass.cjs
@@ -31,6 +31,21 @@ function buildPreviousPassSection(options = {}, imageVariants = []) {
     return [];
   }
 
+  if (hasSelectedBlockTranslationSource(options)) {
+    return [
+      "Selected block",
+      "This is the only block to output. Keep its candidateId and bbox unchanged.",
+      "Its authoritative sourceText is fixed input, not a weak OCR hint. Never replace or extend it from Image 1, old translation, glossary, or story memory.",
+      "The old target translation is only a wording hint and may be replaced by a faithful new translation of the authoritative sourceText.",
+      ...blocks
+        .slice(0, 1)
+        .map((block, index) =>
+          formatPreviousPassBlock(block, index + 1, options, imageVariants),
+        )
+        .filter(Boolean),
+    ];
+  }
+
   return [
     "Previous pass blocks",
     "These are weak review hints from the previous Korean overlay pass. Do not output them as records unless Image 1 shows real Japanese glyphs at the same physical area.",
@@ -80,13 +95,16 @@ function formatPreviousPassBlock(
     return "";
   }
   const role = sanitizePromptLine(block.textRole || "ordinary", 40);
-  const review = classifyPreviousPassTextForPrompt(block, options);
+  const selectedSourceText = readSelectedBlockTranslationSource(options);
+  const review = selectedSourceText
+    ? { omitSource: false, omitTranslation: false, reasons: [] }
+    : classifyPreviousPassTextForPrompt(block, options);
   const languageProfile = resolvePromptLanguageProfile(options);
   const candidate = formatCandidateId(block.candidateId);
   const confidence = formatConfidence(block.confidence);
   const reviewText = formatReviewText(review);
   const sourceText = formatReviewedText(
-    block.sourceText,
+    selectedSourceText || block.sourceText,
     languageProfile.sourceKey,
     review.omitSource,
   );
@@ -96,6 +114,18 @@ function formatPreviousPassBlock(
     review.omitTranslation,
   );
   return `previous ${index}:${candidate} bbox:[${bbox.x1},${bbox.y1},${bbox.x2},${bbox.y2}] role:${role}${confidence}${reviewText}${sourceText}${targetText}`;
+}
+
+/** @param {PromptOptions} options @returns {boolean} */
+function hasSelectedBlockTranslationSource(options) {
+  return Boolean(readSelectedBlockTranslationSource(options));
+}
+
+/** @param {PromptOptions} options @returns {string} */
+function readSelectedBlockTranslationSource(options) {
+  return typeof options.selectedBlockTranslationSourceText === "string"
+    ? sanitizePromptLine(options.selectedBlockTranslationSourceText, 2000)
+    : "";
 }
 
 /** @param {unknown} value @returns {string} */

--- a/src/main/runtime/prompts/prompt-types.d.ts
+++ b/src/main/runtime/prompts/prompt-types.d.ts
@@ -26,6 +26,7 @@ export type PromptOptions = {
   regionCropMode?: unknown;
   strictRefineMode?: unknown;
   keepBlocksMode?: unknown;
+  selectedBlockTranslationSourceText?: unknown;
   collectPageContext?: unknown;
   previousBlocksForPrompt?: PreviousPromptBlock[];
   workContext?: PromptWorkContext | null;

--- a/src/main/runtime/prompts/system-prompt.cjs
+++ b/src/main/runtime/prompts/system-prompt.cjs
@@ -12,6 +12,18 @@ const { localizePromptTextForProfile } = require("./localization.cjs");
  */
 function buildSystemPrompt(options = {}) {
   const languageProfile = resolvePromptLanguageProfile(options);
+  if (hasSelectedBlockTranslationSource(options)) {
+    return localizePromptTextForProfile(
+      [
+        "You are translating one selected existing manga text block.",
+        "The authoritative sourceText is supplied in the user prompt. Translate exactly that sourceText; do not OCR, re-read, correct, extend, merge, or replace it from Image 1.",
+        "Image 1, glossary, character notes, and story memory are context only. They may resolve names, pronouns, tone, honorifics, and ambiguity, but must never add source meaning, events, objects, or dialogue absent from the authoritative sourceText.",
+        "Return only one machine-readable record in the format requested by the user prompt.",
+        "Keep the selected block id and geometry stable.",
+      ].join("\n\n"),
+      languageProfile,
+    );
+  }
   if (options.regionCropMode) {
     return localizePromptTextForProfile(
       [
@@ -63,6 +75,14 @@ function buildSystemPrompt(options = {}) {
   }
 
   return localizePromptTextForProfile(lines.join("\n\n"), languageProfile);
+}
+
+/** @param {PromptOptions} options @returns {boolean} */
+function hasSelectedBlockTranslationSource(options) {
+  return (
+    typeof options.selectedBlockTranslationSourceText === "string" &&
+    options.selectedBlockTranslationSourceText.trim().length > 0
+  );
 }
 
 module.exports = { buildSystemPrompt };

--- a/src/main/runtime/prompts/task-sections.cjs
+++ b/src/main/runtime/prompts/task-sections.cjs
@@ -4,12 +4,21 @@
 /** @typedef {import("./prompt-types").PromptSection} PromptSection */
 /** @typedef {import("../simple-page-language-profile.cjs").PromptLanguageProfile} PromptLanguageProfile */
 
+const {
+  resolvePromptLanguageProfile,
+} = require("../simple-page-language-profile.cjs");
+const { sanitizePromptLine } = require("./common.cjs");
+
 /**
  * @param {PromptOptions} [options]
  * @param {ImageVariant[]} [imageVariants]
  * @returns {PromptSection}
  */
 function buildTaskSection(options = {}, imageVariants = []) {
+  const selectedSourceText = readSelectedBlockTranslationSource(options);
+  if (selectedSourceText) {
+    return buildSelectedBlockTranslationTask(options, selectedSourceText);
+  }
   const hasAssistImages = imageVariants.length > 1;
   const regionCropMode = Boolean(options.regionCropMode);
   const hasRegionContextImage =
@@ -36,6 +45,32 @@ function buildTaskSection(options = {}, imageVariants = []) {
     "Before reading dialogue text, segment the visible speech balloons themselves. Each distinct balloon lobe and each separated dialogue text cluster becomes a separate dialogue record.",
     "Only output real Japanese text. Do not output decorative line art, background marks, panel ornaments, texture, or unreadable marks as text.",
   ];
+}
+
+/**
+ * @param {PromptOptions} options
+ * @param {string} sourceText
+ * @returns {PromptSection}
+ */
+function buildSelectedBlockTranslationTask(options, sourceText) {
+  const profile = resolvePromptLanguageProfile(options);
+  return [
+    "Task",
+    "Translate one user-selected existing block. This is translation only, not OCR or text detection.",
+    `Authoritative ${profile.sourceName} sourceText: ${JSON.stringify(sourceText)}`,
+    `Translate exactly and only that sourceText into natural concise ${profile.targetName}.`,
+    "Image 1 is visual context only. Ignore all other visible text and never use the image to replace, correct, extend, merge, or re-read the authoritative sourceText.",
+    "Glossary, character notes, and story memory may resolve names, pronouns, tone, honorifics, and genuine ambiguity only when compatible with the authoritative sourceText. They must not introduce content absent from it.",
+    "Return exactly one record with id 1. Copy the selected block bbox shown below without changing it.",
+    `In ${profile.sourceKey}, copy the authoritative sourceText exactly. In ${profile.targetKey}, write only its translation.`,
+  ];
+}
+
+/** @param {PromptOptions} options @returns {string} */
+function readSelectedBlockTranslationSource(options) {
+  return typeof options.selectedBlockTranslationSourceText === "string"
+    ? sanitizePromptLine(options.selectedBlockTranslationSourceText, 2000)
+    : "";
 }
 
 /**

--- a/src/main/runtime/prompts/work-context.cjs
+++ b/src/main/runtime/prompts/work-context.cjs
@@ -23,7 +23,13 @@ function buildWorkContextSection(options = {}) {
   const regionCropMode = Boolean(options.regionCropMode);
   const targetIsKorean =
     resolvePromptLanguageProfile(options).targetBaseCode === "ko";
-  const lines = buildWorkContextIntroduction(regionCropMode);
+  const selectedBlockTranslation =
+    typeof options.selectedBlockTranslationSourceText === "string" &&
+    options.selectedBlockTranslationSourceText.trim().length > 0;
+  const lines = buildWorkContextIntroduction(
+    regionCropMode,
+    selectedBlockTranslation,
+  );
   appendGlossaryLines(
     lines,
     readEnabledGlossary(guide.glossary),
@@ -39,14 +45,25 @@ function buildWorkContextSection(options = {}) {
   return lines;
 }
 
-/** @param {boolean} regionCropMode @returns {PromptSection} */
-function buildWorkContextIntroduction(regionCropMode) {
+/**
+ * @param {boolean} regionCropMode
+ * @param {boolean} selectedBlockTranslation
+ * @returns {PromptSection}
+ */
+function buildWorkContextIntroduction(
+  regionCropMode,
+  selectedBlockTranslation,
+) {
   return [
     "Work glossary and story memory",
-    regionCropMode
-      ? "Use these notes only as translation context for the visible Japanese inside Image 1."
-      : "Do not output these notes as records.",
-    "Glossary and character entries are stronger than story memory. Story memory may contain earlier OCR or translation mistakes, so use it only for context unless the visible source text supports it.",
+    selectedBlockTranslation
+      ? "Use these notes only to choose a faithful target-language rendering of the authoritative sourceText. Never use them to replace, extend, or correct the sourceText."
+      : regionCropMode
+        ? "Use these notes only as translation context for the visible Japanese inside Image 1."
+        : "Do not output these notes as records.",
+    selectedBlockTranslation
+      ? "Glossary and character entries may standardize matching names and tone. Story memory may resolve genuine ambiguity, but no context may introduce meaning absent from the authoritative sourceText."
+      : "Glossary and character entries are stronger than story memory. Story memory may contain earlier OCR or translation mistakes, so use it only for context unless the visible source text supports it.",
   ];
 }
 

--- a/src/main/settings/appSettingsTypes.ts
+++ b/src/main/settings/appSettingsTypes.ts
@@ -36,6 +36,8 @@ export type TranslationOptions = {
   collectPageContext?: boolean;
   strictRefineMode?: boolean;
   keepBlocksMode?: boolean;
+  /** Selected-block translation input that images and context must not replace. */
+  selectedBlockTranslationSourceText?: string;
   previousBlocksForPrompt?: PreviousOverlayBlockForPrompt[];
   outputDir: string;
   modelProvider: ModelProvider;

--- a/src/main/wholePagePipeline.ts
+++ b/src/main/wholePagePipeline.ts
@@ -32,6 +32,7 @@ export async function runWholePagePipeline({
   signal,
   skipOcrPrepass = false,
   blockMode,
+  selectedBlockTranslationSourceText,
   decodeImage,
   workContext,
   regionContext,
@@ -50,6 +51,7 @@ export async function runWholePagePipeline({
     signal,
     skipOcrPrepass,
     blockMode,
+    selectedBlockTranslationSourceText,
     decodeImage,
     regionContext,
   });
@@ -209,6 +211,7 @@ async function prepareWholePageRun({
   signal,
   skipOcrPrepass,
   blockMode,
+  selectedBlockTranslationSourceText,
   decodeImage,
 }: Pick<
   PipelineOptions,
@@ -222,6 +225,7 @@ async function prepareWholePageRun({
   | "signal"
 > & {
   skipOcrPrepass: boolean;
+  selectedBlockTranslationSourceText?: string;
 }): Promise<{
   ocrHintsByPageId: Map<string, OcrBboxResult>;
   run: Awaited<ReturnType<typeof prepareAnalysisRun>>;
@@ -234,6 +238,10 @@ async function prepareWholePageRun({
     signal,
     skipOcrPrepass,
   });
+  const lockedSourceText = selectedBlockTranslationSourceText?.trim();
+  if (lockedSourceText) {
+    run.baseOptions.selectedBlockTranslationSourceText = lockedSourceText;
+  }
   const ocrHintsByPageId = await preparePageOcrHints({
     jobId,
     pages,

--- a/src/renderer/src/app/session/buildPanelSyncState.ts
+++ b/src/renderer/src/app/session/buildPanelSyncState.ts
@@ -14,6 +14,7 @@ export function buildPanelSyncState({
 >): PanelSyncState {
   const interactionBusy =
     inpaintingBridge.contextValue.jobActive ||
+    derivedState.jobActive ||
     uiState.translationFlowActive ||
     workspaceHistory.busy;
   return {

--- a/src/renderer/src/app/session/createAppSessionViewProps.ts
+++ b/src/renderer/src/app/session/createAppSessionViewProps.ts
@@ -154,7 +154,13 @@ function createModalsProps({
 function createPanelSessionValue(
   model: AppSessionViewModel,
 ): PanelSessionValue {
-  const { blockEditingActions, panelBridge, pointerHandlers, uiState } = model;
+  const {
+    blockEditingActions,
+    panelBridge,
+    pointerHandlers,
+    translationActions,
+    uiState,
+  } = model;
   return {
     ...buildPanelSyncState(model),
     editorFloating: uiState.editorFloating,
@@ -169,6 +175,18 @@ function createPanelSessionValue(
     onDockEditorWindow: panelBridge.closeEditorWindow,
     onDeleteBlock: blockEditingActions.deleteSelectedBlock,
     onDuplicateBlock: blockEditingActions.duplicateSelectedBlock,
+    onOcrBlock: () => {
+      const blockId = model.derivedState.selectedBlock?.id;
+      if (blockId) {
+        void translationActions.ocrSelectedBlock(blockId);
+      }
+    },
+    onTranslateBlock: () => {
+      const blockId = model.derivedState.selectedBlock?.id;
+      if (blockId) {
+        void translationActions.translateSelectedBlock(blockId);
+      }
+    },
     onSelectTransformMode: (mode) => {
       uiState.selectWorkspaceTool(mode);
     },

--- a/src/renderer/src/app/useAppSessionModel.ts
+++ b/src/renderer/src/app/useAppSessionModel.ts
@@ -81,6 +81,7 @@ function usePanelCommandHandler(
   const actions = translation.blockEditingActions;
   const busy =
     inpainting.inpaintingBridge.contextValue.jobActive ||
+    chapter.derivedState.jobActive ||
     chapter.uiState.translationFlowActive ||
     translation.workspaceHistory.busy;
   const selectedBlockId = chapter.derivedState.selectedBlock?.id ?? null;
@@ -98,6 +99,12 @@ function usePanelCommandHandler(
         actions.deleteSelectedBlock();
       } else if (command.type === "duplicateBlock") {
         actions.duplicateSelectedBlock();
+      } else if (command.type === "ocrBlock") {
+        void translation.translationActions.ocrSelectedBlock(command.blockId);
+      } else if (command.type === "translateBlock") {
+        void translation.translationActions.translateSelectedBlock(
+          command.blockId,
+        );
       } else if (command.type === "selectTransformMode") {
         selectWorkspaceTool(command.mode);
       } else if (command.type === "applyFormat") {
@@ -108,7 +115,14 @@ function usePanelCommandHandler(
         startAreaTranslate();
       }
     },
-    [actions, busy, selectedBlockId, selectWorkspaceTool, startAreaTranslate],
+    [
+      actions,
+      busy,
+      selectedBlockId,
+      selectWorkspaceTool,
+      startAreaTranslate,
+      translation.translationActions,
+    ],
   );
 }
 
@@ -120,7 +134,9 @@ function isStaleBlockPanelCommand(
     (command.type === "updateBlock" ||
       command.type === "adjustFontSize" ||
       command.type === "deleteBlock" ||
-      command.type === "duplicateBlock") &&
+      command.type === "duplicateBlock" ||
+      command.type === "ocrBlock" ||
+      command.type === "translateBlock") &&
     command.blockId !== selectedBlockId
   );
 }

--- a/src/renderer/src/components/EditorBlockAnalysisButtons.tsx
+++ b/src/renderer/src/components/EditorBlockAnalysisButtons.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "./ui/Button";
+
+export function EditorBlockAnalysisButtons({
+  disabled,
+  onOcrBlock,
+  onTranslateBlock,
+  translateDisabled = false,
+}: {
+  disabled: boolean;
+  onOcrBlock?: () => void;
+  onTranslateBlock?: () => void;
+  translateDisabled?: boolean;
+}): React.JSX.Element | null {
+  const { t } = useTranslation("components");
+  if (!onOcrBlock && !onTranslateBlock) return null;
+  return (
+    <div className="editor-block-analysis-buttons">
+      <Button
+        fullWidth
+        size="sm"
+        variant="secondary"
+        disabled={disabled || !onOcrBlock}
+        onClick={onOcrBlock}
+      >
+        {t("editor.ocrBlock")}
+      </Button>
+      <Button
+        fullWidth
+        size="sm"
+        variant="secondary"
+        disabled={disabled || translateDisabled || !onTranslateBlock}
+        onClick={onTranslateBlock}
+      >
+        {t("editor.translateBlock")}
+      </Button>
+    </div>
+  );
+}

--- a/src/renderer/src/components/EditorPanel.tsx
+++ b/src/renderer/src/components/EditorPanel.tsx
@@ -45,6 +45,8 @@ type EditorPanelProps = {
   onUpdate: (patch: Partial<TranslationBlock>) => void;
   onDelete: () => void;
   onDuplicate: () => void;
+  onOcrBlock?: () => void;
+  onTranslateBlock?: () => void;
   onSelectTransformMode?: (mode: TransformEditorMode) => void;
 };
 
@@ -65,6 +67,8 @@ export function EditorPanel({
   onUpdate,
   onDelete,
   onDuplicate,
+  onOcrBlock,
+  onTranslateBlock,
   onSelectTransformMode,
 }: EditorPanelProps): React.JSX.Element {
   const [fontFamilyDraft, setFontFamilyDraft] = React.useState<
@@ -101,6 +105,8 @@ export function EditorPanel({
           onApplyFormat,
           onDelete,
           onDuplicate,
+          onOcrBlock,
+          onTranslateBlock,
           onSelectTransformMode,
           onUpdate,
           pageSize,
@@ -123,6 +129,8 @@ type EditorBlockGroupsProps = {
   onApplyFormat: EditorPanelProps["onApplyFormat"];
   onDelete: EditorPanelProps["onDelete"];
   onDuplicate: EditorPanelProps["onDuplicate"];
+  onOcrBlock?: EditorPanelProps["onOcrBlock"];
+  onTranslateBlock?: EditorPanelProps["onTranslateBlock"];
   onSelectTransformMode?: EditorPanelProps["onSelectTransformMode"];
   onUpdate: EditorPanelProps["onUpdate"];
   pageSize: NonNullable<EditorPanelProps["pageSize"]> | null;
@@ -141,6 +149,8 @@ function EditorBlockGroups({
   onApplyFormat,
   onDelete,
   onDuplicate,
+  onOcrBlock,
+  onTranslateBlock,
   onSelectTransformMode,
   onUpdate,
   pageSize,
@@ -156,7 +166,13 @@ function EditorBlockGroups({
         disabled={disabled}
         onUpdate={onUpdate}
       />
-      <TextEditorGroup block={block} disabled={disabled} onUpdate={onUpdate} />
+      <TextEditorGroup
+        block={block}
+        disabled={disabled}
+        onOcrBlock={onOcrBlock}
+        onTranslateBlock={onTranslateBlock}
+        onUpdate={onUpdate}
+      />
       <BlockTransformEditor
         key={block.id}
         {...{

--- a/src/renderer/src/components/EditorPanelSections.tsx
+++ b/src/renderer/src/components/EditorPanelSections.tsx
@@ -18,6 +18,7 @@ import {
 import { resolveColor, type EditorPanelModel } from "./editorPanelUtils";
 import type { BlockBackgroundApplyScope } from "../hooks/useBlockEditingActions";
 import { BlockBackgroundApplyModal } from "./BlockBackgroundApplyModal";
+import { EditorBlockAnalysisButtons } from "./EditorBlockAnalysisButtons";
 
 type BlockPatchHandler = (patch: Partial<TranslationBlock>) => void;
 
@@ -91,8 +92,13 @@ export function EmptyEditorPanel({
 export function TextEditorGroup({
   block,
   disabled,
+  onOcrBlock,
+  onTranslateBlock,
   onUpdate,
-}: BlockSectionProps): React.JSX.Element {
+}: BlockSectionProps & {
+  onOcrBlock?: () => void;
+  onTranslateBlock?: () => void;
+}): React.JSX.Element {
   const { t } = useTranslation("components");
   const { refCallback: translatedTextareaRef, reset: resetTranslatedHeight } =
     useStickyTextareaHeight("editor.textareaHeight.translated");
@@ -130,6 +136,12 @@ export function TextEditorGroup({
           onResetHeights={resetTextareaHeights}
         />
       </div>
+      <EditorBlockAnalysisButtons
+        disabled={disabled}
+        onOcrBlock={onOcrBlock}
+        onTranslateBlock={onTranslateBlock}
+        translateDisabled={!block.sourceText.trim()}
+      />
       <label>
         {t("editor.translatedText")}
         <textarea

--- a/src/renderer/src/hooks/translationActionHooks.ts
+++ b/src/renderer/src/hooks/translationActionHooks.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { ChapterSnapshot } from "../../../shared/libraryTypes";
 import type { BBox } from "../../../shared/textTypes";
+import type { TargetBlockOperation } from "../../../shared/analysisTypes";
 import { isUsableRegionBbox } from "../../../shared/region";
 import { mangaGateway } from "../api/mangaGateway";
 import { formatErrorMessage } from "../lib/appHelpers";
@@ -34,8 +35,14 @@ import {
   startingJobState,
 } from "./translationActionUtils";
 import { useRunAnalysisAction } from "./useRunAnalysisAction";
+import { useSelectedBlockAnalysisActions } from "./useSelectedBlockAnalysisActions";
 
 type FlowActiveRef = MutableRefObject<boolean>;
+type TranslateRegionAction = (
+  bbox: BBox,
+  targetBlockId?: string,
+  targetBlockOperation?: TargetBlockOperation,
+) => Promise<void>;
 export { reportRefreshLibraryFailure };
 
 export function useTranslationActionsImpl(
@@ -59,9 +66,25 @@ export function useTranslationActionsImpl(
     analysisScopeDefault: options.analysisScopeDefault ?? "missing",
     blockModeDefault: options.blockModeDefault ?? "auto",
   });
-  const translateSelectedRegion = useTranslateSelectedRegionAction(options);
+  const translateRegion = useTranslateRegionAction(options);
+  const translateSelectedRegion = useCallback(
+    (bbox: BBox) => translateRegion(bbox),
+    [translateRegion],
+  );
+  const { ocrSelectedBlock, translateSelectedBlock } =
+    useSelectedBlockAnalysisActions({
+      pushStatus: options.pushStatus,
+      runBlockOperation: translateRegion,
+      selectedPage: options.selectedPage,
+    });
 
-  return { runAnalysis, runTranslationFlow, translateSelectedRegion };
+  return {
+    runAnalysis,
+    runTranslationFlow,
+    ocrSelectedBlock,
+    translateSelectedBlock,
+    translateSelectedRegion,
+  };
 }
 
 function useExecuteAnalysisJob({
@@ -286,7 +309,7 @@ async function runTranslationFlowPasses({
   );
 }
 
-function useTranslateSelectedRegionAction({
+function useTranslateRegionAction({
   beforeTranslate,
   clearStatusLines,
   currentChapter,
@@ -300,10 +323,10 @@ function useTranslateSelectedRegionAction({
   setJobState,
   setSelectedBlockId,
   syncSavedPageVersion,
-}: UseTranslationActionsOptions): TranslationActions["translateSelectedRegion"] {
+}: UseTranslationActionsOptions): TranslateRegionAction {
   const { t } = useTranslation("renderer");
-  return useCallback(
-    async (bbox: BBox) => {
+  return useCallback<TranslateRegionAction>(
+    async (bbox, targetBlockId, operation) => {
       if (!currentChapter || !selectedPage || jobActive) {
         return;
       }
@@ -320,6 +343,8 @@ function useTranslateSelectedRegionAction({
           chapterId: currentChapter.id,
           pageId: selectedPage.id,
           bbox,
+          targetBlockId,
+          targetBlockOperation: operation,
         });
         mergeTranslatedRegionResult(result, {
           currentChapterRef,

--- a/src/renderer/src/hooks/translationActionTypes.ts
+++ b/src/renderer/src/hooks/translationActionTypes.ts
@@ -59,4 +59,6 @@ export type TranslationActions = {
     options: TranslationFlowOptions,
   ) => Promise<RunAnalysisOutcome>;
   translateSelectedRegion: (bbox: BBox) => Promise<void>;
+  ocrSelectedBlock: (blockId: string) => Promise<void>;
+  translateSelectedBlock: (blockId: string) => Promise<void>;
 };

--- a/src/renderer/src/hooks/translationActionUtils.ts
+++ b/src/renderer/src/hooks/translationActionUtils.ts
@@ -340,12 +340,45 @@ function reportCompletedRegionTranslation(
     setSelectedBlockId(result.blockIds[0]);
   }
   const warningSummary = summarizeWarnings(result.warnings ?? [], t);
-  pushStatus(
-    warningSummary ||
-      (t
-        ? t("regionTranslation.success", {
-            count: result.blockIds?.length ?? 0,
-          })
-        : `선택 영역에서 ${result.blockIds?.length ?? 0}개 블록을 만들었습니다.`),
+  pushStatus(resolveCompletedRegionStatus(result, warningSummary, t));
+}
+
+function resolveCompletedRegionStatus(
+  result: TranslateRegionResult,
+  warningSummary: string | null,
+  t?: TFunction<"renderer">,
+): string {
+  if (warningSummary) return warningSummary;
+  const operationStatus = resolveBlockOperationStatus(
+    result.targetBlockOperation,
+    t,
   );
+  if (operationStatus) return operationStatus;
+  if (result.replacedBlockId) {
+    return t
+      ? t("regionTranslation.blockSuccess")
+      : "선택한 블록의 OCR과 번역을 갱신했습니다.";
+  }
+  return t
+    ? t("regionTranslation.success", {
+        count: result.blockIds?.length ?? 0,
+      })
+    : `선택 영역에서 ${result.blockIds?.length ?? 0}개 블록을 만들었습니다.`;
+}
+
+function resolveBlockOperationStatus(
+  operation: TranslateRegionResult["targetBlockOperation"],
+  t?: TFunction<"renderer">,
+): string | null {
+  if (operation === "ocr") {
+    return t
+      ? t("regionTranslation.ocrSuccess")
+      : "선택한 블록의 OCR 원문을 갱신했습니다.";
+  }
+  if (operation === "translate") {
+    return t
+      ? t("regionTranslation.translateSuccess")
+      : "선택한 블록의 번역문을 갱신했습니다.";
+  }
+  return null;
 }

--- a/src/renderer/src/hooks/useSelectedBlockAnalysisActions.ts
+++ b/src/renderer/src/hooks/useSelectedBlockAnalysisActions.ts
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import type { TargetBlockOperation } from "../../../shared/analysisTypes";
+import type { BBox } from "../../../shared/textTypes";
+import type {
+  TranslationActions,
+  UseTranslationActionsOptions,
+} from "./translationActionTypes";
+
+type RunBlockOperation = (
+  bbox: BBox,
+  blockId: string,
+  operation: TargetBlockOperation,
+) => Promise<void>;
+
+export function useSelectedBlockAnalysisActions({
+  pushStatus,
+  runBlockOperation,
+  selectedPage,
+}: {
+  pushStatus: UseTranslationActionsOptions["pushStatus"];
+  runBlockOperation: RunBlockOperation;
+  selectedPage: UseTranslationActionsOptions["selectedPage"];
+}): Pick<TranslationActions, "ocrSelectedBlock" | "translateSelectedBlock"> {
+  const { t } = useTranslation("renderer");
+  const run = useCallback(
+    async (blockId: string, operation: TargetBlockOperation) => {
+      const block = selectedPage?.blocks.find(
+        (candidate) => candidate.id === blockId,
+      );
+      if (!block) {
+        pushStatus(t("regionTranslation.blockMissing"));
+        return;
+      }
+      if (operation === "translate" && !block.sourceText.trim()) {
+        pushStatus(t("regionTranslation.sourceTextMissing"));
+        return;
+      }
+      await runBlockOperation(block.bbox, block.id, operation);
+    },
+    [pushStatus, runBlockOperation, selectedPage, t],
+  );
+  const ocrSelectedBlock = useCallback(
+    (blockId: string) => run(blockId, "ocr"),
+    [run],
+  );
+  const translateSelectedBlock = useCallback(
+    (blockId: string) => run(blockId, "translate"),
+    [run],
+  );
+  return { ocrSelectedBlock, translateSelectedBlock };
+}

--- a/src/renderer/src/panels/EditorPanelContainer.tsx
+++ b/src/renderer/src/panels/EditorPanelContainer.tsx
@@ -56,6 +56,8 @@ export function EditorPanelContainer(): React.JSX.Element {
       onUpdate={session.onUpdateBlock}
       onDelete={session.onDeleteBlock}
       onDuplicate={session.onDuplicateBlock}
+      onOcrBlock={session.onOcrBlock}
+      onTranslateBlock={session.onTranslateBlock}
       onSelectTransformMode={session.onSelectTransformMode}
     />
   );

--- a/src/renderer/src/panels/panelSession.ts
+++ b/src/renderer/src/panels/panelSession.ts
@@ -50,6 +50,8 @@ export type PanelSessionValue = {
   onUpdateBlock: (patch: Partial<TranslationBlock>) => void;
   onDeleteBlock: () => void;
   onDuplicateBlock: () => void;
+  onOcrBlock: () => void;
+  onTranslateBlock: () => void;
   onSelectTransformMode: (mode: TransformEditorMode) => void;
   onApplyFormat: (
     scope: FormatApplyScope,

--- a/src/renderer/src/panels/useRemotePanelSession.ts
+++ b/src/renderer/src/panels/useRemotePanelSession.ts
@@ -79,6 +79,16 @@ function buildRemotePanelSessionValue(
         dispatchCommand({ type: "duplicateBlock", blockId: selectedBlockId });
       }
     },
+    onOcrBlock: () => {
+      if (selectedBlockId) {
+        dispatchCommand({ type: "ocrBlock", blockId: selectedBlockId });
+      }
+    },
+    onTranslateBlock: () => {
+      if (selectedBlockId) {
+        dispatchCommand({ type: "translateBlock", blockId: selectedBlockId });
+      }
+    },
     onSelectTransformMode: (mode) =>
       dispatchCommand({ type: "selectTransformMode", mode }),
     onStartAreaTranslate: () => dispatchCommand({ type: "startAreaTranslate" }),

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1686,6 +1686,12 @@ input[type="radio"] {
   color: var(--text-muted);
 }
 
+.editor-block-analysis-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
 .background-opacity-scope {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }

--- a/src/shared/analysisTypes.ts
+++ b/src/shared/analysisTypes.ts
@@ -2,6 +2,7 @@ import type { BBox } from "./textTypes";
 import type { ChapterSnapshot } from "./libraryTypes";
 
 export type AnalysisBlockMode = "auto" | "keep";
+export type TargetBlockOperation = "ocr" | "translate";
 
 type PageContextCollectionOption = {
   collectPageContext?: boolean;
@@ -44,9 +45,13 @@ export type RegionAnalysisRequest = {
   chapterId: string;
   pageId: string;
   bbox: BBox;
+  targetBlockId?: string;
+  targetBlockOperation?: TargetBlockOperation;
 };
 
 export type RegionAnalysisResult = StartAnalysisResult & {
   pageId?: string;
   blockIds?: string[];
+  replacedBlockId?: string;
+  targetBlockOperation?: TargetBlockOperation;
 };

--- a/src/shared/i18n/locales/en/components.json
+++ b/src/shared/i18n/locales/en/components.json
@@ -233,6 +233,8 @@
   "editor": {
     "text": "Text",
     "translatedText": "Translation",
+    "ocrBlock": "OCR",
+    "translateBlock": "Translate",
     "blockColors": "Block colors",
     "display": {
       "title": "Editor display",

--- a/src/shared/i18n/locales/en/main.json
+++ b/src/shared/i18n/locales/en/main.json
@@ -240,6 +240,12 @@
   "region": {
     "failed": "Region translation failed",
     "pageNotFound": "The selected page was not found.",
+    "blockResultMissing": "No translatable text was found in the selected block.",
+    "blockNotFound": "The block to OCR and translate could not be found.",
+    "blockOcrPreparing": "Preparing selected block OCR",
+    "blockTranslationPreparing": "Preparing selected block translation",
+    "blockOcrCompleted": "Selected block OCR complete",
+    "blockTranslationCompleted": "Selected block translation complete",
     "preparing": "Preparing region translation",
     "completed": "Region translation complete"
   },

--- a/src/shared/i18n/locales/en/renderer.json
+++ b/src/shared/i18n/locales/en/renderer.json
@@ -343,6 +343,11 @@
     "failedTitle": "Region translation failed",
     "failed": "Could not translate the selected area.",
     "startFailed": "Could not start region translation.",
+    "blockMissing": "Could not find the block to OCR and translate.",
+    "sourceTextMissing": "Enter source text or run OCR for this block first.",
+    "blockSuccess": "Updated OCR and translation for the selected block.",
+    "ocrSuccess": "Updated the OCR text for the selected block.",
+    "translateSuccess": "Updated the translation for the selected block.",
     "success": "Created {{count}} blocks from the selected area.",
     "success_one": "Created {{count}} block from the selected area.",
     "success_other": "Created {{count}} blocks from the selected area."

--- a/src/shared/i18n/locales/ja/components.json
+++ b/src/shared/i18n/locales/ja/components.json
@@ -229,6 +229,8 @@
   "editor": {
     "text": "テキスト",
     "translatedText": "翻訳文",
+    "ocrBlock": "OCR",
+    "translateBlock": "翻訳",
     "blockColors": "ブロックの色",
     "display": {
       "title": "編集表示",

--- a/src/shared/i18n/locales/ja/main.json
+++ b/src/shared/i18n/locales/ja/main.json
@@ -240,6 +240,12 @@
   "region": {
     "failed": "選択範囲の翻訳に失敗しました",
     "pageNotFound": "選択したページが見つかりません。",
+    "blockResultMissing": "選択したブロックに翻訳できるテキストが見つかりませんでした。",
+    "blockNotFound": "OCR・翻訳するブロックが見つかりませんでした。",
+    "blockOcrPreparing": "選択ブロックのOCRを準備中",
+    "blockTranslationPreparing": "選択ブロックの翻訳を準備中",
+    "blockOcrCompleted": "選択ブロックのOCRが完了しました",
+    "blockTranslationCompleted": "選択ブロックの翻訳が完了しました",
     "preparing": "選択範囲の翻訳を準備中",
     "completed": "選択範囲の翻訳が完了しました"
   },

--- a/src/shared/i18n/locales/ja/renderer.json
+++ b/src/shared/i18n/locales/ja/renderer.json
@@ -340,6 +340,11 @@
     "failedTitle": "範囲翻訳失敗",
     "failed": "選択範囲を翻訳できませんでした。",
     "startFailed": "範囲翻訳を開始できませんでした。",
+    "blockMissing": "OCR・翻訳するブロックが見つかりませんでした。",
+    "sourceTextMissing": "先にこのブロックの原文を入力するか、OCRを実行してください。",
+    "blockSuccess": "選択したブロックのOCRと翻訳を更新しました。",
+    "ocrSuccess": "選択したブロックのOCRテキストを更新しました。",
+    "translateSuccess": "選択したブロックの翻訳を更新しました。",
     "success": "選択範囲から{{count}}個のブロックを作成しました。",
     "success_one": "選択範囲から{{count}}個のブロックを作成しました。",
     "success_other": "選択範囲から{{count}}個のブロックを作成しました。"

--- a/src/shared/i18n/locales/ko/components.json
+++ b/src/shared/i18n/locales/ko/components.json
@@ -229,6 +229,8 @@
   "editor": {
     "text": "텍스트",
     "translatedText": "번역문",
+    "ocrBlock": "OCR",
+    "translateBlock": "번역",
     "blockColors": "블록 색상",
     "display": {
       "title": "편집 표시",

--- a/src/shared/i18n/locales/ko/main.json
+++ b/src/shared/i18n/locales/ko/main.json
@@ -240,6 +240,12 @@
   "region": {
     "failed": "선택 영역 번역 실패",
     "pageNotFound": "선택한 페이지를 찾지 못했습니다.",
+    "blockResultMissing": "선택한 블록에서 번역할 텍스트를 찾지 못했습니다.",
+    "blockNotFound": "OCR·번역할 블록을 찾지 못했습니다.",
+    "blockOcrPreparing": "선택 블록 OCR 준비 중",
+    "blockTranslationPreparing": "선택 블록 번역 준비 중",
+    "blockOcrCompleted": "선택 블록 OCR 완료",
+    "blockTranslationCompleted": "선택 블록 번역 완료",
     "preparing": "선택 영역 번역 준비 중",
     "completed": "선택 영역 번역 완료"
   },

--- a/src/shared/i18n/locales/ko/renderer.json
+++ b/src/shared/i18n/locales/ko/renderer.json
@@ -346,6 +346,11 @@
     "failedTitle": "선택 영역 번역 실패",
     "failed": "선택 영역 번역에 실패했습니다.",
     "startFailed": "선택 영역 번역을 시작하지 못했습니다.",
+    "blockMissing": "OCR·번역할 블록을 찾지 못했습니다.",
+    "sourceTextMissing": "먼저 이 블록의 OCR 원문을 입력하거나 OCR을 실행해 주세요.",
+    "blockSuccess": "선택한 블록의 OCR과 번역을 갱신했습니다.",
+    "ocrSuccess": "선택한 블록의 OCR 원문을 갱신했습니다.",
+    "translateSuccess": "선택한 블록의 번역문을 갱신했습니다.",
     "success": "선택 영역에서 {{count}}개 블록을 만들었습니다.",
     "success_one": "선택 영역에서 {{count}}개 블록을 만들었습니다.",
     "success_other": "선택 영역에서 {{count}}개 블록을 만들었습니다."

--- a/src/shared/i18n/locales/zh-Hans/components.json
+++ b/src/shared/i18n/locales/zh-Hans/components.json
@@ -225,6 +225,8 @@
   "editor": {
     "text": "文本",
     "translatedText": "译文",
+    "ocrBlock": "OCR",
+    "translateBlock": "翻译",
     "blockColors": "文本块颜色",
     "display": {
       "title": "编辑显示",

--- a/src/shared/i18n/locales/zh-Hans/main.json
+++ b/src/shared/i18n/locales/zh-Hans/main.json
@@ -240,6 +240,12 @@
   "region": {
     "failed": "选区翻译失败",
     "pageNotFound": "找不到所选页面。",
+    "blockResultMissing": "在所选文本块中未找到可翻译的文字。",
+    "blockNotFound": "找不到要进行 OCR 和翻译的文本块。",
+    "blockOcrPreparing": "正在准备所选文本块的 OCR",
+    "blockTranslationPreparing": "正在准备所选文本块的翻译",
+    "blockOcrCompleted": "所选文本块 OCR 已完成",
+    "blockTranslationCompleted": "所选文本块翻译已完成",
     "preparing": "正在准备选区翻译",
     "completed": "选区翻译完成"
   },

--- a/src/shared/i18n/locales/zh-Hans/renderer.json
+++ b/src/shared/i18n/locales/zh-Hans/renderer.json
@@ -337,6 +337,11 @@
     "failedTitle": "区域翻译失败",
     "failed": "无法翻译所选区域。",
     "startFailed": "无法开始区域翻译。",
+    "blockMissing": "找不到要进行 OCR 和翻译的文本块。",
+    "sourceTextMissing": "请先输入该文本块的原文或运行 OCR。",
+    "blockSuccess": "已更新所选文本块的 OCR 和翻译。",
+    "ocrSuccess": "已更新所选文本块的 OCR 原文。",
+    "translateSuccess": "已更新所选文本块的译文。",
     "success": "已从所选区域创建 {{count}} 个文本块。",
     "success_one": "已从所选区域创建 {{count}} 个文本块。",
     "success_other": "已从所选区域创建 {{count}} 个文本块。"

--- a/src/shared/i18n/locales/zh-Hant/components.json
+++ b/src/shared/i18n/locales/zh-Hant/components.json
@@ -225,6 +225,8 @@
   "editor": {
     "text": "文字",
     "translatedText": "譯文",
+    "ocrBlock": "OCR",
+    "translateBlock": "翻譯",
     "blockColors": "文字區塊顏色",
     "display": {
       "title": "編輯顯示",

--- a/src/shared/i18n/locales/zh-Hant/main.json
+++ b/src/shared/i18n/locales/zh-Hant/main.json
@@ -240,6 +240,12 @@
   "region": {
     "failed": "選取區域翻譯失敗",
     "pageNotFound": "找不到所選頁面。",
+    "blockResultMissing": "在所選文字區塊中找不到可翻譯的文字。",
+    "blockNotFound": "找不到要進行 OCR 與翻譯的文字區塊。",
+    "blockOcrPreparing": "正在準備所選文字區塊的 OCR",
+    "blockTranslationPreparing": "正在準備所選文字區塊的翻譯",
+    "blockOcrCompleted": "所選文字區塊 OCR 已完成",
+    "blockTranslationCompleted": "所選文字區塊翻譯已完成",
     "preparing": "正在準備選取區域翻譯",
     "completed": "選取區域翻譯完成"
   },

--- a/src/shared/i18n/locales/zh-Hant/renderer.json
+++ b/src/shared/i18n/locales/zh-Hant/renderer.json
@@ -337,6 +337,11 @@
     "failedTitle": "區域翻譯失敗",
     "failed": "無法翻譯所選區域。",
     "startFailed": "無法開始區域翻譯。",
+    "blockMissing": "找不到要進行 OCR 和翻譯的文字區塊。",
+    "sourceTextMissing": "請先輸入該文字區塊的原文或執行 OCR。",
+    "blockSuccess": "已更新所選文字區塊的 OCR 和翻譯。",
+    "ocrSuccess": "已更新所選文字區塊的 OCR 原文。",
+    "translateSuccess": "已更新所選文字區塊的譯文。",
     "success": "已從所選區域建立 {{count}} 個文字區塊。",
     "success_one": "已從所選區域建立 {{count}} 個文字區塊。",
     "success_other": "已從所選區域建立 {{count}} 個文字區塊。"

--- a/src/shared/ipcJobContracts.ts
+++ b/src/shared/ipcJobContracts.ts
@@ -65,6 +65,8 @@ const regionAnalysisResultSchema = startAnalysisResultSchema
       .array(z.string().min(1).max(200))
       .max(MAX_BLOCKS_PER_RESULT)
       .optional(),
+    replacedBlockId: stringArg.optional(),
+    targetBlockOperation: z.enum(["ocr", "translate"]).optional(),
   })
   .strict();
 const startInpaintingResultSchema = z

--- a/src/shared/ipcJobSchemas.ts
+++ b/src/shared/ipcJobSchemas.ts
@@ -14,6 +14,7 @@ import {
   filePath,
   finiteNumber,
   hexColor,
+  storeId,
   uuid,
 } from "./ipcSchemaPrimitives";
 
@@ -231,5 +232,12 @@ export const RegionAnalysisRequestSchema = z
     chapterId: uuid,
     pageId: uuid,
     bbox: BBoxSchema,
+    targetBlockId: storeId.optional(),
+    targetBlockOperation: z.enum(["ocr", "translate"]).optional(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (request) =>
+      !request.targetBlockOperation || Boolean(request.targetBlockId),
+    { path: ["targetBlockId"], message: "required for block operation" },
+  );

--- a/src/shared/panelBridgeSchemas.ts
+++ b/src/shared/panelBridgeSchemas.ts
@@ -58,6 +58,18 @@ export const PanelCommandSchema = z.discriminatedUnion("type", [
     .strict(),
   z
     .object({
+      type: z.literal("ocrBlock"),
+      blockId: TranslationBlockSchema.shape.id,
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("translateBlock"),
+      blockId: TranslationBlockSchema.shape.id,
+    })
+    .strict(),
+  z
+    .object({
       type: z.literal("selectTransformMode"),
       mode: z.enum(["select", "perspective", "curve"]),
     })

--- a/src/shared/panelBridgeTypes.ts
+++ b/src/shared/panelBridgeTypes.ts
@@ -43,6 +43,8 @@ export type PanelCommand =
   | { type: "adjustFontSize"; blockId: string; adjustment: -1 | 1 }
   | { type: "deleteBlock"; blockId: string }
   | { type: "duplicateBlock"; blockId: string }
+  | { type: "ocrBlock"; blockId: string }
+  | { type: "translateBlock"; blockId: string }
   | { type: "selectTransformMode"; mode: TransformEditorMode }
   | {
       type: "applyFormat";

--- a/tests/appSessionPanelCommand.test.tsx
+++ b/tests/appSessionPanelCommand.test.tsx
@@ -13,12 +13,17 @@ const state = vi.hoisted(() => {
     applyFormatToScope: vi.fn(),
     applyBlockBackgroundOpacityToScope: vi.fn(),
   };
+  const ocrSelectedBlock = vi.fn();
+  const translateSelectedBlock = vi.fn();
   return {
     actions,
     panelCommandHandler: null as ((command: PanelCommand) => void) | null,
     chapter: {
       core: { workspacePanelRef: { current: null } },
-      derivedState: { selectedBlock: { id: "current-block" } },
+      derivedState: {
+        jobActive: false,
+        selectedBlock: { id: "current-block" },
+      },
       uiState: {
         translationFlowActive: false,
         zoomInWorkspace: vi.fn(),
@@ -33,6 +38,7 @@ const state = vi.hoisted(() => {
     translation: {
       actions,
       blockEditingActions: actions,
+      translationActions: { ocrSelectedBlock, translateSelectedBlock },
       workspaceHistory: { busy: false },
     },
   };
@@ -97,6 +103,8 @@ describe("useAppSessionModel panel command target safety", () => {
       },
       { type: "deleteBlock", blockId: "stale-block" },
       { type: "duplicateBlock", blockId: "stale-block" },
+      { type: "ocrBlock", blockId: "stale-block" },
+      { type: "translateBlock", blockId: "stale-block" },
     ] satisfies PanelCommand[];
 
     act(() => {
@@ -109,6 +117,12 @@ describe("useAppSessionModel panel command target safety", () => {
     expect(state.actions.adjustSelectedBlockFontSize).not.toHaveBeenCalled();
     expect(state.actions.deleteSelectedBlock).not.toHaveBeenCalled();
     expect(state.actions.duplicateSelectedBlock).not.toHaveBeenCalled();
+    expect(
+      state.translation.translationActions.ocrSelectedBlock,
+    ).not.toHaveBeenCalled();
+    expect(
+      state.translation.translationActions.translateSelectedBlock,
+    ).not.toHaveBeenCalled();
   });
 
   it("still applies block commands that target the current selection", () => {
@@ -133,6 +147,14 @@ describe("useAppSessionModel panel command target safety", () => {
         type: "duplicateBlock",
         blockId: "current-block",
       });
+      state.panelCommandHandler?.({
+        type: "ocrBlock",
+        blockId: "current-block",
+      });
+      state.panelCommandHandler?.({
+        type: "translateBlock",
+        blockId: "current-block",
+      });
     });
 
     expect(state.actions.updateSelectedBlock).toHaveBeenCalledWith({
@@ -141,5 +163,11 @@ describe("useAppSessionModel panel command target safety", () => {
     expect(state.actions.adjustSelectedBlockFontSize).toHaveBeenCalledWith(-1);
     expect(state.actions.deleteSelectedBlock).toHaveBeenCalledOnce();
     expect(state.actions.duplicateSelectedBlock).toHaveBeenCalledOnce();
+    expect(
+      state.translation.translationActions.ocrSelectedBlock,
+    ).toHaveBeenCalledWith("current-block");
+    expect(
+      state.translation.translationActions.translateSelectedBlock,
+    ).toHaveBeenCalledWith("current-block");
   });
 });

--- a/tests/blockFontSizeAdjustment.test.tsx
+++ b/tests/blockFontSizeAdjustment.test.tsx
@@ -37,7 +37,21 @@ vi.stubGlobal(
   },
 );
 
-afterEach(() => cleanup());
+const localStorageValues = new Map<string, string>();
+Object.defineProperty(window, "localStorage", {
+  configurable: true,
+  value: {
+    clear: () => localStorageValues.clear(),
+    getItem: (key: string) => localStorageValues.get(key) ?? null,
+    removeItem: (key: string) => localStorageValues.delete(key),
+    setItem: (key: string, value: string) => localStorageValues.set(key, value),
+  },
+});
+
+afterEach(() => {
+  cleanup();
+  localStorageValues.clear();
+});
 
 describe("selected block font-size adjustment", () => {
   it("adjusts only the active manual-size block by one pixel", () => {
@@ -151,6 +165,53 @@ describe("selected block font-size adjustment", () => {
     act(() => screen.getByRole("button", { name: "글자 크기 늘리기" }).click());
 
     expect(onAdjustFontSize.mock.calls).toEqual([[-1], [1]]);
+  });
+
+  it("exposes separate OCR and translation actions for the selected block", () => {
+    const onOcrBlock = vi.fn();
+    const onTranslateBlock = vi.fn();
+    render(
+      <EditorPanel
+        block={makeBlock()}
+        disabled={false}
+        onAdjustFontSize={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOcrBlock={onOcrBlock}
+        onTranslateBlock={onTranslateBlock}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    act(() => screen.getByRole("button", { name: "OCR" }).click());
+    act(() => screen.getByRole("button", { name: "번역" }).click());
+
+    expect(onOcrBlock).toHaveBeenCalledOnce();
+    expect(onTranslateBlock).toHaveBeenCalledOnce();
+  });
+
+  it("requires source text before translating a selected block", () => {
+    render(
+      <EditorPanel
+        block={makeBlock({ sourceText: "" })}
+        disabled={false}
+        onAdjustFontSize={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOcrBlock={vi.fn()}
+        onTranslateBlock={vi.fn()}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(
+      (screen.getByRole("button", { name: "OCR" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+    expect(
+      (screen.getByRole("button", { name: "번역" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 
   it("edits line wrapping with user-facing labels", () => {
@@ -414,6 +475,8 @@ describe("font-size panel bridge", () => {
     { type: "adjustFontSize", adjustment: 1 },
     { type: "deleteBlock" },
     { type: "duplicateBlock" },
+    { type: "ocrBlock" },
+    { type: "translateBlock" },
   ])("requires a block id for $type commands", (command) => {
     expect(() => PanelCommandSchema.parse(command)).toThrow();
   });
@@ -461,6 +524,8 @@ describe("font-size panel bridge", () => {
     act(() => result.current?.onUpdateBlock({ translatedText: "수정" }));
     act(() => result.current?.onDeleteBlock());
     act(() => result.current?.onDuplicateBlock());
+    act(() => result.current?.onOcrBlock());
+    act(() => result.current?.onTranslateBlock());
     act(() => result.current?.onApplyBlockBackgroundOpacity("chapter"));
 
     expect(sendPanelCommand).toHaveBeenCalledWith({
@@ -479,6 +544,14 @@ describe("font-size panel bridge", () => {
     });
     expect(sendPanelCommand).toHaveBeenCalledWith({
       type: "duplicateBlock",
+      blockId: block.id,
+    });
+    expect(sendPanelCommand).toHaveBeenCalledWith({
+      type: "ocrBlock",
+      blockId: block.id,
+    });
+    expect(sendPanelCommand).toHaveBeenCalledWith({
+      type: "translateBlock",
       blockId: block.id,
     });
     expect(sendPanelCommand).toHaveBeenCalledWith({

--- a/tests/blockRegionTranslationJob.test.ts
+++ b/tests/blockRegionTranslationJob.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TranslationJobContext } from "../src/main/jobs/translationJobTypes";
+import type { ChapterSnapshot, MangaPage } from "../src/shared/libraryTypes";
+import type { TranslationBlock } from "../src/shared/textTypes";
+
+const mocks = vi.hoisted(() => ({
+  appendAnalyzedPageBlocks: vi.fn(),
+  createRegionCropPage: vi.fn(),
+  getRunPaths: vi.fn(),
+  openChapter: vi.fn(),
+  recognizeSelectedBlock: vi.fn(),
+  replaceAnalyzedPageBlockText: vi.fn(),
+  resolveWorkContextForChapter: vi.fn(),
+  runWholePagePipeline: vi.fn(),
+}));
+
+vi.mock("../src/main/library", () => ({
+  appendAnalyzedPageBlocks: mocks.appendAnalyzedPageBlocks,
+  getRunPaths: mocks.getRunPaths,
+  openChapter: mocks.openChapter,
+  replaceAnalyzedPageBlockText: mocks.replaceAnalyzedPageBlockText,
+  resolveWorkContextForChapter: mocks.resolveWorkContextForChapter,
+}));
+vi.mock("../src/main/regionCrop", () => ({
+  createRegionCropPage: mocks.createRegionCropPage,
+  mapRegionBlocksToPageBlocks: vi.fn(),
+}));
+vi.mock("../src/main/wholePagePipeline", () => ({
+  runWholePagePipeline: mocks.runWholePagePipeline,
+}));
+vi.mock("../src/main/jobs/selectedBlockOcr", () => ({
+  recognizeSelectedBlock: mocks.recognizeSelectedBlock,
+  resolveSelectedBlock: (page: MangaPage, blockId?: string) =>
+    page.blocks.find((block) => block.id === blockId),
+}));
+vi.mock("../src/main/logger", () => ({ logError: vi.fn() }));
+
+import { runRegionTranslationJob } from "../src/main/jobs/translationRegionJobRunner";
+
+describe("selected block OCR and translation job", () => {
+  const selectedBlock = makeBlock("selected-block", {
+    bbox: { x: 100, y: 150, w: 240, h: 320 },
+  });
+  const otherBlock = makeBlock("other-block", {
+    bbox: { x: 500, y: 600, w: 180, h: 220 },
+  });
+  const page = makePage([selectedBlock, otherBlock]);
+  const chapter = makeChapter(page);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.openChapter.mockResolvedValue(chapter);
+    mocks.getRunPaths.mockResolvedValue({ runDir: "/tmp/run" });
+    mocks.resolveWorkContextForChapter.mockResolvedValue({});
+    mocks.runWholePagePipeline.mockResolvedValue({
+      pages: [
+        {
+          ...page,
+          blocks: [
+            {
+              ...selectedBlock,
+              sourceText: "新しい原文",
+              translatedText: "새 번역",
+              confidence: 0.8,
+            },
+          ],
+        },
+      ],
+      warnings: [],
+    });
+    mocks.recognizeSelectedBlock.mockResolvedValue({
+      pages: [
+        {
+          ...page,
+          blocks: [{ ...selectedBlock, sourceText: "OCR로 갱신된 원문" }],
+        },
+      ],
+      warnings: [],
+    });
+    mocks.replaceAnalyzedPageBlockText.mockResolvedValue(chapter);
+  });
+
+  it("translates from the current OCR text without running PaddleOCR again", async () => {
+    const result = await runRegionTranslationJob({
+      context: {
+        decodeImage: vi.fn(),
+        getMainWindow: () => null,
+        jobs: { setCleanup: vi.fn() },
+      } as unknown as TranslationJobContext,
+      request: {
+        chapterId: chapter.id,
+        pageId: page.id,
+        bbox: selectedBlock.bbox,
+        targetBlockId: selectedBlock.id,
+        targetBlockOperation: "translate",
+      },
+      id: "block-job",
+      abortController: new AbortController(),
+      emit: vi.fn(),
+      state: { chapter: null, runPaths: null },
+    });
+
+    expect(mocks.createRegionCropPage).not.toHaveBeenCalled();
+    expect(mocks.runWholePagePipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blockMode: "keep",
+        pages: [expect.objectContaining({ blocks: [selectedBlock] })],
+        regionContext: undefined,
+        skipOcrPrepass: true,
+        writeStoryMemory: false,
+      }),
+    );
+    expect(mocks.replaceAnalyzedPageBlockText).toHaveBeenCalledWith(
+      chapter.id,
+      page.id,
+      selectedBlock.id,
+      expect.objectContaining({
+        sourceText: "新しい原文",
+        translatedText: "새 번역",
+      }),
+      "translate",
+    );
+    expect(mocks.appendAnalyzedPageBlocks).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "completed",
+      blockIds: [selectedBlock.id],
+      replacedBlockId: selectedBlock.id,
+      targetBlockOperation: "translate",
+    });
+  });
+
+  it("runs PaddleOCR only and saves the recognized source text", async () => {
+    const result = await runRegionTranslationJob({
+      context: {
+        decodeImage: vi.fn(),
+        getMainWindow: () => null,
+        jobs: { setCleanup: vi.fn() },
+      } as unknown as TranslationJobContext,
+      request: {
+        chapterId: chapter.id,
+        pageId: page.id,
+        bbox: selectedBlock.bbox,
+        targetBlockId: selectedBlock.id,
+        targetBlockOperation: "ocr",
+      },
+      id: "ocr-block-job",
+      abortController: new AbortController(),
+      emit: vi.fn(),
+      state: { chapter: null, runPaths: null },
+    });
+
+    expect(mocks.runWholePagePipeline).not.toHaveBeenCalled();
+    expect(mocks.recognizeSelectedBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "ocr-block-job",
+        page: expect.objectContaining({ blocks: [selectedBlock] }),
+      }),
+    );
+    expect(mocks.replaceAnalyzedPageBlockText).toHaveBeenCalledWith(
+      chapter.id,
+      page.id,
+      selectedBlock.id,
+      expect.objectContaining({ sourceText: "OCR로 갱신된 원문" }),
+      "ocr",
+    );
+    expect(result).toMatchObject({
+      status: "completed",
+      replacedBlockId: selectedBlock.id,
+      targetBlockOperation: "ocr",
+    });
+  });
+});
+
+function makeBlock(
+  id: string,
+  patch: Partial<TranslationBlock> = {},
+): TranslationBlock {
+  return {
+    id,
+    type: "nonsolid",
+    bbox: { x: 100, y: 100, w: 200, h: 200 },
+    bboxSpace: "normalized_1000",
+    sourceText: "原文",
+    translatedText: "번역",
+    confidence: 0.9,
+    sourceDirection: "vertical",
+    renderDirection: "vertical",
+    fontSizePx: 24,
+    lineHeight: 1.2,
+    textAlign: "center",
+    textColor: "#111111",
+    backgroundColor: "#ffffff",
+    opacity: 1,
+    autoFitText: true,
+    ...patch,
+  };
+}
+
+function makePage(blocks: TranslationBlock[]): MangaPage {
+  return {
+    id: "page-1",
+    name: "001.png",
+    imagePath: "/tmp/001.png",
+    dataUrl: "",
+    width: 1200,
+    height: 1600,
+    blocks,
+    analysisStatus: "completed",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function makeChapter(page: MangaPage): ChapterSnapshot {
+  return {
+    id: "chapter-1",
+    workId: "work-1",
+    title: "1화",
+    sourceKind: "folder",
+    status: "completed",
+    pageOrder: [page.id],
+    pages: [page],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}

--- a/tests/blockRegionTranslationJob.test.ts
+++ b/tests/blockRegionTranslationJob.test.ts
@@ -106,6 +106,7 @@ describe("selected block OCR and translation job", () => {
         blockMode: "keep",
         pages: [expect.objectContaining({ blocks: [selectedBlock] })],
         regionContext: undefined,
+        selectedBlockTranslationSourceText: selectedBlock.sourceText,
         skipOcrPrepass: true,
         writeStoryMemory: false,
       }),

--- a/tests/ipcSchemas.test.ts
+++ b/tests/ipcSchemas.test.ts
@@ -8,6 +8,7 @@ import {
   ModelTestProgressEventSchema,
   parseIpcPayload,
   ReleaseInpaintingHistoryTransactionsRequestSchema,
+  RegionAnalysisRequestSchema,
   SavePageBlocksRequestSchema,
   StartAnalysisRequestSchema,
   StartInpaintingRequestSchema,
@@ -63,6 +64,47 @@ describe("IPC schemas", () => {
       throw new Error("single-page request was not parsed as single-page");
     }
     expect(parsed.pageId).toBe(pageId);
+  });
+
+  it("accepts a target block for region OCR and rejects unsafe block ids", () => {
+    const parsed = parseIpcPayload(
+      RegionAnalysisRequestSchema,
+      {
+        chapterId,
+        pageId,
+        bbox: { x: 10, y: 20, w: 300, h: 400 },
+        targetBlockId: "block-1",
+        targetBlockOperation: "ocr",
+      },
+      "영역 번역",
+    );
+
+    expect(parsed.targetBlockId).toBe("block-1");
+    expect(parsed.targetBlockOperation).toBe("ocr");
+    expect(() =>
+      parseIpcPayload(
+        RegionAnalysisRequestSchema,
+        {
+          chapterId,
+          pageId,
+          bbox: { x: 10, y: 20, w: 300, h: 400 },
+          targetBlockOperation: "translate",
+        },
+        "영역 번역",
+      ),
+    ).toThrow(/요청 형식/);
+    expect(() =>
+      parseIpcPayload(
+        RegionAnalysisRequestSchema,
+        {
+          chapterId,
+          pageId,
+          bbox: { x: 10, y: 20, w: 300, h: 400 },
+          targetBlockId: "../outside",
+        },
+        "영역 번역",
+      ),
+    ).toThrow(/요청 형식/);
   });
 
   it("accepts an optional keep-blocks mode for analysis requests", () => {

--- a/tests/runtimePromptMessages.test.ts
+++ b/tests/runtimePromptMessages.test.ts
@@ -9,6 +9,79 @@ import {
 } from "./helpers/runtimeModelContracts";
 
 describe("runtime prompt message contracts", () => {
+  it("treats selected-block source text as authoritative for translation only", () => {
+    const options = {
+      modelProvider: "gemma",
+      imageWidth: 1200,
+      imageHeight: 1600,
+      strictRefineMode: true,
+      keepBlocksMode: true,
+      selectedBlockTranslationSourceText: "私は犯人じゃない",
+      previousBlocksForPrompt: [
+        {
+          previousId: "block-1",
+          index: 1,
+          candidateId: 1,
+          bbox: { x: 100, y: 200, w: 250, h: 300 },
+          sourceText: "別の誤った原文",
+          translatedText: "잘못된 이전 번역",
+          confidence: 0.9,
+        },
+      ],
+      workContext: {
+        styleGuide: {
+          glossary: [],
+          characters: [],
+          rules: {},
+        },
+        storyMemory: {
+          pages: [
+            {
+              pageIndex: 0,
+              pageName: "previous",
+              summary: "범인은 다른 인물이라고 잘못 기록된 문맥",
+            },
+          ],
+        },
+      },
+    };
+    const variants = [
+      {
+        role: "original",
+        dataUrl: "data:image/png;base64,page",
+        width: 1200,
+        height: 1600,
+      },
+    ];
+    const prompt = getOverlayPrompt(options, variants);
+    const messages = buildMessages(options, variants);
+    const systemText =
+      messages[0]?.content.find((part) => part.type === "text")?.text ?? "";
+
+    expect(prompt).toContain(
+      'Authoritative Japanese sourceText: "私は犯人じゃない"',
+    );
+    expect(prompt).toContain(
+      "Translate exactly and only that sourceText into natural concise Korean",
+    );
+    expect(prompt).toContain(
+      "no context may introduce meaning absent from the authoritative sourceText",
+    );
+    expect(prompt).toContain('jp:"私は犯人じゃない"');
+    expect(prompt).not.toContain("Detect every visible Japanese text group");
+    expect(prompt).not.toContain("Scan the entire page");
+    expect(prompt).not.toContain("weak review hints");
+    expect(prompt).not.toContain("If jp has multiple visible source lines");
+    expect(prompt).not.toContain("If a stylized SFX looks like a Latin letter");
+    expect(prompt).not.toContain(
+      "confidence from 0.00 to 1.00 that the item is real Japanese text",
+    );
+    expect(systemText).toContain(
+      "The authoritative sourceText is supplied in the user prompt",
+    );
+    expect(systemText).not.toContain("aggressively correct OCR");
+  });
+
   it("uses OCR bbox candidates as single-pass geometry hints", () => {
     const options = {
       modelProvider: "openai-codex",

--- a/tests/selectedBlockAnalysisActions.test.tsx
+++ b/tests/selectedBlockAnalysisActions.test.tsx
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { MangaPage } from "../src/shared/libraryTypes";
+import type { TranslationBlock } from "../src/shared/textTypes";
+import { useSelectedBlockAnalysisActions } from "../src/renderer/src/hooks/useSelectedBlockAnalysisActions";
+
+describe("selected block analysis actions", () => {
+  it("dispatches OCR and translation as separate operations", async () => {
+    const block = makeBlock();
+    const runBlockOperation = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useSelectedBlockAnalysisActions({
+        pushStatus: vi.fn(),
+        runBlockOperation,
+        selectedPage: makePage(block),
+      }),
+    );
+
+    await act(() => result.current.ocrSelectedBlock(block.id));
+    await act(() => result.current.translateSelectedBlock(block.id));
+
+    expect(runBlockOperation.mock.calls).toEqual([
+      [block.bbox, block.id, "ocr"],
+      [block.bbox, block.id, "translate"],
+    ]);
+  });
+
+  it("does not translate a block without source text", async () => {
+    const block = { ...makeBlock(), sourceText: "" };
+    const pushStatus = vi.fn();
+    const runBlockOperation = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectedBlockAnalysisActions({
+        pushStatus,
+        runBlockOperation,
+        selectedPage: makePage(block),
+      }),
+    );
+
+    await act(() => result.current.translateSelectedBlock(block.id));
+
+    expect(runBlockOperation).not.toHaveBeenCalled();
+    expect(pushStatus).toHaveBeenCalledOnce();
+  });
+});
+
+function makePage(block: TranslationBlock): MangaPage {
+  return {
+    id: "page-1",
+    name: "001.png",
+    imagePath: "/tmp/001.png",
+    dataUrl: "",
+    width: 1200,
+    height: 1600,
+    blocks: [block],
+    analysisStatus: "completed",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function makeBlock(): TranslationBlock {
+  return {
+    id: "block-1",
+    type: "nonsolid",
+    bbox: { x: 100, y: 100, w: 200, h: 300 },
+    sourceText: "原文",
+    translatedText: "번역",
+    confidence: 0.9,
+    sourceDirection: "vertical",
+    renderDirection: "vertical",
+    fontSizePx: 24,
+    lineHeight: 1.2,
+    textAlign: "center",
+    textColor: "#111111",
+    backgroundColor: "#ffffff",
+    opacity: 1,
+    autoFitText: true,
+  };
+}

--- a/tests/selectedBlockOcr.test.ts
+++ b/tests/selectedBlockOcr.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChapterRunPaths } from "../src/main/library";
+import type { MangaPage } from "../src/shared/libraryTypes";
+import type { TranslationBlock } from "../src/shared/textTypes";
+
+const mocks = vi.hoisted(() => ({
+  prepareAnalysisRun: vi.fn(),
+  prepareKeepBlockHints: vi.fn(),
+}));
+
+vi.mock("../src/main/pipeline/prepareAnalysisRun", () => ({
+  prepareAnalysisRun: mocks.prepareAnalysisRun,
+}));
+vi.mock("../src/main/pipeline/keepBlocksOcr", () => ({
+  prepareKeepBlockHints: mocks.prepareKeepBlockHints,
+}));
+
+import { recognizeSelectedBlock } from "../src/main/jobs/selectedBlockOcr";
+
+describe("selected block OCR", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prepareAnalysisRun.mockResolvedValue({
+      runtime: {},
+      baseOptions: {
+        sourceLanguage: "ja",
+        ocrQualityMode: "economy",
+        ocrGpuBackend: "cuda",
+      },
+    });
+    mocks.prepareKeepBlockHints.mockResolvedValue(
+      new Map([
+        [
+          "page-1",
+          {
+            hints: [{ id: 1, ocrText: "右から 左へ" }],
+            diagnostics: [],
+          },
+        ],
+      ]),
+    );
+  });
+
+  it("updates only source text from the PaddleOCR block crop", async () => {
+    const page = makePage();
+    const result = await recognizeSelectedBlock({
+      decodeImage: vi.fn(),
+      emit: vi.fn(),
+      jobId: "ocr-job",
+      page,
+      runPaths: {
+        chapterDir: "/tmp/chapter",
+        runDir: "/tmp/run",
+      } as ChapterRunPaths,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.prepareAnalysisRun).toHaveBeenCalledWith(
+      expect.objectContaining({ skipOcrPrepass: false }),
+    );
+    expect(mocks.prepareKeepBlockHints).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keepPages: [page],
+        pageCount: 1,
+        baseOptions: expect.objectContaining({ ocrBboxMode: "ocr" }),
+      }),
+    );
+    expect(result.pages[0]?.blocks[0]).toMatchObject({
+      sourceText: "右から 左へ",
+      translatedText: "기존 번역",
+      reviewStatus: "draft",
+    });
+  });
+
+  it.each([
+    ["full", "cuda", "vl"],
+    ["economy", "cuda", "ocr"],
+    ["minimum", "cuda", "ocr"],
+    ["full", "rocm-transformers", "ocr"],
+  ] as const)(
+    "uses %s quality with %s as %s for selected-block OCR",
+    async (ocrQualityMode, ocrGpuBackend, expected) => {
+      mocks.prepareAnalysisRun.mockResolvedValue({
+        runtime: {},
+        baseOptions: {
+          sourceLanguage: "ja",
+          ocrQualityMode,
+          ocrGpuBackend,
+        },
+      });
+
+      await recognizeSelectedBlock({
+        decodeImage: vi.fn(),
+        emit: vi.fn(),
+        jobId: "ocr-job",
+        page: makePage(),
+        runPaths: {
+          chapterDir: "/tmp/chapter",
+          runDir: "/tmp/run",
+        } as ChapterRunPaths,
+        signal: new AbortController().signal,
+      });
+
+      expect(mocks.prepareKeepBlockHints).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseOptions: expect.objectContaining({ ocrBboxMode: expected }),
+        }),
+      );
+    },
+  );
+});
+
+function makePage(): MangaPage {
+  return {
+    id: "page-1",
+    name: "001.png",
+    imagePath: "/tmp/001.png",
+    dataUrl: "",
+    width: 1200,
+    height: 1600,
+    blocks: [makeBlock()],
+    analysisStatus: "completed",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function makeBlock(): TranslationBlock {
+  return {
+    id: "block-1",
+    type: "nonsolid",
+    bbox: { x: 100, y: 100, w: 200, h: 300 },
+    bboxSpace: "normalized_1000",
+    sourceText: "기존 원문",
+    translatedText: "기존 번역",
+    confidence: 0.9,
+    sourceDirection: "vertical",
+    renderDirection: "vertical",
+    fontSizePx: 24,
+    lineHeight: 1.2,
+    textAlign: "center",
+    textColor: "#111111",
+    backgroundColor: "#ffffff",
+    opacity: 1,
+    autoFitText: true,
+  };
+}

--- a/tests/workShare.test.ts
+++ b/tests/workShare.test.ts
@@ -795,6 +795,88 @@ describe("work share packages", () => {
     expect(work?.updatedAt).not.toBe("2026-01-01T00:00:00.000Z");
   });
 
+  it("replaces only OCR text fields when re-translating a block", async () => {
+    const rootDir = await createTempLibrary();
+    const library = await loadLibrary(rootDir);
+    await seedLibrary(rootDir);
+    const chapter = await library.openChapter("chapter-a");
+    const page = firstPage(chapter);
+    const original = firstBlock(page);
+
+    const saved = await library.replaceAnalyzedPageBlockText(
+      chapter.id,
+      page.id,
+      original.id,
+      {
+        ...original,
+        id: "ocr-generated-block",
+        bbox: { x: 300, y: 400, w: 50, h: 60 },
+        sourceText: "新しい原文",
+        translatedText: "새 번역",
+        confidence: 0.72,
+        sourceDirection: "horizontal",
+        renderDirection: "horizontal",
+        fontSizePx: 44,
+        textColor: "#ff0000",
+      },
+    );
+
+    const replaced = firstBlock(firstPage(saved));
+    expect(replaced).toMatchObject({
+      id: original.id,
+      bbox: original.bbox,
+      sourceText: "新しい原文",
+      translatedText: "새 번역",
+      confidence: 0.72,
+      sourceDirection: "horizontal",
+      renderDirection: original.renderDirection,
+      fontSizePx: original.fontSizePx,
+      textColor: original.textColor,
+      reviewStatus: "draft",
+    });
+  });
+
+  it("keeps OCR and translation updates isolated for a selected block", async () => {
+    const rootDir = await createTempLibrary();
+    const library = await loadLibrary(rootDir);
+    await seedLibrary(rootDir);
+    const chapter = await library.openChapter("chapter-a");
+    const page = firstPage(chapter);
+    const original = firstBlock(page);
+
+    const afterOcr = await library.replaceAnalyzedPageBlockText(
+      chapter.id,
+      page.id,
+      original.id,
+      {
+        ...original,
+        sourceText: "OCR 갱신 원문",
+        translatedText: "덮어쓰면 안 되는 번역",
+      },
+      "ocr",
+    );
+    expect(firstBlock(firstPage(afterOcr))).toMatchObject({
+      sourceText: "OCR 갱신 원문",
+      translatedText: original.translatedText,
+    });
+
+    const afterTranslation = await library.replaceAnalyzedPageBlockText(
+      chapter.id,
+      page.id,
+      original.id,
+      {
+        ...original,
+        sourceText: "덮어쓰면 안 되는 원문",
+        translatedText: "번역만 갱신",
+      },
+      "translate",
+    );
+    expect(firstBlock(firstPage(afterTranslation))).toMatchObject({
+      sourceText: "OCR 갱신 원문",
+      translatedText: "번역만 갱신",
+    });
+  });
+
   it("rebases stale page block saves when server blocks still match the baseline", async () => {
     const rootDir = await createTempLibrary();
     const library = await loadLibrary(rootDir);


### PR DESCRIPTION
## 목적

전체 페이지를 한 번에 OCR/번역할 때 연속된 글자 블록이 많으면 번역 결과와 기존 블록 위치의 대응이 어긋날 수 있습니다. 문제가 생긴 한 블록만 다시 처리하려고 전체 페이지를 재실행하면 같은 매칭 경로를 다시 타게 됩니다.

이 PR은 **선택된 기존 블록 하나**를 정확한 block ID와 현재 bbox로 고정한 뒤, 편집기에서 OCR과 번역을 각각 다시 실행할 수 있게 합니다.

## 사용자 동작

선택 블록 편집기에 두 버튼을 추가합니다.

- **OCR**
  - 선택 블록 영역만 crop해 OCR합니다.
  - 현재 OCR 품질 설정을 따릅니다.
    - Full: PaddleOCR-VL
    - Economy / Minimum: 일반 Paddle OCR
    - ROCm Transformers: 지원 범위에 맞춰 일반 OCR
  - 성공 시 원문만 갱신하고 기존 번역·지오메트리·서식은 보존합니다.
- **번역**
  - 현재 편집기에 저장된 원문을 번역의 확정 입력(authoritative sourceText)으로 사용합니다.
  - OCR prepass를 생략하고 선택 블록 하나만 번역합니다.
  - 이미지, 용어집, 캐릭터 메모, 스토리 문맥은 이름·대명사·말투·존칭·실제 중의성 해소에만 사용합니다.
  - 이미지나 문맥이 편집기 원문을 재판독·교정·확장·병합·대체하거나 원문에 없는 의미를 추가할 수 없습니다.
  - 성공 시 번역문만 갱신하고 원문·지오메트리·서식은 보존합니다.
  - 원문이 비어 있으면 실행하지 않습니다.

분리된 편집기 창에서도 동일한 두 동작을 사용할 수 있습니다.

## 구현 범위

- region analysis IPC/panel bridge에 선택 block ID와 `ocr | translate` operation을 전달
- 선택 block ID가 있으면 새 블록을 생성하거나 전체 페이지 결과와 재매칭하지 않음
- OCR은 기존 keep-block crop/OCR 경로를 재사용하고 block 하나의 source text만 저장
- 번역은 keep-block mode + `skipOcrPrepass`로 현재 source text를 번역
- 선택 번역 operation에만 전용 prompt contract를 전달하고 공통 전체 페이지 OCR/재판독 출력 규칙을 제외
- 저장 시 최신 chapter를 다시 읽고 대상 block text만 원자적으로 교체
- 일반 영역 번역의 새 블록 append 동작은 그대로 유지
- 작업 진행/완료/오류 메시지를 5개 UI 언어에 추가

## 의도적으로 바꾸지 않은 것

- 전체 페이지 OCR/번역 파이프라인
- OCR worker 또는 블록 인식 동시성
- 전체 결과의 블록 매칭 정책
- OCR 품질 설정 UI와 기본값
- 인페인팅, 모델 런타임, 패키징

특히 이전에 시험했던 블록 인식 동시성 변경은 이 PR에 포함하지 않습니다.

## 안전성

- 저장은 OCR/번역이 성공한 뒤에만 수행되므로 OCR 결과가 비어 있거나 작업이 실패하면 기존 block은 유지됩니다.
- OCR은 translated text를 덮지 않습니다.
- 번역은 source text와 OCR confidence/direction을 덮지 않습니다.
- 대상 block이 삭제됐거나 ID가 바뀌면 다른 block에 쓰지 않고 명시적으로 실패합니다.
- 선택 block이 아닌 일반 영역 번역 동작은 기존 append 경로를 유지합니다.

## 검증

- `npm run check`
  - TypeScript/JS typecheck
  - Prettier, ESLint 및 error-handling/lint budgets
  - dependency/architecture budgets
  - generated-file guard
  - dead-code 및 exported-dead-code 검사
  - 185 test files passed, 5 platform-skipped
  - 1,091 tests passed, 138 skipped
  - production build
  - image protocol smoke
  - renderer/preload bundle guards
- 집중 회귀 테스트: 7 files, 81 tests passed
- 실제 production `EditorBlockAnalysisButtons`를 저장소 Chromium QA harness로 확인
  - 720×500
  - 390×500
  - 정상/원문 없음 상태에서 잘림, 겹침, 가로 overflow 없음
- `git diff --check` passed

## 핵심 회귀 계약

1. OCR과 번역은 별도 operation이어야 합니다.
2. 선택 block은 ID로 고정하며 전체 페이지 결과와 좌표 기반 재매칭하지 않습니다.
3. OCR은 선택 품질에 따라 Full→VL, Economy/Minimum→일반 OCR을 사용합니다.
4. OCR 성공 시 source text만, 번역 성공 시 translated text만 바꿉니다.
5. 번역 operation은 OCR prepass를 실행하지 않습니다.
6. 선택 번역에서는 현재 source text가 최우선이며 이미지·문맥은 호환되는 의미 해석만 보조합니다.
7. 선택 번역 prompt에는 전체 페이지 스캔, OCR 재판독, 주변 문구 수집 규칙이 섞이지 않아야 합니다.
8. block geometry와 사용자 formatting은 두 operation 모두 보존합니다.
9. main editor와 detached editor가 같은 action을 전달해야 합니다.

## Maintainer / AI 재구현 안내

이 patch를 그대로 병합하지 않더라도 같은 기능을 더 작은 형태로 재구현하려면 다음 경계를 유지하면 됩니다.

- request contract: `targetBlockId` + `targetBlockOperation: "ocr" | "translate"`
- UI: 선택 block 편집기에 OCR/번역 버튼을 분리하고 빈 source text에서는 번역 비활성화
- OCR backend:
  - 정확한 기존 block 하나로 synthetic keep page 구성
  - 기존 block crop OCR helper 재사용
  - effective OCR quality가 Full이면 `ocrBboxMode: "vl"`, Economy/Minimum이면 `"ocr"`
  - source text만 저장
- translation backend:
  - 정확한 기존 block 하나로 keep-block pipeline 실행
  - `skipOcrPrepass: true`
  - 현재 source text를 별도 authoritative input으로 prompt runtime에 전달
  - system/task/previous-block/output prompt에서 이미지·문맥보다 source text를 우선하고 전체 페이지 OCR 규칙을 제외
  - translated text만 저장
- persistence:
  - 최신 chapter를 mutation lock 안에서 다시 읽음
  - target ID가 존재할 때만 text field를 부분 갱신
  - geometry/style/opposite-language field 보존
- detached panel bridge에도 두 action을 직렬화

핵심 파일:

- `src/main/jobs/selectedBlockOcr.ts`
- `src/main/jobs/translationRegionJobRunner.ts`
- `src/main/runtime/prompts/system-prompt.cjs`
- `src/main/runtime/prompts/overlay-prompt.cjs`
- `src/main/runtime/prompts/task-sections.cjs`
- `src/main/libraryStore/libraryAnalysisMutations.ts`
- `src/renderer/src/components/EditorBlockAnalysisButtons.tsx`
- `src/renderer/src/hooks/useSelectedBlockAnalysisActions.ts`
- `tests/blockRegionTranslationJob.test.ts`
- `tests/selectedBlockOcr.test.ts`


## GitHub Actions

원본 저장소의 PR workflow도 통과했습니다.

- Windows `windows-check`: success
- Apple Silicon `macos-arm64-check`: success
  - `npm run check`: success
  - `npm run test:flux-metal`: success
- Run: https://github.com/ucx0204/CarrotMangaTranslator/actions/runs/29938075030
