### PR TITLE
Fix BeeLlama HIP runtime archive extraction

### DIFF
--- a/scripts/verify-packaged-runtime.cjs
+++ b/scripts/verify-packaged-runtime.cjs
@@ -88,9 +88,11 @@ const allowedElectronLocales = new Set([
 // artifacts were omitted. v1.10.1 intentionally adds runtime integrity
 // manifests and hash-complete dependency locks. Font runtime v2 then adds its
 // four small trust/ranker files while leaving the three large model assets
-// external. Keep the resulting payload ceiling exact so unrelated packaging
-// growth still fails closed.
-const MAX_PACKAGED_FILES = 258;
+// external. The runtime hardening pass adds the shared retry scheduler and the
+// pinned BeeLlama archive policy as two small production modules. Keep the
+// resulting payload ceiling exact so unrelated packaging growth still fails
+// closed.
+const MAX_PACKAGED_FILES = 260;
 // The trained font matching runtime bundle (~467 MiB) is externalized out of
 // the installer and downloaded into the data-root cache on first use, so the
 // unpacked payload is ~745 MiB (Electron + app.asar + tools, no bundle) and the

--- a/src/main/runtime/model/llama-runtime-archive-policy.cjs
+++ b/src/main/runtime/model/llama-runtime-archive-policy.cjs
@@ -1,0 +1,209 @@
+// @ts-check
+
+const { randomUUID } = require("node:crypto");
+const { lstat, rename, rm } = require("node:fs/promises");
+const path = require("node:path");
+
+const {
+  MAX_REMOTE_RUNTIME_ARCHIVE_BYTES,
+} = require("../transport/download-budgets.cjs");
+
+/** @typedef {{ originalPath: string; ownedPath: string; restored: boolean }} RuntimeArchiveClaim */
+
+const BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT = Object.freeze({
+  runtimeId: "beellama-v0.3.1-hip-radeon",
+  runtimeKind: "beellama-hip",
+  backend: "rocm",
+  archive: "beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+  url: "https://github.com/Anbeeld/beellama.cpp/releases/download/v0.3.1/beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+  sha256: "53302ae602dc43381f1c61794c2508a5e72931916b6de015531683358dc78fbc",
+  bytes: 553_375_639,
+});
+
+// The contract above contains ggml-hip.dll at exactly 1,515,477,504
+// uncompressed bytes. Scope the exception to the verified asset instead of
+// weakening the shared 1-GiB runtime-archive default for every ZIP and TAR.
+const BEELLAMA_HIP_RADEON_ZIP_EXTRACTION_LIMITS = Object.freeze({
+  maximumEntryBytes: 1_515_477_504,
+});
+
+/** @param {{ id?: unknown; kind?: unknown; backend?: unknown }} runtime */
+function matchesPinnedRuntime(runtime) {
+  return (
+    runtime?.id === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.runtimeId &&
+    runtime?.kind === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.runtimeKind &&
+    runtime?.backend === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.backend
+  );
+}
+
+/** @param {{ archive?: unknown; url?: unknown; sha256?: unknown; expectedBytes?: unknown }} archive */
+function matchesPinnedArchive(archive) {
+  return (
+    archive?.archive === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.archive &&
+    archive?.url === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.url &&
+    archive?.sha256 === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.sha256 &&
+    archive?.expectedBytes === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.bytes
+  );
+}
+
+/** @param {{ sha256?: unknown; bytes?: unknown }} verification */
+function matchesPinnedVerification(verification) {
+  return (
+    verification?.sha256 === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.sha256 &&
+    verification?.bytes === BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.bytes
+  );
+}
+
+/**
+ * @param {{ id?: unknown; kind?: unknown; backend?: unknown }} runtime
+ * @param {{ archive?: unknown; url?: unknown; sha256?: unknown; expectedBytes?: unknown }} archive
+ * @param {{ sha256?: unknown; bytes?: unknown }} verification
+ */
+function resolvePinnedLlamaRuntimeZipExtractionLimits(
+  runtime,
+  archive,
+  verification,
+) {
+  if (!matchesPinnedRuntime(runtime)) return undefined;
+  if (!matchesPinnedArchive(archive)) return undefined;
+  if (!matchesPinnedVerification(verification)) return undefined;
+  return BEELLAMA_HIP_RADEON_ZIP_EXTRACTION_LIMITS;
+}
+
+/** @param {{ expectedBytes?: unknown } | null | undefined} archive */
+function readExpectedRuntimeArchiveBytes(archive) {
+  if (archive?.expectedBytes === undefined) return undefined;
+  const expectedBytes = Number(archive.expectedBytes);
+  if (
+    !Number.isSafeInteger(expectedBytes) ||
+    expectedBytes < 1 ||
+    expectedBytes > MAX_REMOTE_RUNTIME_ARCHIVE_BYTES
+  ) {
+    throw new TypeError(
+      "Gemma 실행 런타임 expectedBytes는 허용 범위의 양의 정수여야 합니다.",
+    );
+  }
+  return expectedBytes;
+}
+
+/** @param {{ expectedBytes?: unknown } | null | undefined} archive */
+function resolveRuntimeArchiveMaximumBytes(archive) {
+  return (
+    readExpectedRuntimeArchiveBytes(archive) ?? MAX_REMOTE_RUNTIME_ARCHIVE_BYTES
+  );
+}
+
+/** @param {Array<{ archive: string; url: string; sha256?: string; expectedBytes?: number }>} archives */
+function assertRuntimeArchiveChecksumsPresent(archives) {
+  if (archives.length === 0) {
+    throw new Error("Gemma 실행 런타임 archive descriptor가 비어 있습니다.");
+  }
+  for (const archive of archives) {
+    if (!normalizeSha256(archive.sha256)) {
+      throw Object.assign(
+        new Error(
+          "Gemma 실행 런타임 descriptor에 유효한 SHA-256이 필요합니다.",
+        ),
+        { archive: archive.archive, url: archive.url },
+      );
+    }
+    resolveRuntimeArchiveMaximumBytes(archive);
+  }
+}
+
+/** @param {unknown} value */
+function normalizeSha256(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  return /^[a-f0-9]{64}$/.test(normalized) ? normalized : "";
+}
+
+/**
+ * Atomically detaches downloaded archives from their stable cache names before
+ * verification. Extraction only sees the unpredictable owned paths; the
+ * stable names are reclaimed with verified bytes before runtime publication.
+ *
+ * @param {string[]} archivePaths
+ * @returns {Promise<Readonly<{ archivePaths: readonly string[]; restore: () => Promise<void> }>>}
+ */
+async function claimRuntimeArchivePaths(archivePaths) {
+  /** @type {RuntimeArchiveClaim[]} */
+  const claims = [];
+  const restore = () => restoreRuntimeArchiveClaims(claims);
+  try {
+    for (const originalPath of archivePaths) {
+      const ownedPath = path.join(
+        path.dirname(originalPath),
+        `.mgt-llama-archive-${randomUUID().replaceAll("-", "")}${runtimeArchiveSuffix(originalPath)}`,
+      );
+      const claim = { originalPath, ownedPath, restored: false };
+      await rename(originalPath, ownedPath);
+      claims.push(claim);
+      const metadata = await lstat(ownedPath);
+      if (!metadata.isFile() || metadata.isSymbolicLink()) {
+        throw new Error(
+          `Gemma 실행 런타임 압축 파일이 일반 파일이 아니어서 설치를 중단했습니다: ${originalPath}`,
+        );
+      }
+    }
+  } catch (error) {
+    try {
+      await restore();
+    } catch (restoreError) {
+      throw new AggregateError(
+        [error, restoreError],
+        "Gemma 실행 런타임 압축 파일 소유권을 복구하지 못했습니다.",
+        { cause: restoreError },
+      );
+    }
+    throw error;
+  }
+  return Object.freeze({
+    archivePaths: Object.freeze(claims.map(({ ownedPath }) => ownedPath)),
+    restore,
+  });
+}
+
+/** @param {string} archivePath */
+function runtimeArchiveSuffix(archivePath) {
+  const lowerName = path.basename(archivePath).toLowerCase();
+  return lowerName.endsWith(".tar.gz") ? ".tar.gz" : path.extname(archivePath);
+}
+
+/** @param {RuntimeArchiveClaim[]} claims */
+async function restoreRuntimeArchiveClaims(claims) {
+  for (const claim of [...claims].reverse()) {
+    if (claim.restored) continue;
+    const ownedExists = await pathExistsWithoutFollowingLinks(claim.ownedPath);
+    // Anything recreated at the public cache name was not the file that was
+    // verified or extracted. Remove only that exact file/symlink; a directory
+    // collision fails closed because recursive deletion is intentionally off.
+    await rm(claim.originalPath, { force: true });
+    if (ownedExists) await rename(claim.ownedPath, claim.originalPath);
+    claim.restored = true;
+  }
+}
+
+/** @param {string} filePath */
+async function pathExistsWithoutFollowingLinks(filePath) {
+  try {
+    await lstat(filePath);
+    return true;
+  } catch (error) {
+    if (/** @type {{ code?: unknown }} */ (error)?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+module.exports = {
+  BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT,
+  assertRuntimeArchiveChecksumsPresent,
+  claimRuntimeArchivePaths,
+  normalizeSha256,
+  readExpectedRuntimeArchiveBytes,
+  resolvePinnedLlamaRuntimeZipExtractionLimits,
+  resolveRuntimeArchiveMaximumBytes,
+};

--- a/src/main/runtime/model/llama-runtime-download.cjs
+++ b/src/main/runtime/model/llama-runtime-download.cjs
@@ -1,7 +1,7 @@
 // @ts-check
 const { createReadStream } = require("node:fs");
 const { createHash } = require("node:crypto");
-const { mkdir, rm, writeFile } = require("node:fs/promises");
+const { mkdir, rm, stat, writeFile } = require("node:fs/promises");
 const path = require("node:path");
 
 const { bundledServerCandidates } = require("../resolve-llama-runtime.cjs");
@@ -9,6 +9,14 @@ const {
   LLAMA_RUNTIME_MARKER_FILE,
   shouldExtractLlamaRuntimeFile,
 } = require("../simple-page-llama-runtimes.cjs");
+const {
+  assertRuntimeArchiveChecksumsPresent,
+  claimRuntimeArchivePaths,
+  normalizeSha256,
+  readExpectedRuntimeArchiveBytes,
+  resolvePinnedLlamaRuntimeZipExtractionLimits,
+  resolveRuntimeArchiveMaximumBytes,
+} = require("./llama-runtime-archive-policy.cjs");
 const {
   downloadHfFileWithProgress,
   mapWithConcurrency,
@@ -43,8 +51,9 @@ const {
 } = require("../transport/download-budgets.cjs");
 
 /** @typedef {import("../runtime-jsdoc-types").RuntimeOptions} ModelAssetOptions */
-/** @typedef {{ archive: string; url: string; sha256?: string; type?: "zip" | "tar.gz"; stripComponents?: number }} LlamaRuntimeArchive */
+/** @typedef {{ archive: string; url: string; sha256?: string; expectedBytes?: number; type?: "zip" | "tar.gz"; stripComponents?: number }} LlamaRuntimeArchive */
 /** @typedef {{ archive?: string; archives?: LlamaRuntimeArchive[]; backend?: string; platform?: string; arch?: string; dir: string; id?: string; kind?: string; requiredFiles?: Array<string | string[]>; url?: string }} LlamaRuntimeDescriptor */
+/** @typedef {{ archivePath: string; archive: LlamaRuntimeArchive; sha256: string; bytes: number }} VerifiedLlamaRuntimeArchive */
 
 /** @param {ModelAssetOptions} [options] */
 async function ensureDefaultLlamaRuntimeDownloaded(options = {}) {
@@ -64,21 +73,29 @@ async function ensureDefaultLlamaRuntimeDownloaded(options = {}) {
     totals,
     aggregate,
   );
-  await verifyRuntimeArchiveChecksums(archivePaths, archives);
-  emitRuntimeInstallStart(options, runtime);
-  await extractRuntimeArchives(
-    layout.runtimeDir,
-    archivePaths,
-    archives,
-    runtime,
-    options,
-  );
-  // Re-read every archive after extraction to close the download/extract TOCTOU
-  // window before any extracted executable is accepted.
-  await verifyRuntimeArchiveChecksums(archivePaths, archives);
-  assertInstalledRuntime(layout, runtime, archivePaths);
-  await writeRuntimeMarker(layout.runtimeDir, runtime, archives);
-  emitRuntimeInstallComplete(options, runtime);
+  const ownership = await claimRuntimeArchivePaths(archivePaths);
+  try {
+    const verifiedArchives = await verifyRuntimeArchiveChecksums(
+      ownership.archivePaths,
+      archives,
+    );
+    emitRuntimeInstallStart(options, runtime);
+    await extractRuntimeArchives(
+      layout.runtimeDir,
+      verifiedArchives,
+      runtime,
+      options,
+      ownership.restore,
+    );
+    assertInstalledRuntime(layout, runtime, archivePaths);
+    await writeRuntimeMarker(layout.runtimeDir, runtime, archives);
+    emitRuntimeInstallComplete(options, runtime);
+  } finally {
+    await safeCleanup(
+      "restore extraction-owned llama runtime archives",
+      ownership.restore,
+    );
+  }
 }
 
 /** @param {ModelAssetOptions} options @param {LlamaRuntimeDescriptor} runtime */
@@ -185,7 +202,7 @@ function buildRuntimeDownloadTask(runtime, archive, destination) {
     file: archive.archive,
     url: archive.url,
     destination,
-    maximumBytes: MAX_REMOTE_RUNTIME_ARCHIVE_BYTES,
+    maximumBytes: resolveRuntimeArchiveMaximumBytes(archive),
     progressPhase: "model_downloading",
     progressTitle: "Gemma 실행 런타임 다운로드 중",
     completeTitle: "Gemma 실행 런타임 다운로드 완료",
@@ -206,13 +223,13 @@ function emitRuntimeInstallStart(options, runtime) {
   );
 }
 
-/** @param {string} runtimeDir @param {string[]} archivePaths @param {LlamaRuntimeArchive[]} archives @param {LlamaRuntimeDescriptor} runtime @param {ModelAssetOptions} options */
+/** @param {string} runtimeDir @param {VerifiedLlamaRuntimeArchive[]} verifiedArchives @param {LlamaRuntimeDescriptor} runtime @param {ModelAssetOptions} options @param {() => Promise<void>} restoreArchivesBeforePublish */
 async function extractRuntimeArchives(
   runtimeDir,
-  archivePaths,
-  archives,
+  verifiedArchives,
   runtime,
   options,
+  restoreArchivesBeforePublish,
 ) {
   const stagingDir = `${runtimeDir}.staging-${process.pid}-${Date.now()}`;
   await safeCleanup("remove stale llama runtime staging directory", () =>
@@ -220,9 +237,8 @@ async function extractRuntimeArchives(
   );
   await mkdir(stagingDir, { recursive: true });
   try {
-    for (let index = 0; index < archivePaths.length; index += 1) {
-      const archivePath = archivePaths[index];
-      const archive = archives[index];
+    for (const verification of verifiedArchives) {
+      const { archivePath, archive } = verification;
       if (archive?.type === "tar.gz" || /\.tar\.gz$/i.test(archivePath)) {
         await extractSelectedTarEntries(
           archivePath,
@@ -238,11 +254,24 @@ async function extractRuntimeArchives(
           archivePath,
           stagingDir,
           shouldExtractLlamaRuntimeFile,
-          { abortSignal: options.abortSignal },
+          {
+            abortSignal: options.abortSignal,
+            limits: resolvePinnedLlamaRuntimeZipExtractionLimits(
+              runtime,
+              archive,
+              verification,
+            ),
+          },
         );
       }
     }
-    await verifyRuntimeArchiveChecksums(archivePaths, archives);
+    // Re-read the extraction-owned paths after extraction. The public cache
+    // names are restored only after this succeeds, so swapping and later
+    // restoring a known download path cannot hide the bytes yauzl consumed.
+    await verifyRuntimeArchiveChecksums(
+      verifiedArchives.map(({ archivePath }) => archivePath),
+      verifiedArchives.map(({ archive }) => archive),
+    );
     if (!hasRequiredLlamaRuntimeFiles(stagingDir, runtime)) {
       throw createDetailedError(
         "Gemma 실행 런타임 압축에 필요한 실행 파일이 없습니다.",
@@ -252,6 +281,7 @@ async function extractRuntimeArchives(
         },
       );
     }
+    await restoreArchivesBeforePublish();
     await replaceDirectoryWithRollback(stagingDir, runtimeDir);
   } catch (error) {
     await safeCleanup("remove rejected llama runtime staging directory", () =>
@@ -261,19 +291,47 @@ async function extractRuntimeArchives(
   }
 }
 
-/** @param {string[]} archivePaths @param {LlamaRuntimeArchive[]} archives */
+/** @param {readonly string[]} archivePaths @param {LlamaRuntimeArchive[]} archives @returns {Promise<VerifiedLlamaRuntimeArchive[]>} */
 async function verifyRuntimeArchiveChecksums(archivePaths, archives) {
+  /** @type {VerifiedLlamaRuntimeArchive[]} */
+  const verified = [];
   for (let index = 0; index < archivePaths.length; index += 1) {
-    const expected = normalizeSha256(archives[index]?.sha256);
+    const archive = archives[index];
+    const expected = normalizeSha256(archive?.sha256);
     if (!expected) {
       throw createDetailedError(
         "Gemma 실행 런타임에 필수 SHA-256이 없어 설치를 중단했습니다.",
-        { archive: archives[index]?.archive },
+        { archive: archive?.archive },
       );
     }
     const archivePath = archivePaths[index];
+    const actualBytes = (await stat(archivePath)).size;
+    const expectedBytes = readExpectedRuntimeArchiveBytes(archive);
+    if (expectedBytes !== undefined && actualBytes !== expectedBytes) {
+      await safeCleanup("remove size-mismatched llama runtime archive", () =>
+        rm(archivePath, { force: true }),
+      );
+      throw createDetailedError(
+        "Gemma 실행 런타임 압축 파일 크기가 고정된 값과 일치하지 않아 설치를 중단했습니다.",
+        {
+          archivePath,
+          expectedBytes,
+          actualBytes,
+        },
+      );
+    }
     const actual = await calculateFileSha256(archivePath);
-    if (actual === expected) continue;
+    if (actual === expected) {
+      verified.push(
+        Object.freeze({
+          archivePath,
+          archive: Object.freeze({ ...archive }),
+          sha256: actual,
+          bytes: actualBytes,
+        }),
+      );
+      continue;
+    }
     await safeCleanup("remove checksum-mismatched llama runtime archive", () =>
       rm(archivePath, { force: true }),
     );
@@ -286,21 +344,7 @@ async function verifyRuntimeArchiveChecksums(archivePaths, archives) {
       },
     );
   }
-}
-
-/** @param {LlamaRuntimeArchive[]} archives */
-function assertRuntimeArchiveChecksumsPresent(archives) {
-  if (archives.length === 0) {
-    throw new Error("Gemma 실행 런타임 archive descriptor가 비어 있습니다.");
-  }
-  for (const archive of archives) {
-    if (!normalizeSha256(archive.sha256)) {
-      throw createDetailedError(
-        "Gemma 실행 런타임 descriptor에 유효한 SHA-256이 필요합니다.",
-        { archive: archive.archive, url: archive.url },
-      );
-    }
-  }
+  return verified;
 }
 
 /** @param {string} filePath */
@@ -308,14 +352,6 @@ async function calculateFileSha256(filePath) {
   const hash = createHash("sha256");
   for await (const chunk of createReadStream(filePath)) hash.update(chunk);
   return hash.digest("hex");
-}
-
-/** @param {unknown} value */
-function normalizeSha256(value) {
-  const normalized = String(value || "")
-    .trim()
-    .toLowerCase();
-  return /^[a-f0-9]{64}$/.test(normalized) ? normalized : "";
 }
 
 /** @param {ReturnType<typeof buildRuntimeLayout>} layout @param {LlamaRuntimeDescriptor} runtime @param {string[]} archivePaths */
@@ -399,6 +435,8 @@ function getLlamaRuntimeArchives(runtime) {
 module.exports = {
   assertRuntimeArchiveChecksumsPresent,
   calculateFileSha256,
+  claimRuntimeArchivePaths,
   ensureDefaultLlamaRuntimeDownloaded,
+  extractRuntimeArchives,
   verifyRuntimeArchiveChecksums,
 };

--- a/src/main/runtime/model/llama-runtime-installed-integrity.cjs
+++ b/src/main/runtime/model/llama-runtime-installed-integrity.cjs
@@ -1,7 +1,24 @@
 // @ts-check
 const { createHash } = require("node:crypto");
-const { readFileSync, readdirSync } = require("node:fs");
+const {
+  closeSync,
+  fstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+} = require("node:fs");
 const path = require("node:path");
+
+const INSTALLED_RUNTIME_HASH_CHUNK_BYTES = 4 * 1024 * 1024;
+const DEFAULT_RUNTIME_HASH_IO = Object.freeze({
+  closeSync,
+  fstatSync,
+  openSync,
+  readSync,
+});
+/** @type {Buffer | null} */
+let installedRuntimeHashBuffer = null;
 
 /** @typedef {{ archive?: unknown; url?: unknown; sha256?: unknown }} MarkerArchive */
 /** @typedef {{ id?: unknown; kind?: unknown; dir?: unknown; archives?: MarkerArchive[]; installedFileSha256?: unknown }} InstalledRuntimeMarker */
@@ -24,14 +41,14 @@ function collectInstalledRuntimeFileHashes(runtimeDir) {
         : entry.name;
       if (entry.isDirectory()) {
         stack.push({ absolute, relative });
-      } else if (entry.isFile() && isExecutableRuntimeFile(relative)) {
-        hashes[relative] = hashFile(absolute);
+      } else if (entry.isFile() && isIntegrityProtectedRuntimeFile(relative)) {
+        hashes[relative] = hashInstalledRuntimeFile(absolute);
       }
     }
   }
   if (Object.keys(hashes).length === 0) {
     throw new Error(
-      "Installed llama runtime contains no hashable executable files.",
+      "Installed llama runtime contains no integrity-protected files.",
     );
   }
   return Object.fromEntries(
@@ -65,9 +82,10 @@ function installedRuntimeHashesMatch(runtimeDir, expectedValue) {
 }
 
 /**
- * Validates both the trusted runtime descriptor binding and every executable
- * file hash. Callers use this immediately before a managed runtime is spawned,
- * not only while deciding whether an existing installation can be reused.
+ * Validates both the trusted runtime descriptor binding and every protected
+ * runtime-file hash. Callers use this immediately before a managed runtime is
+ * spawned, not only while deciding whether an existing installation can be
+ * reused.
  *
  * @param {string} runtimeDir
  * @param {RuntimeDescriptor} runtime
@@ -146,22 +164,89 @@ function validInstalledFile(runtimeDir, actual, relativePath, digest) {
 }
 
 /** @param {string} relativePath */
-function isExecutableRuntimeFile(relativePath) {
-  const name = path.posix.basename(relativePath).toLowerCase();
+function isIntegrityProtectedRuntimeFile(relativePath) {
+  const normalized = String(relativePath).replace(/\\/g, "/").toLowerCase();
+  const name = path.posix.basename(normalized);
   return (
     name === "llama-server" ||
     name === "llama-cli" ||
-    /\.(?:exe|dll|dylib|so|metal|metallib)$/i.test(name)
+    /\.(?:exe|dll|dylib|so|metal|metallib)$/i.test(name) ||
+    (isRocmKernelLibraryPath(normalized) && /\.(?:co|dat|hsaco)$/i.test(name))
   );
 }
 
-/** @param {string} filePath */
-function hashFile(filePath) {
-  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+/** @param {string} normalizedRelativePath */
+function isRocmKernelLibraryPath(normalizedRelativePath) {
+  return (
+    normalizedRelativePath.startsWith("rocblas/") ||
+    normalizedRelativePath.startsWith("hipblaslt/")
+  );
+}
+
+/**
+ * @typedef {{
+ *   closeSync: (fd: number) => void;
+ *   fstatSync: (fd: number) => { isFile: () => boolean; size: number };
+ *   openSync: (filePath: string, flags: string) => number;
+ *   readSync: (fd: number, buffer: Buffer, offset: number, length: number, position: number | null) => number;
+ * }} RuntimeHashIo
+ */
+
+/** @returns {Buffer} */
+function getInstalledRuntimeHashBuffer() {
+  if (!installedRuntimeHashBuffer) {
+    installedRuntimeHashBuffer = Buffer.allocUnsafe(
+      INSTALLED_RUNTIME_HASH_CHUNK_BYTES,
+    );
+  }
+  return installedRuntimeHashBuffer;
+}
+
+/** @param {string} filePath @param {RuntimeHashIo} [io] */
+function hashInstalledRuntimeFile(filePath, io = DEFAULT_RUNTIME_HASH_IO) {
+  const fd = io.openSync(filePath, "r");
+  try {
+    const initial = io.fstatSync(fd);
+    if (
+      !initial.isFile() ||
+      !Number.isSafeInteger(initial.size) ||
+      initial.size < 0
+    ) {
+      throw new Error(`Installed llama runtime file is invalid: ${filePath}`);
+    }
+    const hash = createHash("sha256");
+    const buffer = getInstalledRuntimeHashBuffer();
+    let position = 0;
+    while (position < initial.size) {
+      const requested = Math.min(buffer.length, initial.size - position);
+      const bytesRead = io.readSync(fd, buffer, 0, requested, position);
+      if (
+        !Number.isSafeInteger(bytesRead) ||
+        bytesRead < 1 ||
+        bytesRead > requested
+      ) {
+        throw new Error(
+          `Installed llama runtime file changed while hashing: ${filePath}`,
+        );
+      }
+      hash.update(buffer.subarray(0, bytesRead));
+      position += bytesRead;
+    }
+    if (io.fstatSync(fd).size !== initial.size) {
+      throw new Error(
+        `Installed llama runtime file changed while hashing: ${filePath}`,
+      );
+    }
+    return hash.digest("hex");
+  } finally {
+    io.closeSync(fd);
+  }
 }
 
 module.exports = {
+  INSTALLED_RUNTIME_HASH_CHUNK_BYTES,
   collectInstalledRuntimeFileHashes,
+  hashInstalledRuntimeFile,
   installedRuntimeHashesMatch,
   installedRuntimeMarkerMatches,
 };

--- a/src/main/runtime/runtime-jsdoc-types.d.ts
+++ b/src/main/runtime/runtime-jsdoc-types.d.ts
@@ -85,6 +85,7 @@ export type LlamaRuntimeArchive = {
   archive: string;
   url: string;
   sha256?: string;
+  expectedBytes?: number;
   type?: "zip" | "tar.gz";
   stripComponents?: number;
 };

--- a/src/main/runtime/simple-page-llama-runtimes.cjs
+++ b/src/main/runtime/simple-page-llama-runtimes.cjs
@@ -1,4 +1,7 @@
 // @ts-check
+const {
+  BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT,
+} = require("./model/llama-runtime-archive-policy.cjs");
 const BEELLAMA_LLAMA_RUNTIME_CUDA12 = {
   id: "beellama-v0.2.0-cuda12.4",
   kind: "beellama",
@@ -60,18 +63,18 @@ const BEELLAMA_LLAMA_RUNTIME_CUDA13 = {
 };
 
 const BEELLAMA_LLAMA_RUNTIME_HIP_RADEON = {
-  id: "beellama-v0.3.1-hip-radeon",
-  kind: "beellama-hip",
-  backend: "rocm",
+  id: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.runtimeId,
+  kind: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.runtimeKind,
+  backend: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.backend,
   dir: "beellama-v0.3.1-hip-radeon",
-  archive: "beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
-  url: "https://github.com/Anbeeld/beellama.cpp/releases/download/v0.3.1/beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
+  archive: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.archive,
+  url: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.url,
   archives: [
     {
-      archive: "beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
-      url: "https://github.com/Anbeeld/beellama.cpp/releases/download/v0.3.1/beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
-      sha256:
-        "53302ae602dc43381f1c61794c2508a5e72931916b6de015531683358dc78fbc",
+      archive: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.archive,
+      url: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.url,
+      sha256: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.sha256,
+      expectedBytes: BEELLAMA_HIP_RADEON_ARCHIVE_CONTRACT.bytes,
     },
   ],
   requiredFiles: [

--- a/tests/installerConfig.test.ts
+++ b/tests/installerConfig.test.ts
@@ -188,7 +188,7 @@ describe("Windows installer clean uninstall option", () => {
       "const MAX_PACKAGED_BYTES = 1000 * 1024 * 1024;",
     );
     expect(packagedRuntimeVerifier).toContain(
-      "const MAX_PACKAGED_FILES = 258;",
+      "const MAX_PACKAGED_FILES = 260;",
     );
     expect((electronBuilderConfig as { files: string[] }).files).toEqual(
       expect.arrayContaining([

--- a/tests/llamaRuntimeArchiveOwnership.test.ts
+++ b/tests/llamaRuntimeArchiveOwnership.test.ts
@@ -1,0 +1,164 @@
+import { createRequire } from "node:module";
+import { createWriteStream } from "node:fs";
+import { access, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+import * as yazl from "yazl";
+
+const require = createRequire(import.meta.url);
+const {
+  calculateFileSha256,
+  claimRuntimeArchivePaths,
+  extractRuntimeArchives,
+  verifyRuntimeArchiveChecksums,
+} = require("../src/main/runtime/model/llama-runtime-download.cjs") as {
+  calculateFileSha256: (filePath: string) => Promise<string>;
+  claimRuntimeArchivePaths: (archivePaths: string[]) => Promise<{
+    archivePaths: readonly string[];
+    restore: () => Promise<void>;
+  }>;
+  extractRuntimeArchives: (
+    runtimeDir: string,
+    verifiedArchives: Array<{
+      archivePath: string;
+      archive: RuntimeArchive;
+      sha256: string;
+      bytes: number;
+    }>,
+    runtime: RuntimeDescriptor,
+    options: { abortSignal?: AbortSignal },
+    restoreArchivesBeforePublish: () => Promise<void>,
+  ) => Promise<void>;
+  verifyRuntimeArchiveChecksums: (
+    archivePaths: readonly string[],
+    archives: RuntimeArchive[],
+  ) => Promise<
+    Array<{
+      archivePath: string;
+      archive: RuntimeArchive;
+      sha256: string;
+      bytes: number;
+    }>
+  >;
+};
+
+type RuntimeArchive = {
+  archive: string;
+  url: string;
+  sha256: string;
+};
+
+type RuntimeDescriptor = {
+  id: string;
+  kind: string;
+  backend: string;
+  dir: string;
+  requiredFiles: string[];
+};
+
+const TEST_RUNTIME: RuntimeDescriptor = {
+  id: "test-vulkan-runtime",
+  kind: "test",
+  backend: "vulkan",
+  dir: "test-vulkan-runtime",
+  requiredFiles: ["llama-server.exe", "ggml-vulkan.dll"],
+};
+
+describe("llama runtime archive ownership", () => {
+  it("publishes only the claimed archive when the public cache path is swapped", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mgt-llama-owned-"));
+    const archivePath = join(root, "runtime.zip");
+    const runtimeDir = join(root, "installed-runtime");
+    await writeRuntimeZip(archivePath, "trusted");
+    const archive = await describeRuntimeArchive(archivePath);
+    const ownership = await claimRuntimeArchivePaths([archivePath]);
+
+    try {
+      expect(ownership.archivePaths).toHaveLength(1);
+      expect(ownership.archivePaths[0]).not.toBe(archivePath);
+      await expect(access(archivePath)).rejects.toThrow();
+
+      const verified = await verifyRuntimeArchiveChecksums(
+        ownership.archivePaths,
+        [archive],
+      );
+
+      // This is the stable path an attacker could swap after preverification.
+      // Extraction must continue to consume only the claimed random path.
+      await writeRuntimeZip(archivePath, "unverified");
+      await extractRuntimeArchives(
+        runtimeDir,
+        verified,
+        TEST_RUNTIME,
+        {},
+        ownership.restore,
+      );
+
+      expect(await readFile(join(runtimeDir, "llama-server.exe"), "utf8")).toBe(
+        "trusted-server",
+      );
+      expect(await readFile(join(runtimeDir, "ggml-vulkan.dll"), "utf8")).toBe(
+        "trusted-backend",
+      );
+      expect(await calculateFileSha256(archivePath)).toBe(archive.sha256);
+    } finally {
+      await ownership.restore();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails before publication when the verified cache path cannot be restored", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mgt-llama-owned-blocked-"));
+    const archivePath = join(root, "runtime.zip");
+    const runtimeDir = join(root, "installed-runtime");
+    await writeRuntimeZip(archivePath, "trusted");
+    const archive = await describeRuntimeArchive(archivePath);
+    const ownership = await claimRuntimeArchivePaths([archivePath]);
+
+    try {
+      const verified = await verifyRuntimeArchiveChecksums(
+        ownership.archivePaths,
+        [archive],
+      );
+      await mkdir(archivePath);
+
+      await expect(
+        extractRuntimeArchives(
+          runtimeDir,
+          verified,
+          TEST_RUNTIME,
+          {},
+          ownership.restore,
+        ),
+      ).rejects.toThrow();
+      await expect(access(runtimeDir)).rejects.toThrow();
+    } finally {
+      await rm(archivePath, { recursive: true, force: true });
+      await ownership.restore();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+async function describeRuntimeArchive(
+  archivePath: string,
+): Promise<RuntimeArchive> {
+  return {
+    archive: "runtime.zip",
+    url: "https://example.invalid/runtime.zip",
+    sha256: await calculateFileSha256(archivePath),
+  };
+}
+
+async function writeRuntimeZip(
+  archivePath: string,
+  content: "trusted" | "unverified",
+): Promise<void> {
+  const zip = new yazl.ZipFile();
+  zip.addBuffer(Buffer.from(`${content}-server`), "llama-server.exe");
+  zip.addBuffer(Buffer.from(`${content}-backend`), "ggml-vulkan.dll");
+  zip.end();
+  await pipeline(zip.outputStream, createWriteStream(archivePath));
+}

--- a/tests/llamaRuntimePaths.test.ts
+++ b/tests/llamaRuntimePaths.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -66,10 +67,33 @@ const {
     archive: string;
     url: string;
     backend: string;
-    archives: Array<{ archive: string; url: string; sha256?: string }>;
+    archives: Array<{
+      archive: string;
+      url: string;
+      sha256?: string;
+      expectedBytes?: number;
+    }>;
     requiredFiles: Array<string | string[]>;
   };
 };
+const { resolvePinnedLlamaRuntimeZipExtractionLimits } =
+  require("../src/main/runtime/model/llama-runtime-archive-policy.cjs") as {
+    resolvePinnedLlamaRuntimeZipExtractionLimits: (
+      runtime: Record<string, unknown>,
+      archive: Record<string, unknown>,
+      verification: { sha256: string; bytes: number },
+    ) => { maximumEntryBytes: number } | undefined;
+  };
+const { resolveRuntimeArchiveMaximumBytes } =
+  require("../src/main/runtime/model/llama-runtime-archive-policy.cjs") as {
+    resolveRuntimeArchiveMaximumBytes: (archive: {
+      expectedBytes?: number;
+    }) => number;
+  };
+const { MAX_REMOTE_RUNTIME_ARCHIVE_BYTES } =
+  require("../src/main/runtime/transport/download-budgets.cjs") as {
+    MAX_REMOTE_RUNTIME_ARCHIVE_BYTES: number;
+  };
 const {
   isIncompleteManagedLlamaRuntime,
   resolveLlamaRuntimePreflightTimeoutMs,
@@ -83,11 +107,31 @@ const {
     options?: Record<string, unknown>,
   ) => number;
 };
-const { collectInstalledRuntimeFileHashes } =
+const {
+  INSTALLED_RUNTIME_HASH_CHUNK_BYTES,
+  collectInstalledRuntimeFileHashes,
+  hashInstalledRuntimeFile,
+} =
   require("../src/main/runtime/model/llama-runtime-installed-integrity.cjs") as {
+    INSTALLED_RUNTIME_HASH_CHUNK_BYTES: number;
     collectInstalledRuntimeFileHashes: (
       runtimeDir: string,
     ) => Record<string, string>;
+    hashInstalledRuntimeFile: (
+      filePath: string,
+      io?: {
+        closeSync: (fd: number) => void;
+        fstatSync: (fd: number) => { isFile: () => boolean; size: number };
+        openSync: (filePath: string, flags: string) => number;
+        readSync: (
+          fd: number,
+          buffer: Buffer,
+          offset: number,
+          length: number,
+          position: number | null,
+        ) => number;
+      },
+    ) => string;
   };
 
 describe("llama runtime path selection", () => {
@@ -133,7 +177,95 @@ describe("llama runtime path selection", () => {
     expect(runtime.url).toBe(
       "https://github.com/Anbeeld/beellama.cpp/releases/download/v0.3.1/beellama-v0.3.1-bin-win-hip-radeon-x64.zip",
     );
-    expect(runtime.archives[0]?.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(runtime.archives[0]).toMatchObject({
+      sha256:
+        "53302ae602dc43381f1c61794c2508a5e72931916b6de015531683358dc78fbc",
+      expectedBytes: 553_375_639,
+    });
+  });
+
+  it("scopes the large HIP entry budget to the exact verified BeeLlama archive", () => {
+    const runtime = resolvePreferredLlamaRuntime({
+      llamaRuntimeProfile: "rocm",
+      llamaRocmTarget: "gfx110X",
+      modelRepo: DEFAULT_GEMMA_MODEL_REPO,
+      modelFile: DEFAULT_GEMMA_MODEL_FILE,
+    });
+    const archive = runtime.archives[0];
+    if (!archive?.sha256 || archive.expectedBytes === undefined) {
+      throw new Error("BeeLlama HIP archive binding is incomplete.");
+    }
+    const verification = {
+      sha256: archive.sha256,
+      bytes: archive.expectedBytes,
+    };
+
+    const limits = resolvePinnedLlamaRuntimeZipExtractionLimits(
+      runtime,
+      archive,
+      verification,
+    );
+    expect(limits).toEqual({ maximumEntryBytes: 1_515_477_504 });
+    expect(Object.isFrozen(limits)).toBe(true);
+    expect(resolveRuntimeArchiveMaximumBytes(archive)).toBe(553_375_639);
+
+    const mismatches: Array<
+      [Record<string, unknown>, Record<string, unknown>, typeof verification]
+    > = [
+      [{ ...runtime, id: "other-runtime" }, archive, verification],
+      [{ ...runtime, kind: "other-kind" }, archive, verification],
+      [{ ...runtime, backend: "cuda" }, archive, verification],
+      [runtime, { ...archive, archive: "other.zip" }, verification],
+      [
+        runtime,
+        { ...archive, url: "https://example.invalid/other.zip" },
+        verification,
+      ],
+      [runtime, { ...archive, sha256: "0".repeat(64) }, verification],
+      [
+        runtime,
+        { ...archive, expectedBytes: archive.expectedBytes + 1 },
+        verification,
+      ],
+      [runtime, archive, { ...verification, sha256: "0".repeat(64) }],
+      [runtime, archive, { ...verification, bytes: verification.bytes + 1 }],
+    ];
+    for (const [
+      candidateRuntime,
+      candidateArchive,
+      candidateVerification,
+    ] of mismatches) {
+      expect(
+        resolvePinnedLlamaRuntimeZipExtractionLimits(
+          candidateRuntime,
+          candidateArchive,
+          candidateVerification,
+        ),
+      ).toBeUndefined();
+    }
+
+    const otherRuntime = resolvePreferredLlamaRuntime({
+      llamaRuntimeProfile: "cuda12",
+      modelRepo: GEMMA_26B_MODEL_REPO,
+      modelFile: GEMMA_26B_MODEL_FILE_IQ3_S,
+    });
+    const otherArchive = otherRuntime.archives[0];
+    if (!otherArchive?.sha256) {
+      throw new Error("CUDA archive binding is incomplete.");
+    }
+    expect(resolveRuntimeArchiveMaximumBytes(otherArchive)).toBe(
+      MAX_REMOTE_RUNTIME_ARCHIVE_BYTES,
+    );
+    expect(
+      resolvePinnedLlamaRuntimeZipExtractionLimits(otherRuntime, otherArchive, {
+        sha256: otherArchive.sha256,
+        bytes: 0,
+      }),
+    ).toBeUndefined();
+
+    expect(() =>
+      resolveRuntimeArchiveMaximumBytes({ expectedBytes: 0 }),
+    ).toThrow(/expectedBytes/);
   });
 
   it("does not require a target-specific Lemonade archive for 31B ROCm DFlash", () => {
@@ -322,6 +454,144 @@ describe("llama runtime path selection", () => {
 
       expect(isIncompleteManagedLlamaRuntime(serverPath, options)).toBe(false);
       writeFileSync(serverPath, "tampered after installation");
+      expect(isIncompleteManagedLlamaRuntime(serverPath, options)).toBe(true);
+    } finally {
+      rmSync(managedToolsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("hashes installed runtime files with one bounded reusable chunk", () => {
+    const chunkBytes = INSTALLED_RUNTIME_HASH_CHUNK_BYTES;
+    const logicalBytes = chunkBytes * 2 + 37;
+    const requestedReads: number[] = [];
+    const expected = createHash("sha256");
+    for (let position = 0; position < logicalBytes; ) {
+      const length = Math.min(chunkBytes, logicalBytes - position);
+      const byte = Math.floor(position / chunkBytes) + 1;
+      expected.update(Buffer.alloc(length, byte));
+      position += length;
+    }
+    let closed = false;
+    const digest = hashInstalledRuntimeFile("virtual-large-runtime.dll", {
+      openSync(filePath, flags) {
+        expect(filePath).toBe("virtual-large-runtime.dll");
+        expect(flags).toBe("r");
+        return 17;
+      },
+      fstatSync(fd) {
+        expect(fd).toBe(17);
+        return { isFile: () => true, size: logicalBytes };
+      },
+      readSync(fd, buffer, offset, length, position) {
+        expect(fd).toBe(17);
+        expect(offset).toBe(0);
+        expect(position).not.toBeNull();
+        requestedReads.push(length);
+        const byte = Math.floor(Number(position) / chunkBytes) + 1;
+        buffer.fill(byte, 0, length);
+        return length;
+      },
+      closeSync(fd) {
+        expect(fd).toBe(17);
+        closed = true;
+      },
+    });
+
+    expect(digest).toBe(expected.digest("hex"));
+    expect(requestedReads).toEqual([chunkBytes, chunkBytes, 37]);
+    expect(Math.max(...requestedReads)).toBe(chunkBytes);
+    expect(closed).toBe(true);
+  });
+
+  it("closes and rejects a runtime file that shrinks during chunked hashing", () => {
+    let closed = false;
+    expect(() =>
+      hashInstalledRuntimeFile("shrinking-runtime.dll", {
+        openSync: () => 23,
+        fstatSync: () => ({ isFile: () => true, size: 8 }),
+        readSync: () => 0,
+        closeSync: () => {
+          closed = true;
+        },
+      }),
+    ).toThrow(/changed while hashing/);
+    expect(closed).toBe(true);
+  });
+
+  it("hashes required ROCm kernel artifacts and rejects their later tampering", () => {
+    const managedToolsDir = mkdtempSync(
+      join(tmpdir(), "mgt-managed-rocm-kernel-integrity-"),
+    );
+    const options = {
+      managedToolsDir,
+      llamaRuntimeProfile: "rocm",
+      llamaRocmTarget: "gfx110X",
+      modelSource: "huggingface",
+      modelRepo: DEFAULT_GEMMA_MODEL_REPO,
+      modelFile: DEFAULT_GEMMA_MODEL_FILE,
+    };
+    const runtime = resolvePreferredLlamaRuntime(options);
+    const runtimeDir = join(managedToolsDir, runtime.dir);
+    const rocblasDir = join(runtimeDir, "rocblas", "library");
+    const hipblasltDir = join(runtimeDir, "hipblaslt", "library");
+    mkdirSync(rocblasDir, { recursive: true });
+    mkdirSync(hipblasltDir, { recursive: true });
+    try {
+      for (const requirement of runtime.requiredFiles) {
+        const fileName = Array.isArray(requirement)
+          ? requirement[0]
+          : requirement;
+        writeFileSync(join(runtimeDir, fileName), `trusted:${fileName}`);
+      }
+      const rocblasKernel = join(
+        rocblasDir,
+        "TensileLibrary_Type_HH_gfx1101.dat",
+      );
+      const hipblasltKernel = join(
+        hipblasltDir,
+        "Kernels.so-000-gfx1101.hsaco",
+      );
+      const rocblasCodeObject = join(
+        rocblasDir,
+        "TensileLibrary_Type_HH_gfx1101.co",
+      );
+      writeFileSync(rocblasKernel, "trusted rocblas kernel");
+      writeFileSync(hipblasltKernel, "trusted hipblaslt kernel");
+      writeFileSync(rocblasCodeObject, "trusted rocblas code object");
+      writeFileSync(join(runtimeDir, "unrelated.dat"), "not executable data");
+
+      const installedFileSha256 = collectInstalledRuntimeFileHashes(runtimeDir);
+      expect(installedFileSha256).toHaveProperty(
+        "rocblas/library/TensileLibrary_Type_HH_gfx1101.dat",
+      );
+      expect(installedFileSha256).toHaveProperty(
+        "hipblaslt/library/Kernels.so-000-gfx1101.hsaco",
+      );
+      expect(installedFileSha256).toHaveProperty(
+        "rocblas/library/TensileLibrary_Type_HH_gfx1101.co",
+      );
+      expect(installedFileSha256).not.toHaveProperty("unrelated.dat");
+
+      const serverPath = join(runtimeDir, "llama-server.exe");
+      writeFileSync(
+        join(runtimeDir, ".mgt-runtime.json"),
+        JSON.stringify({
+          id: runtime.id,
+          kind: runtime.kind,
+          dir: runtime.dir,
+          // v1.13 markers predate expectedBytes. The immutable SHA binding is
+          // sufficient for compatibility while new installs also pin bytes.
+          archives: runtime.archives.map((archive) => ({
+            archive: archive.archive,
+            url: archive.url,
+            sha256: archive.sha256,
+          })),
+          installedFileSha256,
+        }),
+      );
+      expect(isIncompleteManagedLlamaRuntime(serverPath, options)).toBe(false);
+
+      writeFileSync(hipblasltKernel, "tampered hipblaslt kernel");
       expect(isIncompleteManagedLlamaRuntime(serverPath, options)).toBe(true);
     } finally {
       rmSync(managedToolsDir, { recursive: true, force: true });

--- a/tests/macGemmaMetal.test.ts
+++ b/tests/macGemmaMetal.test.ts
@@ -118,13 +118,30 @@ const {
   verifyRuntimeArchiveChecksums,
 } = require("../src/main/runtime/model/llama-runtime-download.cjs") as {
   assertRuntimeArchiveChecksumsPresent: (
-    archives: Array<{ archive: string; url: string; sha256?: string }>,
+    archives: Array<{
+      archive: string;
+      url: string;
+      sha256?: string;
+      expectedBytes?: number;
+    }>,
   ) => void;
   calculateFileSha256: (filePath: string) => Promise<string>;
   verifyRuntimeArchiveChecksums: (
     paths: string[],
-    archives: Array<{ archive: string; url: string; sha256?: string }>,
-  ) => Promise<void>;
+    archives: Array<{
+      archive: string;
+      url: string;
+      sha256?: string;
+      expectedBytes?: number;
+    }>,
+  ) => Promise<
+    Array<{
+      archivePath: string;
+      archive: Record<string, unknown>;
+      sha256: string;
+      bytes: number;
+    }>
+  >;
 };
 const { shouldExtractLlamaRuntimeFile } =
   require("../src/main/runtime/simple-page-llama-runtimes.cjs") as {
@@ -396,6 +413,60 @@ describe("Metal runtime archive integrity", () => {
       expect(await calculateFileSha256(file)).toBe(
         "44c9c555407dde048d213b49a590e553f0d88f1cc9f29b7824b66bcc4aa1f053",
       );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a byte-bound verified receipt for a pinned runtime archive", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mgt-runtime-receipt-"));
+    try {
+      const file = join(dir, "runtime.zip");
+      writeFileSync(file, "pinned-runtime");
+      const sha256 = await calculateFileSha256(file);
+      const archive = {
+        archive: "runtime.zip",
+        url: "https://example.invalid/runtime.zip",
+        sha256,
+        expectedBytes: 14,
+      };
+
+      const receipts = await verifyRuntimeArchiveChecksums([file], [archive]);
+      expect(receipts).toEqual([
+        {
+          archivePath: file,
+          archive,
+          sha256,
+          bytes: 14,
+        },
+      ]);
+      expect(Object.isFrozen(receipts[0])).toBe(true);
+      expect(Object.isFrozen(receipts[0]?.archive)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deletes a downloaded runtime when its pinned byte size mismatches", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mgt-runtime-bad-size-"));
+    try {
+      const file = join(dir, "runtime.zip");
+      writeFileSync(file, "pinned-runtime");
+      const sha256 = await calculateFileSha256(file);
+      await expect(
+        verifyRuntimeArchiveChecksums(
+          [file],
+          [
+            {
+              archive: "runtime.zip",
+              url: "https://example.invalid/runtime.zip",
+              sha256,
+              expectedBytes: 15,
+            },
+          ],
+        ),
+      ).rejects.toThrow(/크기/);
+      expect(existsSync(file)).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/runtimeArchivePolicy.test.ts
+++ b/tests/runtimeArchivePolicy.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { createWriteStream } from "node:fs";
 import {
   mkdtemp,
   mkdir,
@@ -9,16 +10,29 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pipeline } from "node:stream/promises";
 import { describe, expect, it, vi } from "vitest";
+import * as yazl from "yazl";
 
 const require = createRequire(import.meta.url);
 const {
+  DEFAULT_RUNTIME_ARCHIVE_EXTRACTION_LIMITS,
+  MAX_RUNTIME_ARCHIVE_ENTRY_BYTES,
   MAX_RUNTIME_ARCHIVE_ENTRY_COUNT,
+  MAX_RUNTIME_ARCHIVE_EXPANDED_BYTES,
   addArchiveEntryToBudget,
   createArchiveExtractionDeadline,
   resolveArchiveExtractionLimits,
 } = require("../src/main/runtime/archive-extraction-policy.cjs") as {
+  DEFAULT_RUNTIME_ARCHIVE_EXTRACTION_LIMITS: {
+    maximumEntries: number;
+    maximumEntryBytes: number;
+    maximumExpandedBytes: number;
+    maximumCompressionRatio: number;
+  };
+  MAX_RUNTIME_ARCHIVE_ENTRY_BYTES: number;
   MAX_RUNTIME_ARCHIVE_ENTRY_COUNT: number;
+  MAX_RUNTIME_ARCHIVE_EXPANDED_BYTES: number;
   addArchiveEntryToBudget: (
     budget: { entryCount: number; expandedBytes: number },
     entry: {
@@ -51,8 +65,21 @@ const {
     maximumCompressionRatio: number;
   };
 };
-const { normalizeSafeZipPath } =
+const { extractSelectedZipEntries, normalizeSafeZipPath } =
   require("../src/main/runtime/simple-page-zip-utils.cjs") as {
+    extractSelectedZipEntries: (
+      archivePath: string,
+      outputDir: string,
+      shouldExtract: (name: string, relativePath: string) => boolean,
+      options?: {
+        limits?: {
+          maximumEntries?: number;
+          maximumEntryBytes?: number;
+          maximumExpandedBytes?: number;
+          maximumCompressionRatio?: number;
+        };
+      },
+    ) => Promise<void>;
     normalizeSafeZipPath: (value: string) => string;
   };
 const { replaceDirectoryWithRollback } =
@@ -112,6 +139,100 @@ describe("runtime archive extraction policy", () => {
     expect(() => resolveArchiveExtractionLimits({ maximumEntries: 0 })).toThrow(
       "maximumEntries",
     );
+  });
+
+  it("keeps global limits while allowing only the pinned HIP entry size", () => {
+    const ggmlHipBytes = 1_515_477_504;
+    expect(MAX_RUNTIME_ARCHIVE_ENTRY_BYTES).toBe(1024 * 1024 * 1024);
+    expect(MAX_RUNTIME_ARCHIVE_EXPANDED_BYTES).toBe(4 * 1024 * 1024 * 1024);
+
+    const entry = {
+      name: "ggml-hip.dll",
+      size: ggmlHipBytes,
+      compressedSize: 330_348_185,
+    };
+    expect(() =>
+      addArchiveEntryToBudget(
+        { entryCount: 0, expandedBytes: 0 },
+        entry,
+        "beellama.zip",
+      ),
+    ).toThrow(/entry is too large/);
+
+    const pinnedLimits = resolveArchiveExtractionLimits({
+      maximumEntryBytes: ggmlHipBytes,
+    });
+    expect(pinnedLimits).toEqual({
+      ...DEFAULT_RUNTIME_ARCHIVE_EXTRACTION_LIMITS,
+      maximumEntryBytes: ggmlHipBytes,
+    });
+    expect(() =>
+      addArchiveEntryToBudget(
+        { entryCount: 0, expandedBytes: 0 },
+        entry,
+        "beellama.zip",
+        pinnedLimits,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      addArchiveEntryToBudget(
+        { entryCount: 0, expandedBytes: 0 },
+        { ...entry, size: ggmlHipBytes + 1 },
+        "beellama.zip",
+        pinnedLimits,
+      ),
+    ).toThrow(/entry is too large/);
+    expect(() =>
+      addArchiveEntryToBudget(
+        { entryCount: 0, expandedBytes: MAX_RUNTIME_ARCHIVE_EXPANDED_BYTES },
+        { name: "overflow.dll", size: 1, compressedSize: 1 },
+        "beellama.zip",
+        pinnedLimits,
+      ),
+    ).toThrow(/expands beyond/);
+  });
+
+  it("applies scoped limits to unselected ZIP entries before publication", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mgt-runtime-limits-"));
+    const archivePath = join(root, "runtime.zip");
+    const outputDir = join(root, "runtime");
+    try {
+      const zip = new yazl.ZipFile();
+      zip.addBuffer(Buffer.from("ok"), "selected.dll");
+      zip.addBuffer(Buffer.from("12345"), "unselected.bin");
+      zip.end();
+      await pipeline(zip.outputStream, createWriteStream(archivePath));
+
+      await expect(
+        extractSelectedZipEntries(
+          archivePath,
+          outputDir,
+          (name) => name === "selected.dll",
+          { limits: { maximumEntryBytes: 4 } },
+        ),
+      ).rejects.toThrow(/unselected\.bin/);
+
+      await extractSelectedZipEntries(
+        archivePath,
+        outputDir,
+        (name) => name === "selected.dll",
+        {
+          limits: {
+            maximumEntries: 2,
+            maximumEntryBytes: 5,
+            maximumExpandedBytes: 7,
+          },
+        },
+      );
+      expect(await readFile(join(outputDir, "selected.dll"), "utf8")).toBe(
+        "ok",
+      );
+      await expect(
+        readFile(join(outputDir, "unselected.bin")),
+      ).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("rejects absolute, traversal, and NUL entry paths", () => {


### PR DESCRIPTION
## Summary

- allow the pinned BeeLlama v0.3.1 HIP Radeon archive to extract its 1,515,477,504-byte `ggml-hip.dll` without raising the shared ZIP/TAR limits
- bind the exception to the exact runtime id, archive name, URL, SHA-256, compressed byte size, and verified receipt
- atomically claim downloaded archives during verification/extraction so public cache path replacement cannot publish unverified output
- hash installed runtime files with a bounded 4 MiB buffer and include ROCm/HIP kernel artifacts in the installed integrity manifest
- update the packaged file-count ceiling from 258 to the freshly verified 260 files

## Root cause

The shared runtime archive policy caps each entry at 1 GiB. The pinned BeeLlama HIP archive is valid and checksum-pinned, but its `ggml-hip.dll` expands to 1,515,477,504 bytes, so installation failed before extraction. Raising the global limits would weaken every runtime archive path.

## Validation

- `npm run check:cold` — passed (all type, lint, architecture, coverage, build, parity, and bundle gates)
- `npm run dist:win` — passed; 260 files / 751.7 MiB unpacked
- packaged Electron require smoke — passed
- real empty-cache production install from the pinned GitHub asset — passed
  - archive: 553,375,639 bytes
  - SHA-256: `53302ae602dc43381f1c61794c2508a5e72931916b6de015531683358dc78fbc`
  - `ggml-hip.dll`: 1,515,477,504 bytes
  - 2,003 protected installed files; marker recheck passed; no ownership leftovers
  - peak RSS about 293 MiB
- fault tests cover path swap, restore collision, size/checksum mismatch, scoped-limit mismatch, kernel tamper, and bounded chunk hashing

Fixes #61