### PR TITLE
ci: seal Windows release names safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,8 @@ jobs:
             throw "Expected exactly one Windows installer, found $($files.Count)."
           }
           $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $files[0].FullName).Hash.ToLowerInvariant()
-          "$hash  $($files[0].Name)" | Set-Content -Encoding ascii dist/SHA256SUMS-windows.txt
+          $publishedArtifact = "CarrotMangaTranslator-Setup-$env:RELEASE_TAG.exe"
+          "$hash  $publishedArtifact" | Set-Content -Encoding ascii dist/SHA256SUMS-windows.txt
           Copy-Item -LiteralPath $env:RELEASE_NOTES_PATH -Destination dist/release-notes.md
           @{
             schemaVersion = 1
@@ -108,6 +109,7 @@ jobs:
             runId = "${{ github.run_id }}"
             runAttempt = "${{ github.run_attempt }}"
             artifact = $files[0].Name
+            publishedArtifact = $publishedArtifact
             sha256 = $hash
           } | ConvertTo-Json | Set-Content -Encoding utf8 dist/windows-provenance.json
 
@@ -139,12 +141,26 @@ jobs:
 
       - name: Verify sealed Windows artifact
         shell: pwsh
+        env:
+          RELEASE_TAG: ${{ needs.build.outputs.tag }}
+          RELEASE_TARGET: ${{ needs.build.outputs.target }}
         run: |
-          $line = (Get-Content -LiteralPath release-artifact/SHA256SUMS-windows.txt -Raw).Trim()
+          $files = @(Get-ChildItem -Path "release-artifact" -Filter "* Setup *.exe")
+          if ($files.Count -ne 1) {
+            throw "Expected exactly one sealed Windows installer, found $($files.Count)."
+          }
+          $line = (Get-Content -LiteralPath release-artifact/SHA256SUMS-windows.txt -Encoding ascii -Raw).Trim()
           if ($line -notmatch '^([a-f0-9]{64})  (.+\.exe)$') { throw "Invalid Windows checksum manifest." }
           $expected = $Matches[1]
           $fileName = $Matches[2]
-          $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path release-artifact $fileName)).Hash.ToLowerInvariant()
+          $publishedArtifact = "CarrotMangaTranslator-Setup-$env:RELEASE_TAG.exe"
+          if ($fileName -ne $publishedArtifact) { throw "Windows checksum manifest names an unexpected release asset." }
+          $provenance = Get-Content -LiteralPath release-artifact/windows-provenance.json -Encoding utf8 -Raw | ConvertFrom-Json
+          if ($provenance.artifact -ne $files[0].Name) { throw "Windows provenance names an unexpected sealed installer." }
+          if ($provenance.publishedArtifact -ne $publishedArtifact) { throw "Windows provenance names an unexpected published asset." }
+          if ($provenance.sha256 -ne $expected) { throw "Windows provenance checksum does not match the checksum manifest." }
+          if ($provenance.commit -ne $env:RELEASE_TARGET) { throw "Windows provenance commit does not match the release target." }
+          $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $files[0].FullName).Hash.ToLowerInvariant()
           if ($actual -ne $expected) { throw "Windows release artifact checksum mismatch." }
 
       - name: Publish GitHub release assets


### PR DESCRIPTION
## Summary

- Write the Windows checksum manifest against the final ASCII release asset name.
- Keep the Korean sealed installer name only in UTF-8 provenance.
- Verify the sealed installer, published name, target commit, provenance hash, and manifest hash together.

## Root cause

The release workflow wrote the Korean local installer filename to an ASCII checksum file. PowerShell replaced the filename with question marks, so the publish job attempted to hash a nonexistent path after downloading the sealed artifact.

## Validation

- Prettier workflow check passed.
- Git diff check passed.
- Local PowerShell reproduction passed with 당근망가번역기 Setup 1.11.0.exe.
- Canonical published name and SHA-256 were verified.