### PR TITLE
ci: target macOS release uploads explicitly

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -237,7 +237,7 @@ jobs:
           test -s "$zip_path"
           test -s "$provenance_path"
           (cd "$artifact_dir" && shasum -a 256 -c SHA256SUMS-macOS-arm64.txt)
-          gh release upload "$RELEASE_TAG" \
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
             "$dmg_path" \
             "$zip_path" \
             "${checksum_paths[0]}" \

--- a/.github/workflows/publish-verified-mac-artifact.yml
+++ b/.github/workflows/publish-verified-mac-artifact.yml
@@ -117,7 +117,7 @@ jobs:
             '.commit == $commit and (.runId | tostring) == $run_id and .artifacts.dmg == $dmg and .artifacts.zip == $zip' \
             "$provenance_path" >/dev/null
 
-          gh release upload "$RELEASE_TAG" \
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
             "$dmg_path" \
             "$zip_path" \
             "${checksum_paths[0]}" \


### PR DESCRIPTION
## Summary

- Pass the repository explicitly to gh release upload in both macOS publish paths.

## Root cause

Publish jobs do not check out the repository. The GitHub CLI therefore cannot infer a repository from git metadata even though the token, tag, files, checksums, and provenance are valid.

## Evidence

Recovery run 31412278619 successfully:
- verified the source macOS Release run and stable tag
- downloaded the artifact
- verified both DMG and ZIP checksums
- verified provenance

It failed only when gh release upload tried to discover a git repository.

## Validation

- Prettier workflow check passed.
- Git diff check passed.