### PR TITLE
Allow text placement beyond page bounds

### DIFF
--- a/scripts/page-artwork-pixel-parity/fixtures.cjs
+++ b/scripts/page-artwork-pixel-parity/fixtures.cjs
@@ -67,6 +67,13 @@ function createFixtureBlocks() {
       translatedText: "**여러 줄**과 *부분 강조*\n외곽선도 함께",
       warpTransform: createWarpFixture("flag", 3),
     }),
+    createBlock("off-canvas-rotated", {
+      bbox: { x: 0, y: 420, w: 180, h: 180 },
+      renderBbox: { x: -165, y: 420, w: 220, h: 180 },
+      renderBboxSpace: "normalized_1000",
+      rotationDeg: 90,
+      translatedText: "경계 밖 텍스트",
+    }),
     createBlock("empty", {
       bbox: { x: 90, y: 980, w: 240, h: 90 },
       sourceText: "",

--- a/scripts/production-cleanup-coverage-floors.json
+++ b/scripts/production-cleanup-coverage-floors.json
@@ -511,6 +511,12 @@
       "functions": { "covered": 21, "total": 27, "pct": 77.77 },
       "branches": { "covered": 18, "total": 22, "pct": 81.81 }
     },
+    "src/renderer/src/hooks/chapterPersistencePayload.ts": {
+      "lines": { "covered": 7, "total": 8, "pct": 87.5 },
+      "statements": { "covered": 9, "total": 10, "pct": 90 },
+      "functions": { "covered": 5, "total": 5, "pct": 100 },
+      "branches": { "covered": 7, "total": 8, "pct": 87.5 }
+    },
     "src/renderer/src/hooks/inpaintingActionTypes.ts": {
       "lines": { "covered": 12, "total": 18, "pct": 66.66 },
       "statements": { "covered": 12, "total": 18, "pct": 66.66 },
@@ -522,6 +528,12 @@
       "statements": { "covered": 17, "total": 18, "pct": 94.44 },
       "functions": { "covered": 7, "total": 7, "pct": 100 },
       "branches": { "covered": 25, "total": 26, "pct": 96.15 }
+    },
+    "src/renderer/src/hooks/useBlockReadingOrderActions.ts": {
+      "lines": { "covered": 10, "total": 73, "pct": 13.69 },
+      "statements": { "covered": 10, "total": 86, "pct": 11.62 },
+      "functions": { "covered": 5, "total": 25, "pct": 20 },
+      "branches": { "covered": 4, "total": 73, "pct": 5.47 }
     },
     "src/renderer/src/hooks/useDrawnPatternInpaintingAction.ts": {
       "lines": { "covered": 34, "total": 48, "pct": 70.83 },
@@ -553,6 +565,12 @@
       "functions": { "covered": 11, "total": 12, "pct": 91.66 },
       "branches": { "covered": 26, "total": 34, "pct": 76.47 }
     },
+    "src/renderer/src/hooks/useUpdateSelectedBlockAction.ts": {
+      "lines": { "covered": 45, "total": 49, "pct": 91.83 },
+      "statements": { "covered": 49, "total": 55, "pct": 89.09 },
+      "functions": { "covered": 19, "total": 19, "pct": 100 },
+      "branches": { "covered": 35, "total": 48, "pct": 72.91 }
+    },
     "src/renderer/src/hooks/useWorkspaceBlockDragHandlers.ts": {
       "lines": { "covered": 72, "total": 78, "pct": 92.3 },
       "statements": { "covered": 74, "total": 83, "pct": 89.15 },
@@ -564,6 +582,18 @@
       "statements": { "covered": 48, "total": 65, "pct": 73.84 },
       "functions": { "covered": 15, "total": 18, "pct": 83.33 },
       "branches": { "covered": 34, "total": 52, "pct": 65.38 }
+    },
+    "src/renderer/src/lib/blockFormatGeometry.ts": {
+      "lines": { "covered": 0, "total": 0, "pct": 100 },
+      "statements": { "covered": 0, "total": 0, "pct": 100 },
+      "functions": { "covered": 0, "total": 0, "pct": 100 },
+      "branches": { "covered": 0, "total": 0, "pct": 100 }
+    },
+    "src/renderer/src/lib/overlayLayout.ts": {
+      "lines": { "covered": 66, "total": 66, "pct": 100 },
+      "statements": { "covered": 71, "total": 71, "pct": 100 },
+      "functions": { "covered": 14, "total": 14, "pct": 100 },
+      "branches": { "covered": 41, "total": 44, "pct": 93.18 }
     },
     "src/renderer/src/lib/stageTool.ts": {
       "lines": { "covered": 4, "total": 4, "pct": 100 },
@@ -583,11 +613,29 @@
       "functions": { "covered": 0, "total": 0, "pct": 100 },
       "branches": { "covered": 0, "total": 0, "pct": 100 }
     },
+    "src/renderer/src/lib/workspaceZoom.ts": {
+      "lines": { "covered": 22, "total": 22, "pct": 100 },
+      "statements": { "covered": 22, "total": 22, "pct": 100 },
+      "functions": { "covered": 3, "total": 3, "pct": 100 },
+      "branches": { "covered": 14, "total": 14, "pct": 100 }
+    },
+    "src/shared/bboxTranslation.ts": {
+      "lines": { "covered": 9, "total": 10, "pct": 90 },
+      "statements": { "covered": 13, "total": 14, "pct": 92.85 },
+      "functions": { "covered": 7, "total": 7, "pct": 100 },
+      "branches": { "covered": 1, "total": 2, "pct": 50 }
+    },
     "src/shared/blockTransforms.ts": {
       "lines": { "covered": 0, "total": 0, "pct": 100 },
       "statements": { "covered": 0, "total": 0, "pct": 100 },
       "functions": { "covered": 0, "total": 0, "pct": 100 },
       "branches": { "covered": 0, "total": 0, "pct": 100 }
+    },
+    "src/shared/geometry.ts": {
+      "lines": { "covered": 74, "total": 76, "pct": 97.36 },
+      "statements": { "covered": 75, "total": 77, "pct": 97.4 },
+      "functions": { "covered": 23, "total": 23, "pct": 100 },
+      "branches": { "covered": 49, "total": 57, "pct": 85.96 }
     },
     "src/shared/ipcEnumSchemas.ts": {
       "lines": { "covered": 63, "total": 96, "pct": 65.62 },
@@ -734,6 +782,30 @@
       "statements": { "covered": 34, "total": 37, "pct": 91.89 },
       "functions": { "covered": 13, "total": 14, "pct": 92.85 },
       "branches": { "covered": 15, "total": 19, "pct": 78.94 }
+    },
+    "src/shared/editableRenderGeometry.ts": {
+      "lines": { "covered": 30, "total": 30, "pct": 100 },
+      "statements": { "covered": 33, "total": 33, "pct": 100 },
+      "functions": { "covered": 9, "total": 9, "pct": 100 },
+      "branches": { "covered": 14, "total": 14, "pct": 100 }
+    },
+    "src/shared/readableTextBox.ts": {
+      "lines": { "covered": 24, "total": 24, "pct": 100 },
+      "statements": { "covered": 26, "total": 26, "pct": 100 },
+      "functions": { "covered": 2, "total": 2, "pct": 100 },
+      "branches": { "covered": 10, "total": 10, "pct": 100 }
+    },
+    "src/shared/renderBbox.ts": {
+      "lines": { "covered": 7, "total": 7, "pct": 100 },
+      "statements": { "covered": 7, "total": 8, "pct": 87.5 },
+      "functions": { "covered": 2, "total": 2, "pct": 100 },
+      "branches": { "covered": 1, "total": 2, "pct": 50 }
+    },
+    "src/shared/renderBboxSchema.ts": {
+      "lines": { "covered": 1, "total": 1, "pct": 100 },
+      "statements": { "covered": 1, "total": 1, "pct": 100 },
+      "functions": { "covered": 0, "total": 0, "pct": 100 },
+      "branches": { "covered": 0, "total": 0, "pct": 100 }
     },
     "src/shared/settingsAliasCanonicalizers.ts": {
       "lines": { "covered": 44, "total": 44, "pct": 100 },

--- a/src/renderer/src/components/TransformEditorGroup.tsx
+++ b/src/renderer/src/components/TransformEditorGroup.tsx
@@ -4,8 +4,10 @@ import type { TransformEditorMode } from "../../../shared/panelBridgeTypes";
 import type { TranslationBlock } from "../../../shared/textTypes";
 import { normalizeRotationDeg } from "../lib/blockFormatGeometry";
 import {
+  bboxFieldMinimumPixels,
   bboxFieldToPixels,
   bboxFieldMaximumPixels,
+  constrainTransformBbox,
   resolveTransformBbox,
   updateBboxFromPixels,
   type BboxField,
@@ -150,13 +152,16 @@ function GeneralTransformControls({
   const [lockRatio, setLockRatio] = React.useState(true);
   const bbox = resolveTransformBbox(block, pageSize);
   const updateField = (field: BboxField, value: number): void => {
-    const next = updateBboxFromPixels({
-      bbox,
-      field,
-      lockRatio,
-      pageSize,
-      value,
-    });
+    const next = constrainTransformBbox(
+      block,
+      updateBboxFromPixels({
+        bbox,
+        field,
+        lockRatio,
+        pageSize,
+        value,
+      }),
+    );
     onUpdate({ renderBbox: next, renderBboxSpace: "normalized_1000" });
   };
   return (
@@ -230,7 +235,7 @@ function BboxNumberField({
     <TransformNumberField
       label={t(`transform.fields.${field}`)}
       value={bboxFieldToPixels(blockBbox, field, pageSize)}
-      min={field === "w" || field === "h" ? 1 : 0}
+      min={bboxFieldMinimumPixels(field, pageSize)}
       max={bboxFieldMaximumPixels(blockBbox, field, pageSize, lockRatio)}
       unit="px"
       disabled={disabled}

--- a/src/renderer/src/hooks/chapterPersistencePayload.ts
+++ b/src/renderer/src/hooks/chapterPersistencePayload.ts
@@ -1,5 +1,6 @@
 import { hashTranslationBlocks } from "../../../shared/blockFingerprint";
-import { clampBbox } from "../../../shared/geometry";
+import { constrainEditableRenderBbox } from "../../../shared/editableRenderGeometry";
+import { clampBbox, normalizeRenderBboxTo1000 } from "../../../shared/geometry";
 import type { ChapterSnapshot, MangaPage } from "../../../shared/libraryTypes";
 import type { SavePageBlocksUpdate } from "../../../shared/shareTypes";
 import type { ServerPageVersion } from "./chapterPersistenceTypes";
@@ -30,9 +31,21 @@ export function collectPageBlockUpdates(
 }
 
 function serializePageBlocks(page: MangaPage): MangaPage["blocks"] {
-  return page.blocks.map((block) => ({
-    ...block,
-    bbox: clampBbox(block.bbox),
-    renderBbox: block.renderBbox ? clampBbox(block.renderBbox) : undefined,
-  }));
+  return page.blocks.map((block) => {
+    const renderBbox = block.renderBbox
+      ? normalizeRenderBboxTo1000(
+          block.renderBbox,
+          { width: page.width, height: page.height },
+          block.renderBboxSpace,
+        )
+      : undefined;
+    return {
+      ...block,
+      bbox: clampBbox(block.bbox),
+      renderBbox: renderBbox
+        ? constrainEditableRenderBbox(block, renderBbox)
+        : undefined,
+      renderBboxSpace: renderBbox ? "normalized_1000" : undefined,
+    };
+  });
 }

--- a/src/renderer/src/hooks/useBlockReadingOrderActions.ts
+++ b/src/renderer/src/hooks/useBlockReadingOrderActions.ts
@@ -117,7 +117,10 @@ export function useUpdateSelectedBlocksAction({
             if (page.id !== selectedPage.id) return page;
             const blocks = page.blocks.map((block) => {
               if (!selectedIds.has(block.id)) return block;
-              const next = normalizeTranslationBlockPatch(block, patch);
+              const next = normalizeTranslationBlockPatch(block, patch, {
+                width: page.width,
+                height: page.height,
+              });
               changed ||= next !== block;
               return next;
             });

--- a/src/renderer/src/hooks/useUpdateSelectedBlockAction.ts
+++ b/src/renderer/src/hooks/useUpdateSelectedBlockAction.ts
@@ -2,11 +2,14 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { ChapterSnapshot, MangaPage } from "../../../shared/libraryTypes";
 import type { TranslationBlock } from "../../../shared/textTypes";
+import { constrainEditableRenderBbox } from "../../../shared/editableRenderGeometry";
 import {
   clampBbox,
   normalizeBlockType,
+  normalizeRenderBboxTo1000,
   normalizeRenderDirection,
   normalizeRotationDeg,
+  resolveEditableBlockBbox,
 } from "../lib/blockFormatGeometry";
 import type { UpdateCurrentChapter } from "./useCurrentChapterUpdater";
 import { clearAutomaticFontMatchForManualStylePatch } from "../lib/automaticFontMatchProvenance";
@@ -90,7 +93,10 @@ function applySelectedBlockPatch(
     if (page.id !== pageId) return page;
     const blocks = page.blocks.map((block) => {
       if (block.id !== blockId) return block;
-      const next = normalizeTranslationBlockPatch(block, patch);
+      const next = normalizeTranslationBlockPatch(block, patch, {
+        width: page.width,
+        height: page.height,
+      });
       changed ||= next !== block;
       return next;
     });
@@ -104,34 +110,121 @@ function applySelectedBlockPatch(
 export function normalizeTranslationBlockPatch(
   block: TranslationBlock,
   patch: Partial<TranslationBlock>,
+  pageSize?: { width: number; height: number },
 ): TranslationBlock {
   const normalizedPatch = clearAutomaticFontMatchForManualStylePatch(
     block,
     patch,
   );
-  const next: TranslationBlock = {
+  const next = constrainPatchedVisualTransform(
+    buildNormalizedTranslationBlock(block, normalizedPatch, pageSize),
+    normalizedPatch,
+    pageSize,
+  );
+  return hasBlockChanged(block, next, normalizedPatch) ? next : block;
+}
+
+function buildNormalizedTranslationBlock(
+  block: TranslationBlock,
+  patch: Partial<TranslationBlock>,
+  pageSize?: { width: number; height: number },
+): TranslationBlock {
+  const sourceGeometry = normalizeSourceGeometryPatch(block, patch);
+  const renderGeometry = normalizeRenderGeometryPatch(block, patch, pageSize);
+  return {
     ...block,
-    ...normalizedPatch,
-    type: normalizeBlockType(normalizedPatch.type ?? block.type),
+    ...patch,
+    ...sourceGeometry,
+    ...renderGeometry,
+    type: normalizeBlockType(valueOr(patch.type, block.type)),
     renderDirection: normalizeRenderDirection(
-      normalizedPatch.renderDirection ?? block.renderDirection,
+      valueOr(patch.renderDirection, block.renderDirection),
       block.renderDirection,
     ),
     rotationDeg: normalizeRotationDeg(
-      normalizedPatch.rotationDeg ?? block.rotationDeg ?? 0,
+      valueOr(patch.rotationDeg, valueOr(block.rotationDeg, 0)),
     ),
-    backgroundColor: normalizedPatch.backgroundColor ?? block.backgroundColor,
-    opacity: normalizedPatch.opacity ?? block.opacity,
-    bbox: normalizedPatch.bbox ? clampBbox(normalizedPatch.bbox) : block.bbox,
-    bboxSpace: normalizedPatch.bbox ? "normalized_1000" : block.bboxSpace,
-    renderBbox: normalizedPatch.renderBbox
-      ? clampBbox(normalizedPatch.renderBbox)
-      : block.renderBbox,
-    renderBboxSpace: normalizedPatch.renderBbox
-      ? "normalized_1000"
-      : block.renderBboxSpace,
+    backgroundColor: valueOr(patch.backgroundColor, block.backgroundColor),
+    opacity: valueOr(patch.opacity, block.opacity),
   };
-  return hasBlockChanged(block, next, normalizedPatch) ? next : block;
+}
+
+function normalizeSourceGeometryPatch(
+  block: TranslationBlock,
+  patch: Partial<TranslationBlock>,
+): Pick<TranslationBlock, "bbox" | "bboxSpace"> {
+  if (!patch.bbox) {
+    return { bbox: block.bbox, bboxSpace: block.bboxSpace };
+  }
+  return { bbox: clampBbox(patch.bbox), bboxSpace: "normalized_1000" };
+}
+
+function normalizeRenderGeometryPatch(
+  block: TranslationBlock,
+  patch: Partial<TranslationBlock>,
+  pageSize?: { width: number; height: number },
+): Pick<TranslationBlock, "renderBbox" | "renderBboxSpace"> {
+  if (!patch.renderBbox) {
+    return {
+      renderBbox: block.renderBbox,
+      renderBboxSpace: block.renderBboxSpace,
+    };
+  }
+  return {
+    renderBbox: constrainEditableRenderBbox(
+      { ...block, ...patch },
+      normalizeRenderBboxTo1000(
+        patch.renderBbox,
+        pageSize,
+        patch.renderBboxSpace,
+      ),
+    ),
+    renderBboxSpace: "normalized_1000",
+  };
+}
+
+function constrainPatchedVisualTransform(
+  next: TranslationBlock,
+  patch: Partial<TranslationBlock>,
+  pageSize?: { width: number; height: number },
+): TranslationBlock {
+  if (!changesVisualTransform(patch)) return next;
+  const editableBbox = resolveEditableBlockBbox(
+    next,
+    pageSize,
+    next.translatedText || next.sourceText || "...",
+  ).bbox;
+  const constrainedBbox = constrainEditableRenderBbox(next, editableBbox);
+  if (areBboxesEqual(editableBbox, constrainedBbox)) return next;
+  return {
+    ...next,
+    renderBbox: constrainedBbox,
+    renderBboxSpace: "normalized_1000",
+  };
+}
+
+function valueOr<T>(value: T | undefined, fallback: T): T {
+  return value === undefined ? fallback : value;
+}
+
+function changesVisualTransform(patch: Partial<TranslationBlock>): boolean {
+  return (
+    Object.hasOwn(patch, "rotationDeg") ||
+    Object.hasOwn(patch, "perspectiveTransform") ||
+    Object.hasOwn(patch, "warpTransform")
+  );
+}
+
+function areBboxesEqual(
+  left: TranslationBlock["bbox"],
+  right: TranslationBlock["bbox"],
+): boolean {
+  return (
+    Math.abs(left.x - right.x) < 0.0001 &&
+    Math.abs(left.y - right.y) < 0.0001 &&
+    Math.abs(left.w - right.w) < 0.0001 &&
+    Math.abs(left.h - right.h) < 0.0001
+  );
 }
 
 function isAutomaticFontRollbackPatch(

--- a/src/renderer/src/hooks/workspaceBlockDragModel.ts
+++ b/src/renderer/src/hooks/workspaceBlockDragModel.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../shared/blockTransforms";
 import type { ChapterSnapshot, MangaPage } from "../../../shared/libraryTypes";
 import type { BBox, TranslationBlock } from "../../../shared/textTypes";
+import { constrainEditableRenderBbox } from "../../../shared/editableRenderGeometry";
 import {
   applyEditableBlockBbox,
   applyMovedEditableBlockBbox,
@@ -60,7 +61,7 @@ export function resolveBlockDrag(
     const bbox =
       drag.mode === "move"
         ? constrainMovedBlockBbox(drag, requestedBbox, page)
-        : requestedBbox;
+        : constrainEditableRenderBbox(drag.startBlock, requestedBbox);
     return {
       bbox,
       label: describeDragBbox(drag.mode, bbox, page),
@@ -69,7 +70,13 @@ export function resolveBlockDrag(
   }
   if (drag.mode === "rotate") {
     const result = resolveDraggedRotationWithSnap(drag, event, rect);
+    const nextBlock = {
+      ...drag.startBlock,
+      rotationDeg: result.rotationDeg,
+    };
+    const bbox = constrainEditableRenderBbox(nextBlock, drag.startBbox);
     return {
+      ...(areBboxesEqual(bbox, drag.startBbox) ? {} : { bbox }),
       patch: { rotationDeg: result.rotationDeg },
       label: `${result.rotationDeg}°`,
       mode: drag.mode,
@@ -86,6 +93,15 @@ export function resolveBlockDrag(
     return resolveWarpDrag(drag, event, rect, page);
   }
   return null;
+}
+
+function areBboxesEqual(left: BBox, right: BBox): boolean {
+  return (
+    Math.abs(left.x - right.x) < 0.0001 &&
+    Math.abs(left.y - right.y) < 0.0001 &&
+    Math.abs(left.w - right.w) < 0.0001 &&
+    Math.abs(left.h - right.h) < 0.0001
+  );
 }
 
 function constrainMovedBlockBbox(

--- a/src/renderer/src/lib/blockFormatGeometry.ts
+++ b/src/renderer/src/lib/blockFormatGeometry.ts
@@ -12,6 +12,7 @@ export {
   clamp,
   clampBbox,
   normalizeBlockType,
+  normalizeRenderBboxTo1000,
   normalizeRenderDirection,
   normalizeRotationDeg,
   resolveEditableBlockBbox,

--- a/src/renderer/src/lib/overlayLayout.ts
+++ b/src/renderer/src/lib/overlayLayout.ts
@@ -1,8 +1,8 @@
 import type { TranslationBlock } from "../../../shared/textTypes";
+import { MIN_READABLE_FONT_SIZE_PX } from "../../../shared/readableTextBox";
 import {
   bboxToPixels,
   clamp,
-  MIN_READABLE_FONT_SIZE_PX,
   normalizeRenderDirection,
   resolveBlockRenderBbox,
   resolveEffectiveRenderBbox,

--- a/src/renderer/src/lib/transformEditorModel.ts
+++ b/src/renderer/src/lib/transformEditorModel.ts
@@ -7,16 +7,19 @@ import type {
   WarpTransform,
 } from "../../../shared/textTypes";
 import {
-  normalizeRotationDeg,
+  constrainEditableRenderBbox,
+  isEditableBlockVisibleOnPage,
+} from "../../../shared/editableRenderGeometry";
+import {
+  MAX_RENDER_BBOX_COORDINATE,
+  MAX_RENDER_BBOX_SIZE,
+  MIN_RENDER_BBOX_COORDINATE,
+} from "../../../shared/renderBbox";
+import {
   resolveEditableBlockBbox,
   resolveFontWidthScale,
 } from "./blockFormatGeometry";
-import {
-  createWarpEvaluator,
-  mapPointToQuad,
-  normalizePerspectiveTransform,
-  quadraticLength,
-} from "../../../shared/blockTransforms";
+import { quadraticLength } from "../../../shared/blockTransforms";
 
 export type PageSize = { width: number; height: number };
 export type BboxField = "x" | "y" | "w" | "h";
@@ -59,20 +62,36 @@ export function updateBboxFromPixels({
     field === "x" || field === "w" ? pageSize.width : pageSize.height;
   const normalized = (value / Math.max(1, dimension)) * 1000;
   if (field === "x") {
-    return { ...bbox, x: clampValue(normalized, 0, 1000 - bbox.w) };
+    return {
+      ...bbox,
+      x: clampValue(
+        normalized,
+        MIN_RENDER_BBOX_COORDINATE,
+        MAX_RENDER_BBOX_COORDINATE,
+      ),
+    };
   }
   if (field === "y") {
-    return { ...bbox, y: clampValue(normalized, 0, 1000 - bbox.h) };
+    return {
+      ...bbox,
+      y: clampValue(
+        normalized,
+        MIN_RENDER_BBOX_COORDINATE,
+        MAX_RENDER_BBOX_COORDINATE,
+      ),
+    };
   }
   if (!lockRatio) {
-    const maximum = field === "w" ? 1000 - bbox.x : 1000 - bbox.y;
-    return { ...bbox, [field]: clampValue(normalized, 1, maximum) };
+    return {
+      ...bbox,
+      [field]: clampValue(normalized, 1, MAX_RENDER_BBOX_SIZE),
+    };
   }
   const current = field === "w" ? bbox.w : bbox.h;
   const minimumScale = Math.max(1 / bbox.w, 1 / bbox.h);
   const maximumScale = Math.min(
-    (1000 - bbox.x) / bbox.w,
-    (1000 - bbox.y) / bbox.h,
+    MAX_RENDER_BBOX_SIZE / bbox.w,
+    MAX_RENDER_BBOX_SIZE / bbox.h,
   );
   const scale = clampValue(
     normalized / Math.max(Number.EPSILON, current),
@@ -88,18 +107,23 @@ export function bboxFieldMaximumPixels(
   pageSize: PageSize,
   lockRatio: boolean,
 ): number {
-  const xPx = (bbox.x / 1000) * pageSize.width;
-  const yPx = (bbox.y / 1000) * pageSize.height;
   const widthPx = (bbox.w / 1000) * pageSize.width;
   const heightPx = (bbox.h / 1000) * pageSize.height;
-  if (field === "x") return Math.max(0, pageSize.width - widthPx);
-  if (field === "y") return Math.max(0, pageSize.height - heightPx);
+  if (field === "x") {
+    return (MAX_RENDER_BBOX_COORDINATE / 1000) * pageSize.width;
+  }
+  if (field === "y") {
+    return (MAX_RENDER_BBOX_COORDINATE / 1000) * pageSize.height;
+  }
   if (!lockRatio) {
-    return field === "w" ? pageSize.width - xPx : pageSize.height - yPx;
+    return (
+      (MAX_RENDER_BBOX_SIZE / 1000) *
+      (field === "w" ? pageSize.width : pageSize.height)
+    );
   }
   const maximumScale = Math.min(
-    (1000 - bbox.x) / bbox.w,
-    (1000 - bbox.y) / bbox.h,
+    MAX_RENDER_BBOX_SIZE / bbox.w,
+    MAX_RENDER_BBOX_SIZE / bbox.h,
   );
   return (field === "w" ? widthPx : heightPx) * maximumScale;
 }
@@ -109,26 +133,9 @@ export function isPerspectiveVisibleOnPage(
   transform: PerspectiveTransform,
   pageSize: PageSize,
 ): boolean {
-  const bbox = resolveTransformBbox(block, pageSize);
-  const center = { x: bbox.x + bbox.w / 2, y: bbox.y + bbox.h / 2 };
-  const radians = (normalizeRotationDeg(block.rotationDeg) * Math.PI) / 180;
-  const cos = Math.cos(radians);
-  const sin = Math.sin(radians);
-  const points = transform.corners.map((corner) => {
-    const x = bbox.x + corner.x * bbox.w - center.x;
-    const y = bbox.y + corner.y * bbox.h - center.y;
-    return {
-      x: center.x + x * cos - y * sin,
-      y: center.y + x * sin + y * cos,
-    };
-  });
-  const xs = points.map((point) => point.x);
-  const ys = points.map((point) => point.y);
-  return (
-    Math.max(...xs) > 0 &&
-    Math.min(...xs) < 1000 &&
-    Math.max(...ys) > 0 &&
-    Math.min(...ys) < 1000
+  return isEditableBlockVisibleOnPage(
+    { ...block, perspectiveTransform: transform },
+    resolveTransformBbox(block, pageSize),
   );
 }
 
@@ -137,47 +144,30 @@ export function isWarpVisibleOnPage(
   transform: WarpTransform,
   pageSize: PageSize,
 ): boolean {
-  const evaluator = createWarpEvaluator(transform);
-  const perspective = block.perspectiveTransform
-    ? normalizePerspectiveTransform(block.perspectiveTransform).corners
-    : null;
-  const samples: Point[] = [];
-  for (let row = 0; row <= 16; row += 1) {
-    for (let column = 0; column <= 16; column += 1) {
-      if (row !== 0 && row !== 16 && column !== 0 && column !== 16) continue;
-      const warped = evaluator.map({ x: column / 16, y: row / 16 });
-      samples.push(perspective ? mapPointToQuad(warped, perspective) : warped);
-    }
-  }
-  return areLocalPointsVisibleOnPage(block, samples, pageSize);
+  return isEditableBlockVisibleOnPage(
+    { ...block, warpTransform: transform },
+    resolveTransformBbox(block, pageSize),
+  );
 }
 
-function areLocalPointsVisibleOnPage(
+export function constrainTransformBbox(
   block: TranslationBlock,
-  localPoints: readonly Point[],
+  bbox: BBox,
+): BBox {
+  return constrainEditableRenderBbox(block, bbox);
+}
+
+export function bboxFieldMinimumPixels(
+  field: BboxField,
   pageSize: PageSize,
-): boolean {
-  const bbox = resolveTransformBbox(block, pageSize);
-  const center = { x: bbox.x + bbox.w / 2, y: bbox.y + bbox.h / 2 };
-  const radians = (normalizeRotationDeg(block.rotationDeg) * Math.PI) / 180;
-  const cos = Math.cos(radians);
-  const sin = Math.sin(radians);
-  const points = localPoints.map((point) => {
-    const x = bbox.x + point.x * bbox.w - center.x;
-    const y = bbox.y + point.y * bbox.h - center.y;
-    return {
-      x: center.x + x * cos - y * sin,
-      y: center.y + x * sin + y * cos,
-    };
-  });
-  const xs = points.map((point) => point.x);
-  const ys = points.map((point) => point.y);
-  return (
-    Math.max(...xs) > 0 &&
-    Math.min(...xs) < 1000 &&
-    Math.max(...ys) > 0 &&
-    Math.min(...ys) < 1000
-  );
+): number {
+  if (field === "x") {
+    return (MIN_RENDER_BBOX_COORDINATE / 1000) * pageSize.width;
+  }
+  if (field === "y") {
+    return (MIN_RENDER_BBOX_COORDINATE / 1000) * pageSize.height;
+  }
+  return 1;
 }
 
 export function resolveCurveBend(curve: CurveLayout): number {

--- a/src/renderer/src/lib/workspaceZoom.ts
+++ b/src/renderer/src/lib/workspaceZoom.ts
@@ -8,8 +8,8 @@ export const MIN_WORKSPACE_ZOOM = 0.5;
 export const MAX_WORKSPACE_ZOOM = 4;
 export const WORKSPACE_ZOOM_STEP = 0.25;
 
-/** Matches the `.workspace` padding in styles.css. */
-const WORKSPACE_PADDING_PX = 24;
+/** Matches the recoverable editing gutter around `.workspace`. */
+const WORKSPACE_EDIT_GUTTER_PX = 96;
 
 export type WorkspaceFitMode = "contain" | "width" | "height" | "actual";
 
@@ -50,8 +50,14 @@ export function computeWorkspaceImageSize(
   ) {
     return null;
   }
-  const availWidth = Math.max(1, container.width - WORKSPACE_PADDING_PX * 2);
-  const availHeight = Math.max(1, container.height - WORKSPACE_PADDING_PX * 2);
+  const availWidth = Math.max(
+    1,
+    container.width - WORKSPACE_EDIT_GUTTER_PX * 2,
+  );
+  const availHeight = Math.max(
+    1,
+    container.height - WORKSPACE_EDIT_GUTTER_PX * 2,
+  );
   const widthScale = availWidth / page.width;
   const heightScale = availHeight / page.height;
   const fitScale = resolveFitScale(fitMode, widthScale, heightScale);

--- a/src/renderer/src/styles/shell-workspace.css
+++ b/src/renderer/src/styles/shell-workspace.css
@@ -438,13 +438,14 @@
 }
 
 .workspace {
+  --workspace-edit-gutter: 96px;
   position: relative;
   display: grid;
   place-items: center;
   width: 100%;
   height: 100%;
   overflow: auto;
-  padding: 24px;
+  padding: var(--workspace-edit-gutter);
   background: #0c0d10;
   outline: none;
 }

--- a/src/renderer/src/styles/stage-overlay.css
+++ b/src/renderer/src/styles/stage-overlay.css
@@ -195,6 +195,11 @@
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
 }
 
+.workspace .page-image,
+.workspace .page-image-placeholder {
+  max-height: calc(100vh - 192px);
+}
+
 .page-image-loading-overlay {
   position: absolute;
   inset: 0;

--- a/src/shared/bboxTranslation.ts
+++ b/src/shared/bboxTranslation.ts
@@ -2,17 +2,24 @@ import type { BBox } from "./textTypes";
 
 export type BboxTranslation = { x: number; y: number };
 
-export function clampTranslationToBboxes(
+/**
+ * Allows boxes to cross the page boundary while retaining a small visible
+ * extent on each axis. This is used only for manual render placement; source
+ * OCR geometry remains page-confined by its own normalization path.
+ */
+export function clampTranslationToVisibleBboxes(
   bboxes: readonly BBox[],
   requestedDelta: BboxTranslation,
+  minimumVisibleExtent: number,
 ): BboxTranslation {
   if (bboxes.length === 0) {
     return { x: 0, y: 0 };
   }
-  const minimumX = Math.max(...bboxes.map((bbox) => -bbox.x));
-  const maximumX = Math.min(...bboxes.map((bbox) => 1000 - bbox.x - bbox.w));
-  const minimumY = Math.max(...bboxes.map((bbox) => -bbox.y));
-  const maximumY = Math.min(...bboxes.map((bbox) => 1000 - bbox.y - bbox.h));
+  const visible = Math.max(0, Math.min(500, minimumVisibleExtent));
+  const minimumX = Math.max(...bboxes.map((bbox) => visible - bbox.x - bbox.w));
+  const maximumX = Math.min(...bboxes.map((bbox) => 1000 - visible - bbox.x));
+  const minimumY = Math.max(...bboxes.map((bbox) => visible - bbox.y - bbox.h));
+  const maximumY = Math.min(...bboxes.map((bbox) => 1000 - visible - bbox.y));
   return {
     x: clamp(requestedDelta.x, minimumX, maximumX),
     y: clamp(requestedDelta.y, minimumY, maximumY),

--- a/src/shared/editableRenderGeometry.ts
+++ b/src/shared/editableRenderGeometry.ts
@@ -1,0 +1,102 @@
+import {
+  createWarpEvaluator,
+  mapPointToQuad,
+  normalizePerspectiveTransform,
+} from "./blockTransforms";
+import { normalizeRotationDeg } from "./blockGeometryValues";
+import {
+  clampTranslationToVisibleBboxes,
+  translateBbox,
+} from "./bboxTranslation";
+import { MIN_VISIBLE_RENDER_BBOX_EXTENT, clampRenderBbox } from "./renderBbox";
+import type { BBox, Point, TranslationBlock } from "./textTypes";
+
+type RenderTransformBlock = Pick<
+  TranslationBlock,
+  "perspectiveTransform" | "rotationDeg" | "warpTransform"
+>;
+
+export function constrainEditableRenderBbox(
+  block: RenderTransformBlock,
+  bbox: BBox,
+): BBox {
+  const safe = clampRenderBbox(bbox);
+  const delta = clampTranslationToVisibleBboxes(
+    [resolveTransformedBlockBounds(block, safe)],
+    { x: 0, y: 0 },
+    MIN_VISIBLE_RENDER_BBOX_EXTENT,
+  );
+  return clampRenderBbox(translateBbox(safe, delta));
+}
+
+export function isEditableBlockVisibleOnPage(
+  block: RenderTransformBlock,
+  bbox: BBox,
+): boolean {
+  const bounds = resolveTransformedBlockBounds(block, clampRenderBbox(bbox));
+  return (
+    bounds.x + bounds.w >= MIN_VISIBLE_RENDER_BBOX_EXTENT &&
+    bounds.x <= 1000 - MIN_VISIBLE_RENDER_BBOX_EXTENT &&
+    bounds.y + bounds.h >= MIN_VISIBLE_RENDER_BBOX_EXTENT &&
+    bounds.y <= 1000 - MIN_VISIBLE_RENDER_BBOX_EXTENT
+  );
+}
+
+export function resolveTransformedBlockBounds(
+  block: RenderTransformBlock,
+  bbox: BBox,
+): BBox {
+  const localPoints = resolveTransformedBoundaryPoints(block);
+  const center = { x: bbox.x + bbox.w / 2, y: bbox.y + bbox.h / 2 };
+  const radians = (normalizeRotationDeg(block.rotationDeg) * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const points = localPoints.map((point) => {
+    const x = bbox.x + point.x * bbox.w - center.x;
+    const y = bbox.y + point.y * bbox.h - center.y;
+    return {
+      x: center.x + x * cos - y * sin,
+      y: center.y + x * sin + y * cos,
+    };
+  });
+  const xs = points.map((point) => point.x);
+  const ys = points.map((point) => point.y);
+  const left = Math.min(...xs);
+  const top = Math.min(...ys);
+  return {
+    x: left,
+    y: top,
+    w: Math.max(...xs) - left,
+    h: Math.max(...ys) - top,
+  };
+}
+
+function resolveTransformedBoundaryPoints(
+  block: RenderTransformBlock,
+): Point[] {
+  const boundary = sampleUnitBoundary(block.warpTransform ? 16 : 1);
+  const warp = block.warpTransform
+    ? createWarpEvaluator(block.warpTransform)
+    : null;
+  const perspective = block.perspectiveTransform
+    ? normalizePerspectiveTransform(block.perspectiveTransform).corners
+    : null;
+  return boundary.map((point) => {
+    const warped = warp ? warp.map(point) : point;
+    return perspective ? mapPointToQuad(warped, perspective) : warped;
+  });
+}
+
+function sampleUnitBoundary(segments: number): Point[] {
+  const points: Point[] = [];
+  for (let index = 0; index <= segments; index += 1) {
+    const value = index / segments;
+    points.push(
+      { x: value, y: 0 },
+      { x: 1, y: value },
+      { x: 1 - value, y: 1 },
+      { x: 0, y: 1 - value },
+    );
+  }
+  return points;
+}

--- a/src/shared/geometry.ts
+++ b/src/shared/geometry.ts
@@ -1,10 +1,19 @@
 import type { BBox, TranslationBlock } from "./textTypes";
 import type { ChapterSnapshot } from "./libraryTypes";
-import { clampTranslationToBboxes, translateBbox } from "./bboxTranslation";
+import {
+  clampTranslationToVisibleBboxes,
+  translateBbox,
+} from "./bboxTranslation";
 import {
   estimateFontSizePx,
   normalizeRenderDirection,
 } from "./blockGeometryValues";
+import { MIN_VISIBLE_RENDER_BBOX_EXTENT, clampRenderBbox } from "./renderBbox";
+import {
+  constrainEditableRenderBbox,
+  resolveTransformedBlockBounds,
+} from "./editableRenderGeometry";
+import { estimateReadableTextBoxSizePx } from "./readableTextBox";
 
 export {
   MAX_FONT_WIDTH_SCALE,
@@ -17,7 +26,6 @@ export {
   normalizeRotationDeg,
   resolveFontWidthScale,
 } from "./blockGeometryValues";
-
 type PageSize = {
   width: number;
   height: number;
@@ -37,12 +45,6 @@ type RenderBboxBlock = Pick<TranslationBlock, "bbox" | "renderBbox"> &
       | "autoFitText"
     >
   >;
-
-export const MIN_READABLE_FONT_SIZE_PX = 10;
-
-const READABLE_AVERAGE_CHAR_WIDTH_RATIO = 0.95;
-const READABLE_VERTICAL_COLUMN_WIDTH_RATIO = 1.15;
-const READABLE_MAX_VERTICAL_COLUMNS = 2;
 
 export function clamp(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) {
@@ -92,9 +94,13 @@ function sanitizeBlockBboxes(
   pageSize?: PageSize | null,
 ): TranslationBlock {
   const renderBbox = block.renderBbox
-    ? normalizeBboxTo1000(block.renderBbox, pageSize, block.renderBboxSpace)
+    ? normalizeRenderBboxTo1000(
+        block.renderBbox,
+        pageSize,
+        block.renderBboxSpace,
+      )
     : undefined;
-  return {
+  const normalized: TranslationBlock = {
     ...block,
     bbox: normalizeBboxTo1000(block.bbox, pageSize, block.bboxSpace),
     bboxSpace: "normalized_1000",
@@ -105,6 +111,12 @@ function sanitizeBlockBboxes(
       "horizontal",
     ),
   };
+  return renderBbox
+    ? {
+        ...normalized,
+        renderBbox: constrainEditableRenderBbox(normalized, renderBbox),
+      }
+    : normalized;
 }
 
 export function bboxToPixels(bbox: BBox, width: number, height: number): BBox {
@@ -125,6 +137,15 @@ export function pixelsToBbox(bbox: BBox, width: number, height: number): BBox {
   });
 }
 
+function pixelsToRenderBbox(bbox: BBox, width: number, height: number): BBox {
+  return clampRenderBbox({
+    x: (bbox.x / Math.max(1, width)) * 1000,
+    y: (bbox.y / Math.max(1, height)) * 1000,
+    w: (bbox.w / Math.max(1, width)) * 1000,
+    h: (bbox.h / Math.max(1, height)) * 1000,
+  });
+}
+
 export function normalizeBboxTo1000(
   bbox: BBox,
   pageSize?: PageSize | null,
@@ -137,12 +158,24 @@ export function normalizeBboxTo1000(
   return clampBbox(bbox);
 }
 
+export function normalizeRenderBboxTo1000(
+  bbox: BBox,
+  pageSize?: PageSize | null,
+  bboxSpace?: BBoxSpace,
+): BBox {
+  if (bboxSpace === "pixels" && pageSize) {
+    return pixelsToRenderBbox(bbox, pageSize.width, pageSize.height);
+  }
+
+  return clampRenderBbox(bbox);
+}
+
 export function resolveBlockRenderBbox(
   block: RenderBboxBlock,
   pageSize?: PageSize | null,
 ): BBox {
   if (block.renderBbox) {
-    return normalizeBboxTo1000(
+    return normalizeRenderBboxTo1000(
       block.renderBbox,
       pageSize,
       block.renderBboxSpace,
@@ -194,7 +227,7 @@ export function resolveEditableBlockBbox(
   if (block.renderBbox) {
     return {
       key: "renderBbox",
-      bbox: normalizeBboxTo1000(
+      bbox: normalizeRenderBboxTo1000(
         block.renderBbox,
         pageSize,
         block.renderBboxSpace,
@@ -220,19 +253,20 @@ export function resolveEditableBlockBbox(
 export function applyEditableBlockBbox(
   block: TranslationBlock,
   nextBbox: BBox,
-  pageSize?: PageSize | null,
-  text = "",
+  _pageSize?: PageSize | null,
+  _text = "",
 ): TranslationBlock {
-  const target = resolveEditableBlockBbox(block, pageSize, text);
-  const clamped = clampBbox(nextBbox);
-  return target.key === "renderBbox"
-    ? { ...block, renderBbox: clamped, renderBboxSpace: "normalized_1000" }
-    : { ...block, bbox: clamped, bboxSpace: "normalized_1000" };
+  const renderBbox = constrainEditableRenderBbox(block, nextBbox);
+  return {
+    ...block,
+    renderBbox,
+    renderBboxSpace: "normalized_1000",
+  };
 }
 
 /**
- * Moves the pointer-editable box and its source box by one shared delta.
- * Sizes and the source/render offset are preserved, including at page edges.
+ * Moves only the pointer-editable render box. The OCR/inpainting source box is
+ * immutable during manual placement.
  */
 export function applyMovedEditableBlockBbox(
   block: TranslationBlock,
@@ -241,50 +275,50 @@ export function applyMovedEditableBlockBbox(
   text = "",
 ): TranslationBlock {
   const target = resolveEditableBlockBbox(block, pageSize, text);
-  const delta = clampTranslationToBboxes(
-    resolveEditableBlockMoveBboxes(block, pageSize, text),
+  const visualBounds = resolveTransformedBlockBounds(block, target.bbox);
+  const delta = clampTranslationToVisibleBboxes(
+    [visualBounds],
     {
       x: nextBbox.x - target.bbox.x,
       y: nextBbox.y - target.bbox.y,
     },
+    MIN_VISIBLE_RENDER_BBOX_EXTENT,
   );
   if (delta.x === 0 && delta.y === 0) {
     return block;
   }
 
-  const bbox = translateBbox(
-    normalizeBboxTo1000(block.bbox, pageSize, block.bboxSpace),
-    delta,
-  );
-  if (target.key === "renderBbox") {
-    return {
-      ...block,
-      bbox,
-      bboxSpace: "normalized_1000",
-      renderBbox: translateBbox(target.bbox, delta),
-      renderBboxSpace: "normalized_1000",
-    };
-  }
-  return { ...block, bbox, bboxSpace: "normalized_1000" };
+  return {
+    ...block,
+    renderBbox: clampRenderBbox(translateBbox(target.bbox, delta)),
+    renderBboxSpace: "normalized_1000",
+  };
 }
 
 /**
- * Restricts a shared interactive move so every source and render box remains
- * on-page without changing their relative positions.
+ * Restricts a shared interactive move so each transformed render box keeps a
+ * small recoverable extent on-page. Source OCR boxes do not participate.
  */
 export function resolveSharedEditableBlockMoveDelta(
   blocks: readonly TranslationBlock[],
   pageSize: PageSize,
   requestedDelta: { x: number; y: number },
 ): { x: number; y: number } {
-  const bboxes = blocks.flatMap((block) =>
-    resolveEditableBlockMoveBboxes(
+  const bboxes = blocks.map((block) =>
+    resolveTransformedBlockBounds(
       block,
-      pageSize,
-      block.translatedText || block.sourceText || "...",
+      resolveEditableBlockBbox(
+        block,
+        pageSize,
+        block.translatedText || block.sourceText || "...",
+      ).bbox,
     ),
   );
-  return clampTranslationToBboxes(bboxes, requestedDelta);
+  return clampTranslationToVisibleBboxes(
+    bboxes,
+    requestedDelta,
+    MIN_VISIBLE_RENDER_BBOX_EXTENT,
+  );
 }
 
 export function offsetBlockBboxes(
@@ -293,97 +327,22 @@ export function offsetBlockBboxes(
   dy: number,
   pageSize?: PageSize | null,
 ): TranslationBlock {
-  const bbox = normalizeBboxTo1000(block.bbox, pageSize, block.bboxSpace);
-  const renderBbox = block.renderBbox
-    ? normalizeBboxTo1000(block.renderBbox, pageSize, block.renderBboxSpace)
-    : undefined;
-  const delta = clampTranslationToBboxes(
-    renderBbox ? [bbox, renderBbox] : [bbox],
+  const target = resolveEditableBlockBbox(
+    block,
+    pageSize,
+    block.translatedText || block.sourceText || "...",
+  );
+  const delta = clampTranslationToVisibleBboxes(
+    [resolveTransformedBlockBounds(block, target.bbox)],
     { x: dx, y: dy },
+    MIN_VISIBLE_RENDER_BBOX_EXTENT,
   );
 
   return {
     ...block,
-    bbox: translateBbox(bbox, delta),
-    bboxSpace: "normalized_1000",
-    renderBbox: renderBbox ? translateBbox(renderBbox, delta) : undefined,
-    renderBboxSpace: renderBbox ? "normalized_1000" : undefined,
+    renderBbox: clampRenderBbox(translateBbox(target.bbox, delta)),
+    renderBboxSpace: "normalized_1000",
   };
-}
-
-function resolveEditableBlockMoveBboxes(
-  block: TranslationBlock,
-  pageSize?: PageSize | null,
-  text = "",
-): BBox[] {
-  const sourceBbox = normalizeBboxTo1000(block.bbox, pageSize, block.bboxSpace);
-  const target = resolveEditableBlockBbox(block, pageSize, text);
-  return target.key === "renderBbox" ? [sourceBbox, target.bbox] : [sourceBbox];
-}
-
-function estimateReadableTextBoxSizePx(
-  text: string,
-  block: RenderBboxBlock,
-  basePx: BBox,
-): { width: number; height: number } {
-  const compactLength = Math.max(
-    1,
-    [...text.replace(/\r/g, "").replace(/\n/g, " ")].length,
-  );
-  const fontSizePx = MIN_READABLE_FONT_SIZE_PX;
-  const letterSpacingPx = (block.letterSpacing ?? 0) * fontSizePx;
-  const lineHeightPx = fontSizePx * Math.max(1, block.lineHeight ?? 1.18);
-
-  if (block.renderDirection === "vertical") {
-    const verticalAdvancePx = Math.max(1, lineHeightPx + letterSpacingPx);
-    const availableHeight = Math.max(1, basePx.h);
-    const charsPerColumn = Math.max(
-      1,
-      Math.floor(availableHeight / verticalAdvancePx),
-    );
-    const columnCount = Math.min(
-      READABLE_MAX_VERTICAL_COLUMNS,
-      Math.max(1, Math.ceil(compactLength / charsPerColumn)),
-    );
-    return {
-      width: columnCount * fontSizePx * READABLE_VERTICAL_COLUMN_WIDTH_RATIO,
-      height: Math.min(compactLength, charsPerColumn) * verticalAdvancePx,
-    };
-  }
-
-  const charAdvancePx = Math.max(
-    1,
-    fontSizePx * READABLE_AVERAGE_CHAR_WIDTH_RATIO + letterSpacingPx,
-  );
-  const availableWidth = Math.max(1, basePx.w);
-  const naturalCharsPerLine =
-    resolveNaturalHorizontalCharsPerLine(compactLength);
-  const widthLimitedCharsPerLine = Math.max(
-    1,
-    Math.floor(availableWidth / charAdvancePx),
-  );
-  const charsPerLine = Math.max(
-    Math.min(compactLength, naturalCharsPerLine),
-    Math.min(compactLength, widthLimitedCharsPerLine),
-  );
-  const lineCount = Math.max(1, Math.ceil(compactLength / charsPerLine));
-  return {
-    width: charsPerLine * charAdvancePx,
-    height: lineCount * lineHeightPx,
-  };
-}
-
-function resolveNaturalHorizontalCharsPerLine(compactLength: number): number {
-  if (compactLength <= 4) {
-    return compactLength;
-  }
-  if (compactLength <= 10) {
-    return Math.min(compactLength, 5);
-  }
-  return Math.min(
-    compactLength,
-    Math.max(6, Math.min(14, Math.ceil(Math.sqrt(compactLength * 5)))),
-  );
 }
 
 function expandBboxAroundCenter(

--- a/src/shared/ipcSchemaPrimitives.ts
+++ b/src/shared/ipcSchemaPrimitives.ts
@@ -23,6 +23,7 @@ import {
 } from "./bubbleLayout";
 import { FONT_MATCHING_SEMANTIC_ROLES } from "./fontMatchingProfileTypes";
 import { normalizeVisualClusterId } from "./visualClusterId";
+import { RenderBBoxSchema } from "./renderBboxSchema";
 
 export { MAX_MAX_TOKENS, MIN_CONTEXT_TOKENS, MIN_MAX_TOKENS };
 
@@ -315,7 +316,7 @@ export const TranslationBlockSchema = z
     id: z.string().min(1).max(200),
     type: z.preprocess(() => "nonsolid", z.literal("nonsolid")),
     bbox: BBoxSchema,
-    renderBbox: BBoxSchema.optional(),
+    renderBbox: RenderBBoxSchema.optional(),
     bboxSpace: z.enum(["normalized_1000", "pixels"]).optional(),
     renderBboxSpace: z.enum(["normalized_1000", "pixels"]).optional(),
     bubbleLayout: BubbleLayoutSchema.optional(),

--- a/src/shared/readableTextBox.ts
+++ b/src/shared/readableTextBox.ts
@@ -1,0 +1,72 @@
+import type { BBox, TranslationBlock } from "./textTypes";
+
+type ReadableTextBlock = Partial<
+  Pick<TranslationBlock, "letterSpacing" | "lineHeight" | "renderDirection">
+>;
+
+export const MIN_READABLE_FONT_SIZE_PX = 10;
+
+const READABLE_AVERAGE_CHAR_WIDTH_RATIO = 0.95;
+const READABLE_VERTICAL_COLUMN_WIDTH_RATIO = 1.15;
+const READABLE_MAX_VERTICAL_COLUMNS = 2;
+
+export function estimateReadableTextBoxSizePx(
+  text: string,
+  block: ReadableTextBlock,
+  basePx: BBox,
+): { width: number; height: number } {
+  const compactLength = Math.max(
+    1,
+    [...text.replace(/\r/g, "").replace(/\n/g, " ")].length,
+  );
+  const fontSizePx = MIN_READABLE_FONT_SIZE_PX;
+  const letterSpacingPx = (block.letterSpacing ?? 0) * fontSizePx;
+  const lineHeightPx = fontSizePx * Math.max(1, block.lineHeight ?? 1.18);
+
+  if (block.renderDirection === "vertical") {
+    const verticalAdvancePx = Math.max(1, lineHeightPx + letterSpacingPx);
+    const availableHeight = Math.max(1, basePx.h);
+    const charsPerColumn = Math.max(
+      1,
+      Math.floor(availableHeight / verticalAdvancePx),
+    );
+    const columnCount = Math.min(
+      READABLE_MAX_VERTICAL_COLUMNS,
+      Math.max(1, Math.ceil(compactLength / charsPerColumn)),
+    );
+    return {
+      width: columnCount * fontSizePx * READABLE_VERTICAL_COLUMN_WIDTH_RATIO,
+      height: Math.min(compactLength, charsPerColumn) * verticalAdvancePx,
+    };
+  }
+
+  const charAdvancePx = Math.max(
+    1,
+    fontSizePx * READABLE_AVERAGE_CHAR_WIDTH_RATIO + letterSpacingPx,
+  );
+  const availableWidth = Math.max(1, basePx.w);
+  const naturalCharsPerLine =
+    resolveNaturalHorizontalCharsPerLine(compactLength);
+  const widthLimitedCharsPerLine = Math.max(
+    1,
+    Math.floor(availableWidth / charAdvancePx),
+  );
+  const charsPerLine = Math.max(
+    Math.min(compactLength, naturalCharsPerLine),
+    Math.min(compactLength, widthLimitedCharsPerLine),
+  );
+  const lineCount = Math.max(1, Math.ceil(compactLength / charsPerLine));
+  return {
+    width: charsPerLine * charAdvancePx,
+    height: lineCount * lineHeightPx,
+  };
+}
+
+function resolveNaturalHorizontalCharsPerLine(compactLength: number): number {
+  if (compactLength <= 4) return compactLength;
+  if (compactLength <= 10) return Math.min(compactLength, 5);
+  return Math.min(
+    compactLength,
+    Math.max(6, Math.min(14, Math.ceil(Math.sqrt(compactLength * 5)))),
+  );
+}

--- a/src/shared/renderBbox.ts
+++ b/src/shared/renderBbox.ts
@@ -1,0 +1,33 @@
+import type { BBox } from "./textTypes";
+
+/**
+ * Manual text placement is intentionally wider than the 0..1000 source-image
+ * coordinate space. The hard limits protect persisted/IPC data from runaway
+ * geometry while still allowing a text box up to four page extents wide/high.
+ */
+export const MIN_RENDER_BBOX_COORDINATE = -4000;
+export const MAX_RENDER_BBOX_COORDINATE = 5000;
+export const MAX_RENDER_BBOX_SIZE = 4000;
+export const MIN_VISIBLE_RENDER_BBOX_EXTENT = 8;
+
+export function clampRenderBbox(bbox: BBox): BBox {
+  return {
+    x: clampFinite(
+      bbox.x,
+      MIN_RENDER_BBOX_COORDINATE,
+      MAX_RENDER_BBOX_COORDINATE,
+    ),
+    y: clampFinite(
+      bbox.y,
+      MIN_RENDER_BBOX_COORDINATE,
+      MAX_RENDER_BBOX_COORDINATE,
+    ),
+    w: clampFinite(bbox.w, 1, MAX_RENDER_BBOX_SIZE),
+    h: clampFinite(bbox.h, 1, MAX_RENDER_BBOX_SIZE),
+  };
+}
+
+function clampFinite(value: number, minimum: number, maximum: number): number {
+  if (!Number.isFinite(value)) return minimum;
+  return Math.min(maximum, Math.max(minimum, value));
+}

--- a/src/shared/renderBboxSchema.ts
+++ b/src/shared/renderBboxSchema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import {
+  MAX_RENDER_BBOX_COORDINATE,
+  MAX_RENDER_BBOX_SIZE,
+  MIN_RENDER_BBOX_COORDINATE,
+  clampRenderBbox,
+} from "./renderBbox";
+
+export const RenderBBoxSchema = z
+  .object({
+    x: z
+      .number()
+      .finite()
+      .min(MIN_RENDER_BBOX_COORDINATE)
+      .max(MAX_RENDER_BBOX_COORDINATE),
+    y: z
+      .number()
+      .finite()
+      .min(MIN_RENDER_BBOX_COORDINATE)
+      .max(MAX_RENDER_BBOX_COORDINATE),
+    w: z.number().finite().min(1).max(MAX_RENDER_BBOX_SIZE),
+    h: z.number().finite().min(1).max(MAX_RENDER_BBOX_SIZE),
+  })
+  .strict()
+  .transform(clampRenderBbox);

--- a/src/shared/textTypes.ts
+++ b/src/shared/textTypes.ts
@@ -78,7 +78,9 @@ export type CurveLayout = {
 export type TranslationBlock = {
   id: string;
   type: BlockType;
+  /** Source OCR/inpainting geometry, always confined to the page. */
   bbox: BBox;
+  /** Optional user-authored visual geometry; may extend beyond the page. */
   renderBbox?: BBox;
   bboxSpace?: "normalized_1000" | "pixels";
   renderBboxSpace?: "normalized_1000" | "pixels";

--- a/tests/blockKeyboardNudge.test.tsx
+++ b/tests/blockKeyboardNudge.test.tsx
@@ -79,10 +79,16 @@ describe("block keyboard nudge model", () => {
       { width: 1_000, height: 2_000 },
       { x: 1, y: 1 },
     );
-    expect(moved.bbox).toEqual({ x: 101, y: 100.5, w: 200, h: 200 });
+    expect(moved.bbox).toEqual(block.bbox);
+    expect(moved.renderBbox).toEqual({
+      x: 101,
+      y: 100.5,
+      w: 200,
+      h: 200,
+    });
   });
 
-  it("moves an explicit render box and its source box by the same delta", () => {
+  it("moves an explicit render box without changing its source box", () => {
     const block = makeBlock({
       bbox: { x: 100, y: 100, w: 80, h: 80 },
       renderBbox: { x: 200, y: 250, w: 300, h: 180 },
@@ -93,7 +99,7 @@ describe("block keyboard nudge model", () => {
       { width: 1_000, height: 1_000 },
       { x: -2, y: 4 },
     );
-    expect(moved.bbox).toEqual({ x: 98, y: 104, w: 80, h: 80 });
+    expect(moved.bbox).toEqual(block.bbox);
     expect(moved.renderBbox).toEqual({
       x: 198,
       y: 254,
@@ -102,7 +108,7 @@ describe("block keyboard nudge model", () => {
     });
   });
 
-  it("uses the stricter source boundary without changing the source-render offset", () => {
+  it("ignores the source boundary when moving the render box", () => {
     const block = makeBlock({
       bbox: { x: 850, y: 100, w: 100, h: 100 },
       renderBbox: { x: 700, y: 80, w: 100, h: 140 },
@@ -119,22 +125,22 @@ describe("block keyboard nudge model", () => {
       shared,
     );
 
-    expect(shared).toEqual({ x: 50, y: 0 });
-    expect(moved.bbox).toEqual({ x: 900, y: 100, w: 100, h: 100 });
-    expect(moved.renderBbox).toEqual({ x: 750, y: 80, w: 100, h: 140 });
-    expect((moved.bbox.x ?? 0) - (moved.renderBbox?.x ?? 0)).toBe(150);
+    expect(shared).toEqual({ x: 100, y: 0 });
+    expect(moved.bbox).toEqual(block.bbox);
+    expect(moved.renderBbox).toEqual({ x: 800, y: 80, w: 100, h: 140 });
   });
 
-  it("stops at page edges without shrinking the editable box", () => {
+  it("stops only when eight normalized units would remain hidden", () => {
     const block = makeBlock({
       bbox: { x: 790, y: 0, w: 200, h: 200 },
     });
     const moved = nudgeBlockByImagePixels(
       block,
       { width: 1_000, height: 1_000 },
-      { x: 100, y: -100 },
+      { x: 1_000, y: -1_000 },
     );
-    expect(moved.bbox).toEqual({ x: 800, y: 0, w: 200, h: 200 });
+    expect(moved.bbox).toEqual(block.bbox);
+    expect(moved.renderBbox).toEqual({ x: 992, y: -192, w: 200, h: 200 });
   });
 
   it("clamps a multi-selection as one group at page edges", () => {
@@ -149,17 +155,17 @@ describe("block keyboard nudge model", () => {
     const shared = resolveSharedBlockNudgeDeltaPx(
       [left, right],
       { width: 1_000, height: 1_000 },
-      { x: 100, y: 0 },
+      { x: 1_000, y: 0 },
     );
-    expect(shared).toEqual({ x: 10, y: 0 });
+    expect(shared).toEqual({ x: 202, y: 0 });
     expect(
       nudgeBlockByImagePixels(left, { width: 1_000, height: 1_000 }, shared)
-        .bbox.x,
-    ).toBe(110);
+        .renderBbox?.x,
+    ).toBe(302);
     expect(
       nudgeBlockByImagePixels(right, { width: 1_000, height: 1_000 }, shared)
-        .bbox.x,
-    ).toBe(800);
+        .renderBbox?.x,
+    ).toBe(992);
   });
 });
 

--- a/tests/chapterPersistencePayload.test.ts
+++ b/tests/chapterPersistencePayload.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { collectPageBlockUpdates } from "../src/renderer/src/hooks/chapterPersistencePayload";
+import type { ChapterSnapshot } from "../src/shared/libraryTypes";
+
+describe("chapter persistence payload", () => {
+  it("preserves a visible off-page render box and never moves the source bbox", () => {
+    const chapter = makeChapter();
+    const update = collectPageBlockUpdates(
+      chapter,
+      [chapter.pages[0].id],
+      new Map(),
+    )[0];
+
+    expect(update?.blocks[0]?.bbox).toEqual({ x: 40, y: 120, w: 160, h: 180 });
+    expect(update?.blocks[0]?.renderBbox).toEqual({
+      x: -152,
+      y: 120,
+      w: 160,
+      h: 180,
+    });
+  });
+
+  it("recovers an invisible render box before saving", () => {
+    const chapter = makeChapter();
+    chapter.pages[0].blocks[0].renderBbox = {
+      x: -2_000,
+      y: 120,
+      w: 160,
+      h: 180,
+    };
+    const update = collectPageBlockUpdates(
+      chapter,
+      [chapter.pages[0].id],
+      new Map(),
+    )[0];
+
+    expect(update?.blocks[0]?.bbox).toEqual({ x: 40, y: 120, w: 160, h: 180 });
+    expect(update?.blocks[0]?.renderBbox?.x).toBe(-152);
+  });
+
+  it("normalizes legacy pixel-space render boxes before saving", () => {
+    const chapter = makeChapter();
+    chapter.pages[0].height = 2_000;
+    chapter.pages[0].blocks[0].renderBbox = {
+      x: -100,
+      y: 200,
+      w: 400,
+      h: 600,
+    };
+    chapter.pages[0].blocks[0].renderBboxSpace = "pixels";
+    const update = collectPageBlockUpdates(
+      chapter,
+      [chapter.pages[0].id],
+      new Map(),
+    )[0];
+
+    expect(update?.blocks[0]?.renderBbox).toEqual({
+      x: -100,
+      y: 100,
+      w: 400,
+      h: 300,
+    });
+    expect(update?.blocks[0]?.renderBboxSpace).toBe("normalized_1000");
+  });
+});
+
+function makeChapter(): ChapterSnapshot {
+  const now = "2026-08-15T00:00:00.000Z";
+  return {
+    id: "chapter-1",
+    workId: "work-1",
+    title: "시험",
+    sourceKind: "images",
+    status: "idle",
+    pageOrder: ["page-1"],
+    pages: [
+      {
+        id: "page-1",
+        name: "page.png",
+        imagePath: "page.png",
+        dataUrl: "",
+        width: 1000,
+        height: 1000,
+        analysisStatus: "completed",
+        createdAt: now,
+        updatedAt: now,
+        blocks: [
+          {
+            id: "block-1",
+            type: "nonsolid",
+            bbox: { x: 40, y: 120, w: 160, h: 180 },
+            renderBbox: { x: -152, y: 120, w: 160, h: 180 },
+            renderBboxSpace: "normalized_1000",
+            sourceText: "原文",
+            translatedText: "번역",
+            confidence: 1,
+            sourceDirection: "horizontal",
+            renderDirection: "horizontal",
+            fontSizePx: 48,
+            lineHeight: 1.18,
+            textAlign: "center",
+            textColor: "#111111",
+            backgroundColor: "#ffffff",
+            opacity: 1,
+          },
+        ],
+      },
+    ],
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/tests/generatedBubbleTextLayout.test.ts
+++ b/tests/generatedBubbleTextLayout.test.ts
@@ -127,7 +127,7 @@ describe("generated bubble text layout", () => {
     expect(gated.rect).toEqual({
       left: 940,
       top: 80,
-      width: 60,
+      width: 100,
       height: 220,
     });
     expect(generatedBlock.renderBbox).toEqual({
@@ -164,9 +164,9 @@ describe("generated bubble text layout", () => {
     const fixedLayout = resolveBlockTextLayout(fixedAuto);
 
     expect(manualLayout.rect.left).toBe(940);
-    expect(manualLayout.rect.width).toBe(60);
+    expect(manualLayout.rect.width).toBe(100);
     expect(fixedLayout.rect.left).toBe(940);
-    expect(fixedLayout.rect.width).toBe(60);
+    expect(fixedLayout.rect.width).toBe(100);
     expect(fixedLayout.fontSizePx).toBe(fixedAuto.fontSizePx);
   });
 

--- a/tests/geometry.test.ts
+++ b/tests/geometry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  constrainEditableRenderBbox,
+  isEditableBlockVisibleOnPage,
+} from "../src/shared/editableRenderGeometry";
+import {
   applyEditableBlockBbox,
   applyMovedEditableBlockBbox,
   bboxOverlapRatio,
@@ -140,8 +144,8 @@ describe("geometry helpers", () => {
       h: 1,
     });
     expect(chapter.pages[0].blocks[0].renderBbox).toEqual({
-      x: 999,
-      y: 999,
+      x: 992,
+      y: 992,
       w: 1,
       h: 1,
     });
@@ -257,7 +261,7 @@ describe("geometry helpers", () => {
     expect(next.renderBbox).toEqual({ x: 120, y: 140, w: 240, h: 280 });
   });
 
-  it("moves source and render boxes by the exact same delta", () => {
+  it("moves only the render box and preserves OCR source geometry", () => {
     const next = applyMovedEditableBlockBbox(
       {
         id: "block-1",
@@ -279,13 +283,11 @@ describe("geometry helpers", () => {
       { x: 130, y: 150, w: 220, h: 260 },
     );
 
-    expect(next.bbox).toEqual({ x: 150, y: 180, w: 80, h: 120 });
+    expect(next.bbox).toEqual({ x: 100, y: 120, w: 80, h: 120 });
     expect(next.renderBbox).toEqual({ x: 130, y: 150, w: 220, h: 260 });
-    expect((next.bbox.x ?? 0) - (next.renderBbox?.x ?? 0)).toBe(20);
-    expect((next.bbox.y ?? 0) - (next.renderBbox?.y ?? 0)).toBe(30);
   });
 
-  it("uses the stricter box boundary without desynchronizing source and render positions", () => {
+  it("lets the render box cross the source boundary independently", () => {
     const block = {
       id: "block-1",
       type: "nonsolid" as const,
@@ -310,9 +312,8 @@ describe("geometry helpers", () => {
       h: 140,
     });
 
-    expect(next.bbox).toEqual({ x: 900, y: 100, w: 100, h: 100 });
-    expect(next.renderBbox).toEqual({ x: 750, y: 80, w: 100, h: 140 });
-    expect((next.bbox.x ?? 0) - (next.renderBbox?.x ?? 0)).toBe(150);
+    expect(next.bbox).toEqual({ x: 850, y: 100, w: 100, h: 100 });
+    expect(next.renderBbox).toEqual({ x: 800, y: 80, w: 100, h: 140 });
   });
 
   it("stores a temporary readable render box when dragging a tiny source-only block", () => {
@@ -345,7 +346,7 @@ describe("geometry helpers", () => {
     expect(next.renderBbox).toEqual({ x: 120, y: 120, w: 80, h: 60 });
   });
 
-  it("offsets both source and render boxes when duplicating a block", () => {
+  it("offsets only the editable render box when duplicating a block", () => {
     const duplicated = offsetBlockBboxes(
       {
         id: "block-1",
@@ -368,11 +369,11 @@ describe("geometry helpers", () => {
       16,
     );
 
-    expect(duplicated.bbox).toEqual({ x: 116, y: 116, w: 80, h: 120 });
+    expect(duplicated.bbox).toEqual({ x: 100, y: 100, w: 80, h: 120 });
     expect(duplicated.renderBbox).toEqual({ x: 96, y: 106, w: 220, h: 260 });
   });
 
-  it("keeps duplicated source and render boxes aligned at a page edge", () => {
+  it("does not use the source boundary to limit a duplicated render box", () => {
     const duplicated = offsetBlockBboxes(
       {
         id: "block-1",
@@ -395,13 +396,54 @@ describe("geometry helpers", () => {
       0,
     );
 
-    expect(duplicated.bbox).toEqual({ x: 900, y: 100, w: 100, h: 100 });
+    expect(duplicated.bbox).toEqual({ x: 850, y: 100, w: 100, h: 100 });
     expect(duplicated.renderBbox).toEqual({
-      x: 750,
+      x: 800,
       y: 80,
       w: 100,
       h: 140,
     });
+  });
+
+  it("keeps exactly eight normalized units recoverable at an outer edge", () => {
+    const block = {
+      id: "block-1",
+      type: "nonsolid" as const,
+      bbox: { x: 900, y: 900, w: 100, h: 100 },
+      sourceText: "원문",
+      translatedText: "번역",
+      confidence: 1,
+      sourceDirection: "horizontal" as const,
+      renderDirection: "horizontal" as const,
+      fontSizePx: 24,
+      lineHeight: 1.18,
+      textAlign: "center" as const,
+      textColor: "#111111",
+      backgroundColor: "#fffdf5",
+      opacity: 0.8,
+    };
+    const moved = applyMovedEditableBlockBbox(block, {
+      x: 2_000,
+      y: -2_000,
+      w: 100,
+      h: 100,
+    });
+
+    expect(moved.bbox).toEqual(block.bbox);
+    expect(moved.renderBbox).toEqual({ x: 992, y: -92, w: 100, h: 100 });
+  });
+
+  it("constrains the transformed outline rather than the unrotated box", () => {
+    const block = { rotationDeg: 45 };
+    const constrained = constrainEditableRenderBbox(block, {
+      x: 1_200,
+      y: 400,
+      w: 240,
+      h: 80,
+    });
+
+    expect(isEditableBlockVisibleOnPage(block, constrained)).toBe(true);
+    expect(constrained.x).toBeLessThan(1_000);
   });
 
   it("normalizes old block kinds into the unified inpainting block type and allows manual direction controls", () => {

--- a/tests/patternPageMask.test.ts
+++ b/tests/patternPageMask.test.ts
@@ -11,7 +11,7 @@ import type { MangaPage } from "../src/shared/libraryTypes";
 import type { TranslationBlock } from "../src/shared/textTypes";
 
 describe("pattern page text masks", () => {
-  it("inpaints an automatic block's moved source location instead of its original location", () => {
+  it("keeps inpainting at the source location after visual text is moved", () => {
     const width = 100;
     const height = 100;
     const block: TranslationBlock = {
@@ -33,9 +33,10 @@ describe("pattern page text masks", () => {
       height,
     });
 
-    expect(moved.bbox).toEqual({ x: 600, y: 600, w: 200, h: 200 });
-    expect(context.pageMask[20 * width + 20]).toBe(0);
-    expect(context.pageMask[70 * width + 70]).toBe(1);
+    expect(moved.bbox).toEqual({ x: 100, y: 100, w: 200, h: 200 });
+    expect(moved.renderBbox).toEqual({ x: 580, y: 580, w: 240, h: 240 });
+    expect(context.pageMask[20 * width + 20]).toBe(1);
+    expect(context.pageMask[70 * width + 70]).toBe(0);
   });
 
   it("keeps block-owned masks separate for overlapping Metal windows", () => {

--- a/tests/productionCleanupCoverageGate.test.ts
+++ b/tests/productionCleanupCoverageGate.test.ts
@@ -426,8 +426,8 @@ describe("production cleanup coverage floor gate", () => {
     expect(Object.keys(manifest.floors)).toEqual(scope.existing);
     expect(Object.keys(manifest.introducedFloors)).toEqual(scope.added);
     expect(manifest.deletedFiles).toEqual(scope.deleted);
-    expect(scope.existing).toHaveLength(106);
-    expect(scope.added).toHaveLength(18);
+    expect(scope.existing).toHaveLength(114);
+    expect(scope.added).toHaveLength(22);
     expect(scope.deleted).toHaveLength(0);
   });
 });

--- a/tests/renderBboxSchema.test.ts
+++ b/tests/renderBboxSchema.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { TranslationBlockSchema } from "../src/shared/ipcSchemaPrimitives";
+
+describe("render bbox schema", () => {
+  it("accepts a partially off-page render box while source geometry stays bounded", () => {
+    const parsed = TranslationBlockSchema.parse({
+      ...makeBlock(),
+      bbox: { x: 0, y: 100, w: 120, h: 160 },
+      renderBbox: { x: -112, y: 100, w: 120, h: 160 },
+      renderBboxSpace: "normalized_1000",
+    });
+
+    expect(parsed.bbox).toEqual({ x: 0, y: 100, w: 120, h: 160 });
+    expect(parsed.renderBbox).toEqual({ x: -112, y: 100, w: 120, h: 160 });
+  });
+
+  it("rejects render boxes outside the extended safety range", () => {
+    for (const renderBbox of [
+      { x: -4001, y: 100, w: 120, h: 160 },
+      { x: 100, y: 100, w: 4001, h: 160 },
+    ]) {
+      expect(
+        TranslationBlockSchema.safeParse({
+          ...makeBlock(),
+          renderBbox,
+          renderBboxSpace: "normalized_1000",
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("continues to reject off-page source geometry", () => {
+    expect(
+      TranslationBlockSchema.safeParse({
+        ...makeBlock(),
+        bbox: { x: -1, y: 100, w: 120, h: 160 },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+function makeBlock() {
+  return {
+    id: "block-1",
+    type: "nonsolid",
+    bbox: { x: 100, y: 100, w: 120, h: 160 },
+    sourceText: "原文",
+    translatedText: "번역",
+    confidence: 1,
+    sourceDirection: "horizontal",
+    renderDirection: "horizontal",
+    fontSizePx: 24,
+    lineHeight: 1.18,
+    textAlign: "center",
+    textColor: "#111111",
+    backgroundColor: "#ffffff",
+    opacity: 1,
+  };
+}

--- a/tests/renderLayout.test.ts
+++ b/tests/renderLayout.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { MIN_READABLE_FONT_SIZE_PX } from "../src/shared/geometry";
+import { MIN_READABLE_FONT_SIZE_PX } from "../src/shared/readableTextBox";
 import {
   resolveBlockPaddingPx,
   resolveBlockRectPx,

--- a/tests/transformEditor.test.tsx
+++ b/tests/transformEditor.test.tsx
@@ -6,7 +6,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { TransformEditorGroup } from "../src/renderer/src/components/TransformEditorGroup";
 import {
   bboxFieldMaximumPixels,
+  constrainTransformBbox,
   isPerspectiveVisibleOnPage,
+  updateCurveBend,
   updateBboxFromPixels,
 } from "../src/renderer/src/lib/transformEditorModel";
 import {
@@ -279,11 +281,11 @@ describe("dense transform editor", () => {
 });
 
 describe("transform editor geometry safety", () => {
-  it("keeps the block size when X/Y input reaches the page edge", () => {
+  it("allows X/Y input beyond the page without changing block size", () => {
     const bbox = { x: 100, y: 200, w: 300, h: 150 };
     const page = { width: 1000, height: 1000 };
 
-    expect(bboxFieldMaximumPixels(bbox, "x", page, true)).toBe(700);
+    expect(bboxFieldMaximumPixels(bbox, "x", page, true)).toBe(5000);
     expect(
       updateBboxFromPixels({
         bbox,
@@ -292,10 +294,35 @@ describe("transform editor geometry safety", () => {
         pageSize: page,
         value: 1000,
       }),
-    ).toEqual({ x: 700, y: 200, w: 300, h: 150 });
+    ).toEqual({ x: 1000, y: 200, w: 300, h: 150 });
+    expect(
+      updateBboxFromPixels({
+        bbox,
+        field: "y",
+        lockRatio: true,
+        pageSize: page,
+        value: -500,
+      }),
+    ).toEqual({ x: 100, y: -500, w: 300, h: 150 });
   });
 
-  it("limits ratio-locked growth by both remaining page axes", () => {
+  it("updates an unlocked extent and reports its expanded maximum", () => {
+    const bbox = { x: 100, y: 200, w: 300, h: 150 };
+    const page = { width: 1000, height: 500 };
+
+    expect(
+      updateBboxFromPixels({
+        bbox,
+        field: "h",
+        lockRatio: false,
+        pageSize: page,
+        value: 750,
+      }),
+    ).toEqual({ x: 100, y: 200, w: 300, h: 1500 });
+    expect(bboxFieldMaximumPixels(bbox, "h", page, false)).toBe(2000);
+  });
+
+  it("limits ratio-locked growth by the render-box safety size", () => {
     const result = updateBboxFromPixels({
       bbox: { x: 100, y: 800, w: 400, h: 100 },
       field: "w",
@@ -304,7 +331,18 @@ describe("transform editor geometry safety", () => {
       value: 900,
     });
 
-    expect(result).toEqual({ x: 100, y: 800, w: 800, h: 200 });
+    expect(result).toEqual({ x: 100, y: 800, w: 900, h: 225 });
+  });
+
+  it("pulls a direct position back until eight units remain visible", () => {
+    expect(
+      constrainTransformBbox(makeBlock(), {
+        x: 5000,
+        y: -4000,
+        w: 300,
+        h: 150,
+      }),
+    ).toEqual({ x: 992, y: -142, w: 300, h: 150 });
   });
 
   it("rejects a perspective quad that is completely outside the page", () => {
@@ -328,6 +366,15 @@ describe("transform editor geometry safety", () => {
         { width: 1000, height: 1000 },
       ),
     ).toBe(false);
+  });
+
+  it("moves a curve control point to the requested signed bend", () => {
+    const curve = createCurvePreset("straight");
+    const bent = updateCurveBend(curve, 50);
+
+    expect(bent.path.start).toEqual(curve.path.start);
+    expect(bent.path.end).toEqual(curve.path.end);
+    expect(bent.path.control).not.toEqual(curve.path.control);
   });
 });
 

--- a/tests/translationBlockPatchGeometry.test.ts
+++ b/tests/translationBlockPatchGeometry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTranslationBlockPatch } from "../src/renderer/src/hooks/useUpdateSelectedBlockAction";
+import type { TranslationBlock } from "../src/shared/textTypes";
+
+describe("translation block patch geometry", () => {
+  it("repositions an off-page render box when rotation would hide it", () => {
+    const block = makeBlock({
+      renderBbox: { x: 992, y: 400, w: 100, h: 10 },
+      renderBboxSpace: "normalized_1000",
+    });
+    const next = normalizeTranslationBlockPatch(
+      block,
+      { rotationDeg: 90 },
+      { width: 1000, height: 1000 },
+    );
+
+    expect(next.bbox).toEqual(block.bbox);
+    expect(next.rotationDeg).toBe(90);
+    expect(next.renderBbox).toEqual({ x: 947, y: 400, w: 100, h: 10 });
+  });
+
+  it("does not create render geometry for an already visible rotation", () => {
+    const block = makeBlock();
+    const next = normalizeTranslationBlockPatch(
+      block,
+      { rotationDeg: 45 },
+      { width: 1000, height: 1000 },
+    );
+
+    expect(next.rotationDeg).toBe(45);
+    expect(next.renderBbox).toBeUndefined();
+  });
+});
+
+function makeBlock(patch: Partial<TranslationBlock> = {}): TranslationBlock {
+  return {
+    id: "block-1",
+    type: "nonsolid",
+    bbox: { x: 100, y: 100, w: 200, h: 100 },
+    sourceText: "原文",
+    translatedText: "번역",
+    confidence: 1,
+    sourceDirection: "horizontal",
+    renderDirection: "horizontal",
+    fontSizePx: 24,
+    lineHeight: 1.18,
+    textAlign: "center",
+    textColor: "#111111",
+    backgroundColor: "#ffffff",
+    opacity: 1,
+    ...patch,
+  };
+}

--- a/tests/workspaceBlockDragModel.test.ts
+++ b/tests/workspaceBlockDragModel.test.ts
@@ -68,7 +68,46 @@ describe("workspace block drag model", () => {
     expect(changed.pages[0].blocks[0]).toEqual(preview);
   });
 
-  it("moves an automatic block's source and render boxes together in preview and commit", () => {
+  it("repositions a narrow off-page box when rotation would hide it", () => {
+    const fixture = makeFixture("rotate");
+    const startBlock = {
+      ...fixture.block,
+      bbox: { x: 100, y: 100, w: 100, h: 10 },
+      renderBbox: { x: 992, y: 400, w: 100, h: 10 },
+      renderBboxSpace: "normalized_1000" as const,
+      rotationDeg: 0,
+    };
+    const result = resolveBlockDrag(
+      {
+        ...fixture.drag,
+        startBlock,
+        startBbox: startBlock.renderBbox,
+        startX: 109.2,
+        startY: 40.5,
+      },
+      { clientX: 104.2, clientY: 45.5 },
+      { left: 0, top: 0, width: 100, height: 100 },
+      fixture.page,
+    );
+
+    expect(result?.patch?.rotationDeg).toBe(90);
+    expect(result?.bbox).toEqual({ x: 947, y: 400, w: 100, h: 10 });
+  });
+
+  it("does not add a bbox patch when rotation remains recoverable", () => {
+    const fixture = makeFixture("rotate");
+    const result = resolveBlockDrag(
+      fixture.drag,
+      { clientX: 0, clientY: 0 },
+      { left: 0, top: 0, width: 100, height: 100 },
+      fixture.page,
+    );
+
+    expect(result?.mode).toBe("rotate");
+    expect(result && Object.hasOwn(result, "bbox")).toBe(false);
+  });
+
+  it("moves an automatic block's render box while preserving its source box", () => {
     const fixture = makeFixture("move");
     const startBlock: TranslationBlock = {
       ...fixture.block,
@@ -98,9 +137,27 @@ describe("workspace block drag model", () => {
     const preview = applyBlockDragResolution(startBlock, page, resolution);
     const changed = applyResolvedBlockDrag(chapter, page, drag, resolution);
 
-    expect(preview.bbox).toEqual({ x: 200, y: 320, w: 200, h: 100 });
+    expect(preview.bbox).toEqual(startBlock.bbox);
     expect(preview.renderBbox).toEqual({ x: 180, y: 290, w: 260, h: 140 });
     expect(changed.pages[0]?.blocks[0]).toEqual(preview);
+  });
+
+  it("allows a move beyond the page and keeps eight units of the box visible", () => {
+    const fixture = makeFixture("move");
+    const startBlock = {
+      ...fixture.block,
+      bbox: { x: 900, y: 100, w: 100, h: 200 },
+      renderBbox: { x: 900, y: 100, w: 100, h: 200 },
+      renderBboxSpace: "normalized_1000" as const,
+    };
+    const result = resolveBlockDrag(
+      { ...fixture.drag, startBbox: startBlock.renderBbox, startBlock },
+      { clientX: 80, clientY: 0 },
+      { left: 0, top: 0, width: 100, height: 100 },
+      { ...fixture.page, blocks: [startBlock] },
+    );
+
+    expect(result?.bbox).toEqual({ x: 992, y: 100, w: 100, h: 200 });
   });
 
   it("keeps source geometry unchanged when only the render box is resized", () => {

--- a/tests/workspacePointerInteractions.test.tsx
+++ b/tests/workspacePointerInteractions.test.tsx
@@ -122,7 +122,7 @@ describe("workspace pointer interactions", () => {
     });
     act(() => frames.flush());
 
-    expect(api.current.getBlockPreview()?.bbox).toMatchObject({
+    expect(api.current.getBlockPreview()?.renderBbox).toMatchObject({
       x: 700,
       y: 700,
     });
@@ -165,7 +165,7 @@ describe("workspace pointer interactions", () => {
     expect(frames.count()).toBe(1);
 
     act(() => frames.flush());
-    expect(api.current.getBlockPreview()?.bbox.x).toBe(700);
+    expect(api.current.getBlockPreview()?.renderBbox?.x).toBe(700);
 
     fireEvent.pointerUp(stage, {
       clientX: 80,
@@ -176,11 +176,13 @@ describe("workspace pointer interactions", () => {
     expect(api.current.updateCurrentChapter).toHaveBeenCalledTimes(1);
     const updater = api.current.updateCurrentChapter.mock.calls[0]?.[1];
     const page = makePage();
-    expect(updater?.(makeChapter(page)).pages[0]?.blocks[0]?.bbox.x).toBe(700);
+    const moved = updater?.(makeChapter(page)).pages[0]?.blocks[0];
+    expect(moved?.bbox.x).toBe(100);
+    expect(moved?.renderBbox?.x).toBe(700);
     expect(api.current.getBlockPreview()).toBeNull();
   });
 
-  it("moves automatic source and render boxes together through pointer handlers", () => {
+  it("moves only the render box through pointer handlers", () => {
     const api = renderHarness({
       initialSelectedBlockId: "block-1",
       withBubbleLayout: true,
@@ -208,7 +210,7 @@ describe("workspace pointer interactions", () => {
     const updater = api.current.updateCurrentChapter.mock.calls[0]?.[1];
     const page = makePage({ withBubbleLayout: true });
     const moved = updater?.(makeChapter(page)).pages[0]?.blocks[0];
-    expect(moved?.bbox).toEqual({ x: 500, y: 400, w: 200, h: 100 });
+    expect(moved?.bbox).toEqual({ x: 100, y: 100, w: 200, h: 100 });
     expect(moved?.renderBbox).toEqual({
       x: 500,
       y: 400,

--- a/tests/workspaceZoom.test.ts
+++ b/tests/workspaceZoom.test.ts
@@ -21,8 +21,8 @@ describe("computeWorkspaceImageSize", () => {
 
   it("fits the whole image to the workspace and upscales small pages", () => {
     expect(computeWorkspaceImageSize(1, "contain", page, container)).toEqual({
-      width: 952,
-      height: 1428,
+      width: 808,
+      height: 1212,
     });
   });
 
@@ -34,9 +34,9 @@ describe("computeWorkspaceImageSize", () => {
   it("scales the fitted size by the zoom factor", () => {
     const base = computeWorkspaceImageSize(2, "contain", page, container);
     expect(base).not.toBeNull();
-    // Width-bound fit: 1000-48 = 952; height = 952 * 1200/800.
-    expect(base?.width).toBe(Math.round(952 * 2));
-    expect(base?.height).toBe(Math.round((952 / (800 / 1200)) * 2));
+    // Width-bound fit: 1000-192 = 808; height = 808 * 1200/800.
+    expect(base?.width).toBe(Math.round(808 * 2));
+    expect(base?.height).toBe(Math.round((808 / (800 / 1200)) * 2));
   });
 
   it("keeps the whole image within the available height when tall", () => {
@@ -45,8 +45,8 @@ describe("computeWorkspaceImageSize", () => {
       width: 1000,
       height: 600,
     });
-    // Height-bound: availHeight 600-48 = 552, then * zoom.
-    expect(result?.height).toBe(Math.round(552 * 1.5));
+    // Height-bound: availHeight 600-192 = 408, then * zoom.
+    expect(result?.height).toBe(Math.round(408 * 1.5));
   });
 
   it("supports width, height, and actual-pixel bases", () => {
@@ -54,14 +54,14 @@ describe("computeWorkspaceImageSize", () => {
     expect(
       computeWorkspaceImageSize(1, "width", page, compactContainer),
     ).toEqual({
-      width: 952,
-      height: 1428,
+      width: 808,
+      height: 1212,
     });
     expect(
       computeWorkspaceImageSize(1, "height", page, compactContainer),
     ).toEqual({
-      width: 501,
-      height: 752,
+      width: 405,
+      height: 608,
     });
     expect(
       computeWorkspaceImageSize(1, "actual", page, compactContainer),

--- a/tests/workspaceZoomNaturalImage.test.tsx
+++ b/tests/workspaceZoomNaturalImage.test.tsx
@@ -47,8 +47,8 @@ describe("workspace zoom natural image dimensions", () => {
     expect(result.current).toEqual({
       className: "is-zoomed",
       style: {
-        "--page-display-h": "952px",
-        "--page-display-w": "663px",
+        "--page-display-h": "808px",
+        "--page-display-w": "563px",
       },
     });
   });


### PR DESCRIPTION
## 변경 내용

- OCR·인페인트 원본 영역인 `bbox`와 사용자가 배치하는 `renderBbox`를 분리했습니다.
- 수동 이동·크기 조정 시 원본 `bbox`를 유지하면서 `renderBbox`가 이미지 밖으로 나갈 수 있게 했습니다.
- `renderBbox`의 안전 범위를 정규화 좌표 `x/y -4000~5000`, `w/h 1~4000`으로 확장했습니다.
- 회전·원근·왜곡이 적용된 실제 외곽선이 페이지 안에 최소 8/1000 남도록 공용 제약을 적용했습니다.
- 작업 이미지 둘레의 편집 여백을 96px로 늘려 바깥쪽 텍스트와 핸들을 계속 조작할 수 있게 했습니다.
- 저장·재로딩과 구버전 픽셀 좌표 정규화를 지원하고, 출력은 기존 페이지 경계에서 정확히 잘립니다.
- 자동 말풍선 배치, OCR, 일반 인페인트는 계속 원본 `bbox`를 기준으로 동작합니다.

## 이유와 영향

기존에는 표시 영역과 OCR 원본 영역이 같은 페이지 내부 제약을 공유해, 큰 글자나 회전 글자를 모서리에 배치할 수 없었습니다. 이제 편집 위치만 독립적으로 바깥까지 이동할 수 있으며 원본 분석·인페인트 좌표는 변하지 않습니다.

피드백 3번의 원문 글자 크기 추정과 폰트 매칭 v2 동작은 변경하지 않았습니다.

## 검증

- `npm run check`
  - 타입 검사, 포맷, 린트, 아키텍처·경계 검사 통과
  - 479개 테스트 파일 통과: 3,536개 통과, 2개 제외
  - production cleanup coverage gate 통과
  - 프로덕션 빌드와 프로토콜·번들 스모크 통과
  - 페이지 아트워크 픽셀 일치: 두 fixture 모두 불일치 0픽셀
- 실제 프로덕션 `ImageStage`/`PageArtwork`를 사용한 UI QA
  - 1440×1000, 1000×760에서 네 모서리의 회전 블록과 96px 편집 여백 확인
  - 좁은 화면의 겹침·가로 오버플로 없음 확인
  - 출력 미리보기에서 페이지 밖 픽셀 잘림 확인

## 사용자 확인 항목

- 큰 글자를 네 모서리에 두고 45°·90°·135°로 회전
- 블록 절반 이상을 이미지 밖으로 옮긴 뒤 이동·크기 조정
- 저장 후 앱을 다시 열어 위치 유지 확인
- PNG/JPG/WebP/PSD 출력에서 바깥 부분만 잘리는지 확인
- 이동한 블록의 OCR·인페인트 원본 영역이 함께 이동하지 않는지 확인

이 PR은 사용자 시험 결과가 나오기 전까지 병합하지 않습니다.
