### PR TITLE
Refine transform handles

### DIFF
--- a/src/renderer/src/assets.d.ts
+++ b/src/renderer/src/assets.d.ts
@@ -2,3 +2,8 @@ declare module "*.png" {
   const src: string;
   export default src;
 }
+
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}

--- a/src/renderer/src/assets/cursors/tabler-rotate-clockwise.svg
+++ b/src/renderer/src/assets/cursors/tabler-rotate-clockwise.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <!-- Tabler Icons "rotate-clockwise", MIT License, Copyright (c) 2020-2026 Paweł Kuna. -->
+  <path d="M4.05 11a8 8 0 1 1 .5 4m-.5 5v-5h5" stroke="#07111c" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4.05 11a8 8 0 1 1 .5 4m-.5 5v-5h5" stroke="#f7fbff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/renderer/src/components/overlayTransforms.css
+++ b/src/renderer/src/components/overlayTransforms.css
@@ -212,7 +212,8 @@
 .rotation-handle {
   left: 50%;
   top: -28px;
-  cursor: url("../assets/cursors/tabler-rotate-clockwise.svg") 12 12,
+  cursor:
+    url("../assets/cursors/tabler-rotate-clockwise.svg") 12 12,
     crosshair;
 }
 

--- a/src/renderer/src/components/overlayTransforms.css
+++ b/src/renderer/src/components/overlayTransforms.css
@@ -126,23 +126,12 @@
   position: absolute;
   left: 50%;
   top: 50%;
-  width: 7px;
-  height: 7px;
-  border: 1.5px solid #102133;
-  border-radius: 2px;
-  background: #eff8ff;
+  width: 3px;
+  height: 3px;
+  border: 0;
+  border-radius: 50%;
+  background: #58b9ff;
   transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 1px #58b9ff;
-}
-
-.transform-handle:hover::after,
-.transform-handle:focus-visible::after {
-  width: 9px;
-  height: 9px;
-  background: #fff;
-  box-shadow:
-    0 0 0 2px #58b9ff,
-    0 2px 5px rgba(0, 0, 0, 0.5);
 }
 
 .transform-handle:focus-visible {
@@ -214,9 +203,6 @@
 }
 
 .rotation-handle::after {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
   background: #58b9ff;
 }
 
@@ -232,9 +218,6 @@
 .perspective-controls .perspective-right::after,
 .perspective-controls .perspective-bottom::after,
 .perspective-controls .perspective-left::after {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
   background: #dff3ff;
 }
 
@@ -243,9 +226,7 @@
 }
 
 .curve-controls .transform-handle::after {
-  border-radius: 50%;
   background: #ffb647;
-  box-shadow: 0 0 0 1px #ffb647;
 }
 
 .curve-controls .curve-control::after {
@@ -293,19 +274,11 @@
 }
 
 .warp-controls .warp-point::after {
-  border-radius: 50%;
   background: #dff3ff;
-  box-shadow: 0 0 0 1px #58b9ff;
 }
 
 .warp-controls .warp-point.selected::after {
-  width: 10px;
-  height: 10px;
-  border-color: #17202d;
   background: #ffbf58;
-  box-shadow:
-    0 0 0 2px #fff2d8,
-    0 2px 5px rgba(0, 0, 0, 0.55);
 }
 
 .stage-drag-hud.invalid {

--- a/src/renderer/src/components/overlayTransforms.css
+++ b/src/renderer/src/components/overlayTransforms.css
@@ -80,6 +80,11 @@
   outline: 0;
 }
 
+.overlay-block.transform-mode-select.selected {
+  outline: 1px solid #58b9ff;
+  outline-offset: 0;
+}
+
 .transform-guide {
   position: absolute;
   inset: 0;
@@ -113,12 +118,24 @@
   width: 24px;
   height: 24px;
   margin: -12px 0 0 -12px;
+  appearance: none;
   padding: 0;
   border: 0;
   border-radius: 50%;
   background: transparent;
+  box-shadow: none;
+  outline: 0;
   pointer-events: auto;
   touch-action: none;
+}
+
+.transform-handle:hover:not(:disabled),
+.transform-handle:active:not(:disabled),
+.transform-handle:focus-visible {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  outline: 0;
 }
 
 .transform-handle::after {
@@ -126,16 +143,12 @@
   position: absolute;
   left: 50%;
   top: 50%;
-  width: 3px;
-  height: 3px;
+  width: 0.5vmin;
+  height: 0.5vmin;
   border: 0;
   border-radius: 50%;
   background: #58b9ff;
   transform: translate(-50%, -50%);
-}
-
-.transform-handle:focus-visible {
-  outline: 0;
 }
 
 .resize-nw {
@@ -199,7 +212,8 @@
 .rotation-handle {
   left: 50%;
   top: -28px;
-  cursor: grab;
+  cursor: url("../assets/cursors/tabler-rotate-clockwise.svg") 12 12,
+    crosshair;
 }
 
 .rotation-handle::after {

--- a/src/renderer/src/hooks/workspaceBlockDragModel.ts
+++ b/src/renderer/src/hooks/workspaceBlockDragModel.ts
@@ -8,6 +8,7 @@ import {
 import type { ChapterSnapshot, MangaPage } from "../../../shared/libraryTypes";
 import type { BBox, TranslationBlock } from "../../../shared/textTypes";
 import { constrainEditableRenderBbox } from "../../../shared/editableRenderGeometry";
+import rotateCursorUrl from "../assets/cursors/tabler-rotate-clockwise.svg";
 import {
   applyEditableBlockBbox,
   applyMovedEditableBlockBbox,
@@ -137,7 +138,10 @@ export function applyResolvedBlockDrag(
 }
 
 export function resolveDragCursor(mode: DragMode): string {
-  if (mode === "move" || mode === "rotate") return "grabbing";
+  if (mode === "move") return "grabbing";
+  if (mode === "rotate") {
+    return `url("${rotateCursorUrl}") 12 12, crosshair`;
+  }
   if (
     mode.startsWith("perspective-") ||
     mode.startsWith("curve-") ||

--- a/tests/transformHandleCss.test.ts
+++ b/tests/transformHandleCss.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const stylesheet = readFileSync(
+  resolve(process.cwd(), "src/renderer/src/components/overlayTransforms.css"),
+  "utf8",
+);
+const stageStylesheet = readFileSync(
+  resolve(process.cwd(), "src/renderer/src/styles/stage-overlay.css"),
+  "utf8",
+);
+
+describe("transform handle presentation", () => {
+  it("keeps a 24px pointer target around a 3px marker", () => {
+    const hitArea = declarationBlock(stylesheet, ".transform-handle");
+    const marker = declarationBlock(stylesheet, ".transform-handle::after");
+
+    expect(hitArea).toMatch(/width:\s*24px;/);
+    expect(hitArea).toMatch(/height:\s*24px;/);
+    expect(hitArea).toMatch(/margin:\s*-12px 0 0 -12px;/);
+    expect(marker).toMatch(/width:\s*3px;/);
+    expect(marker).toMatch(/height:\s*3px;/);
+  });
+
+  it("does not enlarge or ring markers on hover, focus, or selection", () => {
+    expect(stylesheet).not.toMatch(/\.transform-handle:hover::after/);
+    expect(stylesheet).not.toMatch(/\.transform-handle:focus-visible::after/);
+
+    for (const selector of [
+      ".rotation-handle::after",
+      ".curve-controls .transform-handle::after",
+      ".warp-controls .warp-point::after",
+      ".warp-controls .warp-point.selected::after",
+    ]) {
+      expect(declarationBlock(stylesheet, selector)).not.toMatch(
+        /(?:width|height|box-shadow):/,
+      );
+    }
+  });
+
+  it("retains transform cursors and uses the block outline for focus context", () => {
+    expect(declarationBlock(stylesheet, ".resize-nw")).toMatch(
+      /cursor:\s*nwse-resize;/,
+    );
+    expect(declarationBlock(stylesheet, ".resize-n")).toMatch(
+      /cursor:\s*ns-resize;/,
+    );
+    expect(declarationBlock(stylesheet, ".resize-ne")).toMatch(
+      /cursor:\s*nesw-resize;/,
+    );
+    expect(declarationBlock(stylesheet, ".resize-e")).toMatch(
+      /cursor:\s*ew-resize;/,
+    );
+    expect(declarationBlock(stylesheet, ".rotation-handle")).toMatch(
+      /cursor:\s*grab;/,
+    );
+    expect(
+      declarationBlock(stylesheet, ".transform-handle:focus-visible"),
+    ).toMatch(/outline:\s*0;/);
+    expect(
+      declarationBlock(stageStylesheet, ".overlay-block.selected"),
+    ).toMatch(/outline:\s*2px solid var\(--accent-bd\);/);
+  });
+});
+
+function declarationBlock(source: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const selectorIndex = source.search(new RegExp(`${escapedSelector}\\s*\\{`));
+  if (selectorIndex < 0) {
+    throw new Error(`Missing CSS selector: ${selector}`);
+  }
+  const start = source.indexOf("{", selectorIndex);
+  const end = source.indexOf("}", start);
+  if (start < 0 || end < 0) {
+    throw new Error(`Invalid CSS declaration block: ${selector}`);
+  }
+  return source.slice(start + 1, end);
+}

--- a/tests/transformHandleCss.test.ts
+++ b/tests/transformHandleCss.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -12,20 +12,32 @@ const stageStylesheet = readFileSync(
 );
 
 describe("transform handle presentation", () => {
-  it("keeps a 24px pointer target around a 3px marker", () => {
+  it("keeps a 24px pointer target around a viewport-responsive marker", () => {
     const hitArea = declarationBlock(stylesheet, ".transform-handle");
     const marker = declarationBlock(stylesheet, ".transform-handle::after");
 
     expect(hitArea).toMatch(/width:\s*24px;/);
     expect(hitArea).toMatch(/height:\s*24px;/);
     expect(hitArea).toMatch(/margin:\s*-12px 0 0 -12px;/);
-    expect(marker).toMatch(/width:\s*3px;/);
-    expect(marker).toMatch(/height:\s*3px;/);
+    expect(marker).toMatch(/width:\s*0\.5vmin;/);
+    expect(marker).toMatch(/height:\s*0\.5vmin;/);
+  });
+
+  it("keeps the full hit target transparent on hover, active, and focus", () => {
+    const interactionStates = declarationBlock(
+      stylesheet,
+      ".transform-handle:hover:not(:disabled),\n.transform-handle:active:not(:disabled),\n.transform-handle:focus-visible",
+    );
+
+    expect(interactionStates).toMatch(/border:\s*0;/);
+    expect(interactionStates).toMatch(/background:\s*transparent;/);
+    expect(interactionStates).toMatch(/box-shadow:\s*none;/);
+    expect(interactionStates).toMatch(/outline:\s*0;/);
   });
 
   it("does not enlarge or ring markers on hover, focus, or selection", () => {
-    expect(stylesheet).not.toMatch(/\.transform-handle:hover::after/);
-    expect(stylesheet).not.toMatch(/\.transform-handle:focus-visible::after/);
+    expect(stylesheet).not.toMatch(/\.transform-handle:hover[^,{]*::after/);
+    expect(stylesheet).not.toMatch(/\.transform-handle:focus-visible[^,{]*::after/);
 
     for (const selector of [
       ".rotation-handle::after",
@@ -53,14 +65,28 @@ describe("transform handle presentation", () => {
       /cursor:\s*ew-resize;/,
     );
     expect(declarationBlock(stylesheet, ".rotation-handle")).toMatch(
-      /cursor:\s*grab;/,
+      /cursor:\s*url\("\.\.\/assets\/cursors\/tabler-rotate-clockwise\.svg"\) 12 12,\s*crosshair;/,
     );
     expect(
-      declarationBlock(stylesheet, ".transform-handle:focus-visible"),
-    ).toMatch(/outline:\s*0;/);
+      existsSync(
+        resolve(
+          process.cwd(),
+          "src/renderer/src/assets/cursors/tabler-rotate-clockwise.svg",
+        ),
+      ),
+    ).toBe(true);
+    expect(declarationBlock(stylesheet, ".transform-handle")).toMatch(
+      /outline:\s*0;/,
+    );
     expect(
       declarationBlock(stageStylesheet, ".overlay-block.selected"),
     ).toMatch(/outline:\s*2px solid var\(--accent-bd\);/);
+    const transformSelection = declarationBlock(
+      stylesheet,
+      ".overlay-block.transform-mode-select.selected",
+    );
+    expect(transformSelection).toMatch(/outline:\s*1px solid #58b9ff;/);
+    expect(transformSelection).toMatch(/outline-offset:\s*0;/);
   });
 });
 

--- a/tests/transformHandleCss.test.ts
+++ b/tests/transformHandleCss.test.ts
@@ -37,7 +37,9 @@ describe("transform handle presentation", () => {
 
   it("does not enlarge or ring markers on hover, focus, or selection", () => {
     expect(stylesheet).not.toMatch(/\.transform-handle:hover[^,{]*::after/);
-    expect(stylesheet).not.toMatch(/\.transform-handle:focus-visible[^,{]*::after/);
+    expect(stylesheet).not.toMatch(
+      /\.transform-handle:focus-visible[^,{]*::after/,
+    );
 
     for (const selector of [
       ".rotation-handle::after",

--- a/tests/workspaceBlockDragModel.test.ts
+++ b/tests/workspaceBlockDragModel.test.ts
@@ -5,11 +5,19 @@ import {
   applyBlockDragResolution,
   applyResolvedBlockDrag,
   resolveBlockDrag,
+  resolveDragCursor,
 } from "../src/renderer/src/hooks/workspaceBlockDragModel";
 import type { DragState } from "../src/renderer/src/hooks/workspacePointerGeometry";
 import { createIdentityWarpTransform } from "../src/shared/blockTransforms";
 
 describe("workspace block drag model", () => {
+  it("keeps the rotation cursor active throughout a rotation drag", () => {
+    expect(resolveDragCursor("move")).toBe("grabbing");
+    const rotationCursor = resolveDragCursor("rotate");
+    expect(rotationCursor).toContain("data:image/svg+xml");
+    expect(rotationCursor).toMatch(/^url\(".+"\) 12 12, crosshair$/);
+  });
+
   it("rejects a perspective edge that crosses the opposite edge", () => {
     const { page, drag } = makeFixture("perspective-top");
     const result = resolveBlockDrag(


### PR DESCRIPTION
## 변경 내용

- 변형 포인트의 보이는 점을 프로그램 창 크기에 비례하는 `0.5vmin`으로 조정했습니다.
- 실제 마우스 인식 영역은 기존과 같은 24×24px로 유지했습니다.
- hover·active·키보드 focus 상태에서도 인식 영역 배경, 검은 원, 링, 점 확대가 나타나지 않게 했습니다.
- 회전 포인터를 직접 그린 그림 대신 MIT 라이선스의 Tabler `rotate-clockwise` 아이콘으로 교체했습니다. 회전 드래그 중에도 같은 포인터가 유지됩니다.
- 일반 변형 선택선은 포인트와 같은 1px 하늘색으로 통일해 기존 빨간 선택선이 겹치지 않게 했습니다. 다른 편집 모드와 다중 선택의 기존 표시 방식은 유지합니다.

## 이유

실사용자 피드백 2번을 독립적으로 시험하는 단계입니다. 점의 크기는 이미지 확대율이 아니라 프로그램 창에 따라 일정한 비율로 보이며, 투명한 넓은 인식 영역으로 드래그 난이도는 유지합니다.

## 검증

- focused Vitest: 5개 파일, 41개 테스트 통과
- 실제 프로덕션 `OverlayTransformControls` UI QA: 1440×1000 및 1000×760 확인
  - 보이는 점: 각각 5.0px, 3.8px (`0.5vmin`)
  - 인식 영역: 두 화면 모두 24×24px
  - hover·focus 검은 원 없음, 가로 오버플로·잘림·겹침 없음
  - Tabler 회전 포인터와 단일 하늘색 변형 선택선 확인
- `npm run check`: 480개 테스트 파일, 3,541개 통과, 2개 제외
- 프로덕션 빌드 및 커버리지 게이트 통과
- 페이지 편집/출력 픽셀 일치 2종: 불일치 픽셀 0

## 사용자 시험

- 프로그램 창을 크게/작게 바꿨을 때 점이 창 크기에 비례하는지 확인
- 보이는 점 주변의 투명 영역을 잡아도 기존처럼 쉽게 조절되는지 확인
- hover·focus·드래그 중 검은 원이나 확대 효과가 생기지 않는지 확인
- 회전 포인트 위와 실제 회전 드래그 중 Tabler 회전 포인터가 유지되는지 확인
- 선택 시 빨간 외곽선이 추가로 겹치지 않고 하늘색 변형 선택선 하나만 보이는지 확인
