### PR TITLE
Fix workspace fit and rail interactions

### DIFF
--- a/docs/production-cleanup-scenario-ledger.md
+++ b/docs/production-cleanup-scenario-ledger.md
@@ -81,12 +81,12 @@ editing the totals by hand.
   need it. Node 22/V8 12.4 and Node 24/V8 13.6 produced identical covered/total
   counts for every sealed file and are the only accepted runtime families.
   The accepted Node 22 post-refactor and issue #65 follow-up capture that
-  established the eight
+  established the 22
   introduced floors has SHA-256
   `5c694dc7b0c2636bc36e1d72461ba6289569db926fed512b8ea3ee85e6f7bec4`.
 - The manifest pins the exact Windows covered/total counts and the diagnostic
-  percentage for lines/statements/functions/branches in all 80 existing
-  coverage-eligible `src/**` files changed since cleanup start. The eight new
+  percentage for lines/statements/functions/branches in all 123 existing
+  coverage-eligible `src/**` files changed since cleanup start. The 22 new
   eligible source files have their accepted post-refactor Windows ratios sealed
   as `introducedFloors`; they cannot regress to a merely present 0% record.
 - `scripts/check-production-cleanup-coverage.cjs` derives the eligible modified,

--- a/scripts/production-cleanup-coverage-floors.json
+++ b/scripts/production-cleanup-coverage-floors.json
@@ -349,6 +349,12 @@
       "functions": { "covered": 18, "total": 18, "pct": 100 },
       "branches": { "covered": 33, "total": 40, "pct": 82.5 }
     },
+    "src/renderer/src/app/session/AppSessionView.tsx": {
+      "lines": { "covered": 0, "total": 6, "pct": 0 },
+      "statements": { "covered": 0, "total": 6, "pct": 0 },
+      "functions": { "covered": 0, "total": 2, "pct": 0 },
+      "branches": { "covered": 0, "total": 18, "pct": 0 }
+    },
     "src/renderer/src/app/session/buildPanelSyncState.ts": {
       "lines": { "covered": 0, "total": 2, "pct": 0 },
       "statements": { "covered": 0, "total": 2, "pct": 0 },
@@ -373,6 +379,18 @@
       "functions": { "covered": 12, "total": 13, "pct": 92.3 },
       "branches": { "covered": 43, "total": 56, "pct": 76.78 }
     },
+    "src/renderer/src/components/AppRightQuickRail.tsx": {
+      "lines": { "covered": 4, "total": 5, "pct": 80 },
+      "statements": { "covered": 4, "total": 5, "pct": 80 },
+      "functions": { "covered": 2, "total": 3, "pct": 66.66 },
+      "branches": { "covered": 4, "total": 5, "pct": 80 }
+    },
+    "src/renderer/src/components/AppSidebar.tsx": {
+      "lines": { "covered": 13, "total": 13, "pct": 100 },
+      "statements": { "covered": 13, "total": 13, "pct": 100 },
+      "functions": { "covered": 3, "total": 3, "pct": 100 },
+      "branches": { "covered": 6, "total": 9, "pct": 66.66 }
+    },
     "src/renderer/src/components/AppWorkspace.tsx": {
       "lines": { "covered": 25, "total": 31, "pct": 80.64 },
       "statements": { "covered": 25, "total": 31, "pct": 80.64 },
@@ -384,6 +402,12 @@
       "statements": { "covered": 10, "total": 10, "pct": 100 },
       "functions": { "covered": 7, "total": 7, "pct": 100 },
       "branches": { "covered": 26, "total": 26, "pct": 100 }
+    },
+    "src/renderer/src/components/LibraryTree.tsx": {
+      "lines": { "covered": 30, "total": 47, "pct": 63.82 },
+      "statements": { "covered": 32, "total": 50, "pct": 64 },
+      "functions": { "covered": 13, "total": 19, "pct": 68.42 },
+      "branches": { "covered": 14, "total": 31, "pct": 45.16 }
     },
     "src/renderer/src/components/OverlayBlock.tsx": {
       "lines": { "covered": 25, "total": 26, "pct": 96.15 },
@@ -409,6 +433,18 @@
       "functions": { "covered": 8, "total": 8, "pct": 100 },
       "branches": { "covered": 12, "total": 14, "pct": 85.71 }
     },
+    "src/renderer/src/components/PageList.tsx": {
+      "lines": { "covered": 23, "total": 27, "pct": 85.18 },
+      "statements": { "covered": 24, "total": 28, "pct": 85.71 },
+      "functions": { "covered": 11, "total": 15, "pct": 73.33 },
+      "branches": { "covered": 20, "total": 32, "pct": 62.5 }
+    },
+    "src/renderer/src/components/SidebarSectionCollapseButton.tsx": {
+      "lines": { "covered": 3, "total": 3, "pct": 100 },
+      "statements": { "covered": 3, "total": 3, "pct": 100 },
+      "functions": { "covered": 1, "total": 1, "pct": 100 },
+      "branches": { "covered": 4, "total": 4, "pct": 100 }
+    },
     "src/renderer/src/components/StatusDockButton.tsx": {
       "lines": { "covered": 50, "total": 51, "pct": 98.03 },
       "statements": { "covered": 53, "total": 57, "pct": 92.98 },
@@ -426,6 +462,12 @@
       "statements": { "covered": 13, "total": 19, "pct": 68.42 },
       "functions": { "covered": 5, "total": 8, "pct": 62.5 },
       "branches": { "covered": 14, "total": 20, "pct": 70 }
+    },
+    "src/renderer/src/components/WorkspaceViewControls.tsx": {
+      "lines": { "covered": 51, "total": 51, "pct": 100 },
+      "statements": { "covered": 59, "total": 60, "pct": 98.33 },
+      "functions": { "covered": 19, "total": 19, "pct": 100 },
+      "branches": { "covered": 33, "total": 36, "pct": 91.66 }
     },
     "src/renderer/src/components/appWorkspaceTypes.ts": {
       "lines": { "covered": 0, "total": 0, "pct": 100 },
@@ -511,6 +553,12 @@
       "functions": { "covered": 21, "total": 27, "pct": 77.77 },
       "branches": { "covered": 18, "total": 22, "pct": 81.81 }
     },
+    "src/renderer/src/components/ui/ControlTooltip.tsx": {
+      "lines": { "covered": 4, "total": 4, "pct": 100 },
+      "statements": { "covered": 4, "total": 4, "pct": 100 },
+      "functions": { "covered": 1, "total": 1, "pct": 100 },
+      "branches": { "covered": 5, "total": 5, "pct": 100 }
+    },
     "src/renderer/src/hooks/chapterPersistencePayload.ts": {
       "lines": { "covered": 7, "total": 8, "pct": 87.5 },
       "statements": { "covered": 9, "total": 10, "pct": 90 },
@@ -576,6 +624,12 @@
       "statements": { "covered": 74, "total": 83, "pct": 89.15 },
       "functions": { "covered": 19, "total": 20, "pct": 95 },
       "branches": { "covered": 47, "total": 74, "pct": 63.51 }
+    },
+    "src/renderer/src/hooks/useWorkspaceZoomStyle.ts": {
+      "lines": { "covered": 54, "total": 54, "pct": 100 },
+      "statements": { "covered": 61, "total": 64, "pct": 95.31 },
+      "functions": { "covered": 19, "total": 19, "pct": 100 },
+      "branches": { "covered": 43, "total": 56, "pct": 76.78 }
     },
     "src/renderer/src/hooks/workspaceBlockDragModel.ts": {
       "lines": { "covered": 45, "total": 60, "pct": 75 },

--- a/src/renderer/src/app/session/AppSessionView.tsx
+++ b/src/renderer/src/app/session/AppSessionView.tsx
@@ -72,12 +72,34 @@ export function AppSessionView({
   workspaceProps,
 }: AppSessionViewProps): React.JSX.Element {
   const stablePanelSessionValue = useStablePanelSessionValue(panelSessionValue);
+  const [workspaceEffectiveScale, setWorkspaceEffectiveScale] = React.useState(
+    workspaceProps.workspaceZoom,
+  );
+  React.useLayoutEffect(() => {
+    setWorkspaceEffectiveScale(workspaceProps.workspaceZoom);
+  }, [workspaceProps.selectedPage?.id, workspaceProps.workspaceZoom]);
   return (
     <PanelSessionContext.Provider value={stablePanelSessionValue}>
       <main className="app-shell">
         <AppSidebar {...sidebarProps} />
-        <AppWorkspace {...workspaceProps} />
-        <AppRightQuickRail {...rightRailProps} />
+        <div className="workspace-region">
+          <AppWorkspace
+            {...workspaceProps}
+            onEffectiveScaleChange={setWorkspaceEffectiveScale}
+          />
+          <AppRightQuickRail
+            {...rightRailProps}
+            workspaceViewControls={{
+              effectiveScale: workspaceEffectiveScale,
+              fitMode: workspaceProps.workspaceFitMode,
+              zoom: workspaceProps.workspaceZoom,
+              onChangeFitMode: workspaceProps.onChangeWorkspaceFitMode,
+              onResetZoom: workspaceProps.onResetWorkspaceZoom,
+              onZoomIn: workspaceProps.onZoomInWorkspace,
+              onZoomOut: workspaceProps.onZoomOutWorkspace,
+            }}
+          />
+        </div>
         <AppRightRail {...rightRailProps} />
         <MemoizedAppModals {...modalsProps} />
       </main>

--- a/src/renderer/src/components/AppRightQuickRail.tsx
+++ b/src/renderer/src/components/AppRightQuickRail.tsx
@@ -1,7 +1,14 @@
 import React from "react";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
 import type { UnifiedRightRailProps } from "./rightRailPanels";
 import { ChapterQuickControls } from "./ChapterQuickControls";
 import { StatusDockButton } from "./StatusDockButton";
+import {
+  WorkspaceViewControls,
+  type WorkspaceViewControlsProps,
+} from "./WorkspaceViewControls";
+import { ControlTooltip } from "./ui/ControlTooltip";
 
 export type AppRightQuickRailProps = Pick<
   UnifiedRightRailProps,
@@ -35,59 +42,152 @@ export type AppRightQuickRailProps = Pick<
   | "showProgressBar"
   | "statusLines"
   | "undoLabel"
->;
+> & {
+  workspaceViewControls: WorkspaceViewControlsProps;
+};
 
 /**
- * Page-wide actions live in their own strip between the canvas and inspector.
- * Keeping this outside both surfaces prevents controls from covering artwork
- * or consuming the narrow task-card content width.
+ * Mirror the left stage toolbar from the right edge of the canvas. Both tool
+ * groups float over the pasteboard so neither changes the page centre.
  */
 export function AppRightQuickRail(
   props: AppRightQuickRailProps,
 ): React.JSX.Element {
+  const { t } = useTranslation("components");
   const controlsId = React.useId();
   const disabled = !props.currentChapter || props.jobActive || props.flowActive;
+  const [topCollapsed, setTopCollapsed] = React.useState(false);
+  const [bottomCollapsed, setBottomCollapsed] = React.useState(false);
 
   return (
     <aside className="right-quick-rail">
-      <div className="chapter-quick-controls-frame">
-        <ChapterQuickControls
-          canRedo={props.canRedo}
-          canUndo={props.canUndo}
-          chapterAvailable={Boolean(props.currentChapter)}
-          compareAvailable={props.compareAvailable}
-          disabled={disabled}
-          id={controlsId}
-          peeking={props.peeking}
-          redoLabel={props.redoLabel}
-          resetAvailable={props.resetAvailable}
-          showBlockChrome={props.showBlockChrome}
-          showTextBlocks={props.showTextBlocks}
-          undoLabel={props.undoLabel}
-          onOpenStyleGuide={props.onOpenStyleGuide}
-          onOpenTextView={props.onOpenTextView}
-          onPeekToggle={props.onPeekToggle}
-          onRedo={props.onRedo}
-          onResetPage={props.onResetPage}
-          onToggleBlocks={props.onToggleBlocks}
-          onToggleChrome={props.onToggleChrome}
-          onUndo={props.onUndo}
+      <TopQuickRailGroup
+        collapsed={topCollapsed}
+        controlsId={controlsId}
+        disabled={disabled}
+        label={t(
+          topCollapsed
+            ? "workspace.quickRail.showTop"
+            : "workspace.quickRail.hideTop",
+        )}
+        quickRailProps={props}
+        onToggle={() => setTopCollapsed((collapsed) => !collapsed)}
+      />
+      <BottomQuickRailGroup
+        collapsed={bottomCollapsed}
+        label={t(
+          bottomCollapsed
+            ? "workspace.quickRail.showBottom"
+            : "workspace.quickRail.hideBottom",
+        )}
+        quickRailProps={props}
+        onToggle={() => setBottomCollapsed((collapsed) => !collapsed)}
+      />
+    </aside>
+  );
+}
+
+function TopQuickRailGroup({
+  collapsed,
+  controlsId,
+  disabled,
+  label,
+  quickRailProps: props,
+  onToggle,
+}: {
+  collapsed: boolean;
+  controlsId: string;
+  disabled: boolean;
+  label: string;
+  quickRailProps: AppRightQuickRailProps;
+  onToggle: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="right-quick-rail-top">
+      <div
+        className={`chapter-quick-controls-frame right-quick-controls-frame ${collapsed ? "collapsed" : ""}`.trim()}
+      >
+        {!collapsed ? (
+          <ChapterQuickControls
+            canRedo={props.canRedo}
+            canUndo={props.canUndo}
+            chapterAvailable={Boolean(props.currentChapter)}
+            compareAvailable={props.compareAvailable}
+            disabled={disabled}
+            id={controlsId}
+            peeking={props.peeking}
+            redoLabel={props.redoLabel}
+            resetAvailable={props.resetAvailable}
+            showBlockChrome={props.showBlockChrome}
+            showTextBlocks={props.showTextBlocks}
+            undoLabel={props.undoLabel}
+            onOpenStyleGuide={props.onOpenStyleGuide}
+            onOpenTextView={props.onOpenTextView}
+            onPeekToggle={props.onPeekToggle}
+            onRedo={props.onRedo}
+            onResetPage={props.onResetPage}
+            onToggleBlocks={props.onToggleBlocks}
+            onToggleChrome={props.onToggleChrome}
+            onUndo={props.onUndo}
+          />
+        ) : null}
+        <QuickRailGroupToggle
+          collapsed={collapsed}
+          label={label}
+          onToggle={onToggle}
         />
       </div>
+    </div>
+  );
+}
+
+function BottomQuickRailGroup({
+  collapsed,
+  label,
+  quickRailProps: props,
+  onToggle,
+}: {
+  collapsed: boolean;
+  label: string;
+  quickRailProps: AppRightQuickRailProps;
+  onToggle: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="right-quick-rail-bottom">
+      <div
+        className={`right-quick-controls-frame right-quick-bottom-frame ${collapsed ? "collapsed" : ""}`.trim()}
+      >
+        {!collapsed ? <BottomQuickRailControls {...props} /> : null}
+        <QuickRailGroupToggle
+          collapsed={collapsed}
+          label={label}
+          onToggle={onToggle}
+        />
+      </div>
+    </div>
+  );
+}
+
+function BottomQuickRailControls(
+  props: AppRightQuickRailProps,
+): React.JSX.Element {
+  const failedPages =
+    props.currentChapter?.pages
+      .filter((page) => page.analysisStatus === "failed")
+      .map((page) => ({
+        id: page.id,
+        name: page.name,
+        error: page.lastError,
+      })) ?? [];
+  return (
+    <div className="right-quick-rail-bottom-controls">
+      <WorkspaceViewControls {...props.workspaceViewControls} />
       <StatusDockButton
         jobState={props.jobState}
         progressSnapshot={props.progressSnapshot}
         showProgressBar={props.showProgressBar}
         statusLines={props.statusLines}
-        failedPages={
-          props.currentChapter?.pages
-            .filter((page) => page.analysisStatus === "failed")
-            .map((page) => ({
-              id: page.id,
-              name: page.name,
-              error: page.lastError,
-            })) ?? []
-        }
+        failedPages={failedPages}
         onCancelJob={props.onCancelJob}
         onClear={props.onClearStatusLines}
         onOpenExport={props.onOpenExport}
@@ -95,6 +195,34 @@ export function AppRightQuickRail(
         onReviewResults={props.onReviewResults}
         onRetryPage={props.onRetryPage}
       />
-    </aside>
+    </div>
+  );
+}
+
+function QuickRailGroupToggle({
+  collapsed,
+  label,
+  onToggle,
+}: {
+  collapsed: boolean;
+  label: string;
+  onToggle: () => void;
+}): React.JSX.Element {
+  const Icon = collapsed ? IconChevronLeft : IconChevronRight;
+  return (
+    <ControlTooltip
+      className="right-quick-rail-toggle"
+      content={label}
+      placement="left"
+    >
+      <button
+        type="button"
+        aria-pressed={collapsed}
+        aria-label={label}
+        onClick={onToggle}
+      >
+        <Icon size={20} stroke={2.2} aria-hidden="true" />
+      </button>
+    </ControlTooltip>
   );
 }

--- a/src/renderer/src/components/AppSidebar.tsx
+++ b/src/renderer/src/components/AppSidebar.tsx
@@ -47,74 +47,91 @@ export function AppSidebar(props: AppSidebarProps): React.JSX.Element {
   );
 }
 
-function LibrarySidebarContent({
-  currentChapter,
-  jobActive,
-  library,
-  lockedPageIds = EMPTY_PAGE_IDS,
-  onOpenBatchImport,
-  onOpenChapter,
-  onOpenLibraryFolder,
-  onOpenSettings,
-  onOpenShareExport,
-  onOpenShareImport,
-  onOpenTranslationSource,
-  onRemovePage,
-  onRenameChapter,
-  onRenameWork,
-  onReorderChapter,
-  onReorderPage,
-  onRetranslatePage,
-  onSelectPage,
-  selectedPageId,
-  settingsBusy,
-  settingsOpen,
-}: AppSidebarProps): React.JSX.Element {
-  const stableOnOpenChapter = useEventCallback(onOpenChapter);
-  const stableOnRemovePage = useEventCallback(onRemovePage);
-  const stableOnRenameChapter = useEventCallback(onRenameChapter);
-  const stableOnRenameWork = useEventCallback(onRenameWork);
-  const stableOnReorderChapter = useEventCallback(onReorderChapter);
-  const stableOnReorderPage = useEventCallback(onReorderPage);
-  const stableOnRetranslatePage = useEventCallback(onRetranslatePage);
-  const stableOnSelectPage = useEventCallback(onSelectPage);
+function LibrarySidebarContent(props: AppSidebarProps): React.JSX.Element {
+  const { collapsedPanel, toggleLibraryContent, togglePageContent } =
+    useSidebarPanelCollapse();
+  const actions = useStableSidebarActions(props);
   return (
     <>
       <SidebarToolbar
-        jobActive={jobActive}
-        library={library}
-        onOpenBatchImport={onOpenBatchImport}
-        onOpenLibraryFolder={onOpenLibraryFolder}
-        onOpenSettings={onOpenSettings}
-        onOpenShareExport={onOpenShareExport}
-        onOpenShareImport={onOpenShareImport}
-        onOpenTranslationSource={onOpenTranslationSource}
-        settingsBusy={settingsBusy}
-        settingsOpen={settingsOpen}
+        jobActive={props.jobActive}
+        library={props.library}
+        onOpenBatchImport={props.onOpenBatchImport}
+        onOpenLibraryFolder={props.onOpenLibraryFolder}
+        onOpenSettings={props.onOpenSettings}
+        onOpenShareExport={props.onOpenShareExport}
+        onOpenShareImport={props.onOpenShareImport}
+        onOpenTranslationSource={props.onOpenTranslationSource}
+        settingsBusy={props.settingsBusy}
+        settingsOpen={props.settingsOpen}
       />
 
       <LibraryTree
-        library={library}
-        currentChapterId={currentChapter?.id ?? null}
-        jobActive={jobActive}
-        onOpenChapter={stableOnOpenChapter}
-        onRenameWork={stableOnRenameWork}
-        onRenameChapter={stableOnRenameChapter}
-        onReorderChapter={stableOnReorderChapter}
+        collapsed={collapsedPanel === "library"}
+        otherPanelCollapsed={collapsedPanel === "pages"}
+        library={props.library}
+        currentChapterId={props.currentChapter?.id ?? null}
+        jobActive={props.jobActive}
+        onOpenChapter={actions.onOpenChapter}
+        onRenameWork={actions.onRenameWork}
+        onRenameChapter={actions.onRenameChapter}
+        onReorderChapter={actions.onReorderChapter}
+        onToggleOtherPanel={togglePageContent}
       />
 
       <PageList
-        pages={currentChapter?.pages ?? []}
-        selectedPageId={selectedPageId}
-        jobActive={jobActive}
-        lockedPageIds={lockedPageIds}
-        onSelect={stableOnSelectPage}
-        onRetranslate={stableOnRetranslatePage}
-        onRemove={stableOnRemovePage}
-        onReorder={stableOnReorderPage}
+        collapsed={collapsedPanel === "pages"}
+        otherPanelCollapsed={collapsedPanel === "library"}
+        pages={props.currentChapter?.pages ?? []}
+        selectedPageId={props.selectedPageId}
+        jobActive={props.jobActive}
+        lockedPageIds={props.lockedPageIds ?? EMPTY_PAGE_IDS}
+        onSelect={actions.onSelectPage}
+        onRetranslate={actions.onRetranslatePage}
+        onRemove={actions.onRemovePage}
+        onReorder={actions.onReorderPage}
+        onToggleOtherPanel={toggleLibraryContent}
       />
     </>
   );
+}
+
+function useSidebarPanelCollapse(): {
+  collapsedPanel: "library" | "pages" | null;
+  toggleLibraryContent: () => void;
+  togglePageContent: () => void;
+} {
+  const [collapsedPanel, setCollapsedPanel] = React.useState<
+    "library" | "pages" | null
+  >(null);
+  return {
+    collapsedPanel,
+    toggleLibraryContent: React.useCallback(
+      () =>
+        setCollapsedPanel((current) =>
+          current === "library" ? null : "library",
+        ),
+      [],
+    ),
+    togglePageContent: React.useCallback(
+      () =>
+        setCollapsedPanel((current) => (current === "pages" ? null : "pages")),
+      [],
+    ),
+  };
+}
+
+function useStableSidebarActions(props: AppSidebarProps) {
+  return {
+    onOpenChapter: useEventCallback(props.onOpenChapter),
+    onRemovePage: useEventCallback(props.onRemovePage),
+    onRenameChapter: useEventCallback(props.onRenameChapter),
+    onRenameWork: useEventCallback(props.onRenameWork),
+    onReorderChapter: useEventCallback(props.onReorderChapter),
+    onReorderPage: useEventCallback(props.onReorderPage),
+    onRetranslatePage: useEventCallback(props.onRetranslatePage),
+    onSelectPage: useEventCallback(props.onSelectPage),
+  };
 }
 
 const EMPTY_PAGE_IDS: ReadonlySet<string> = new Set();

--- a/src/renderer/src/components/AppWorkspace.tsx
+++ b/src/renderer/src/components/AppWorkspace.tsx
@@ -3,15 +3,15 @@ import { useTranslation } from "react-i18next";
 import { InstallProgressOverlay } from "./InstallProgressOverlay";
 import { StageToolbar } from "./StageToolbar";
 import { useWorkspaceZoomStyle } from "../hooks/useWorkspaceZoomStyle";
-import { WorkspaceViewControls } from "./WorkspaceViewControls";
 import { useEventCallback } from "../hooks/useEventCallback";
+import type { WorkspaceScrollOrigin } from "../lib/workspaceZoom";
 import type { AppWorkspaceProps } from "./appWorkspaceTypes";
 import { BubbleLayoutContextBar } from "./BubbleLayoutContextBar";
 import { WorkspaceContent } from "./WorkspaceContent";
 
 export function AppWorkspace(props: AppWorkspaceProps): React.JSX.Element {
   const { t } = useTranslation("components");
-  const { workspacePanelRef } = props;
+  const { onEffectiveScaleChange, workspacePanelRef } = props;
   const stableActions = useStableWorkspaceActions(props);
   const stableProps = { ...props, ...stableActions };
   const zoomStyle = useWorkspaceZoomStyle({
@@ -22,11 +22,30 @@ export function AppWorkspace(props: AppWorkspaceProps): React.JSX.Element {
     page: props.selectedPage,
     zoom: props.workspaceZoom,
   });
+  React.useLayoutEffect(() => {
+    if (zoomStyle.effectiveScale !== null) {
+      onEffectiveScaleChange?.(zoomStyle.effectiveScale);
+    }
+  }, [onEffectiveScaleChange, zoomStyle.effectiveScale]);
   useResetWorkspaceScrollOnRenderedPage({
+    layoutReady: zoomStyle.effectiveScale !== null,
+    scrollOrigin: zoomStyle.scrollOrigin,
     pageId: props.selectedPage?.id ?? null,
     renderedImagePageId: props.selectedPageImagePageId,
     workspacePanelRef,
   });
+  React.useLayoutEffect(() => {
+    const panel = workspacePanelRef.current;
+    if (zoomStyle.pageFits && panel) {
+      panel.scrollTop = 0;
+      panel.scrollLeft = 0;
+    }
+  }, [
+    props.selectedPage?.id,
+    workspacePanelRef,
+    zoomStyle.effectiveScale,
+    zoomStyle.pageFits,
+  ]);
   return (
     <section className="workspace-shell">
       {props.selectedPage ? (
@@ -59,11 +78,12 @@ function WorkspaceCanvasViewport({
   zoomStyle: ReturnType<typeof useWorkspaceZoomStyle>;
 }): React.JSX.Element {
   const { workspacePanelRef } = props;
+  const lockFitScroll = zoomStyle.pageFits;
   return (
     <div className="workspace-canvas-viewport">
       <div
         ref={workspacePanelRef as React.RefObject<HTMLDivElement | null>}
-        className={`workspace ${zoomStyle.className}`.trim()}
+        className={`workspace ${zoomStyle.className} ${lockFitScroll ? "is-fit-scroll-locked" : ""}`.trim()}
         style={zoomStyle.style}
         tabIndex={0}
         aria-label={readingAreaLabel}
@@ -86,30 +106,20 @@ function WorkspaceCanvasChrome({
   props: AppWorkspaceProps;
 }): React.JSX.Element {
   return (
-    <>
-      <StageToolbar
-        bubbleLayoutAvailable={hasSelectedBubbleLayoutTarget(props)}
-        brushColor={props.brushColor}
-        brushRadius={props.brushRadius}
-        disabled={props.jobActive}
-        hidden={props.stageToolbarHidden}
-        lastRetouchTool={props.lastRetouchTool}
-        onSelectTool={props.onSelectStageTool}
-        onToggleRegionTranslation={props.onToggleRegionTranslation}
-        onToggleHidden={props.onToggleStageToolbarHidden}
-        regionTranslationActive={props.regionSelectionActive}
-        regionTranslationAvailable={props.regionTranslationAvailable}
-        tool={props.stageTool}
-      />
-      <WorkspaceViewControls
-        fitMode={props.workspaceFitMode}
-        zoom={props.workspaceZoom}
-        onChangeFitMode={props.onChangeWorkspaceFitMode}
-        onResetZoom={props.onResetWorkspaceZoom}
-        onZoomIn={props.onZoomInWorkspace}
-        onZoomOut={props.onZoomOutWorkspace}
-      />
-    </>
+    <StageToolbar
+      bubbleLayoutAvailable={hasSelectedBubbleLayoutTarget(props)}
+      brushColor={props.brushColor}
+      brushRadius={props.brushRadius}
+      disabled={props.jobActive}
+      hidden={props.stageToolbarHidden}
+      lastRetouchTool={props.lastRetouchTool}
+      onSelectTool={props.onSelectStageTool}
+      onToggleRegionTranslation={props.onToggleRegionTranslation}
+      onToggleHidden={props.onToggleStageToolbarHidden}
+      regionTranslationActive={props.regionSelectionActive}
+      regionTranslationAvailable={props.regionTranslationAvailable}
+      tool={props.stageTool}
+    />
   );
 }
 
@@ -169,32 +179,114 @@ function useStableWorkspaceActions(
 }
 
 function useResetWorkspaceScrollOnRenderedPage({
+  layoutReady,
+  scrollOrigin,
   pageId,
   renderedImagePageId,
   workspacePanelRef,
 }: {
+  layoutReady: boolean;
+  scrollOrigin: WorkspaceScrollOrigin | null;
   pageId: string | null;
   renderedImagePageId: string | null;
   workspacePanelRef: React.RefObject<HTMLElement | null>;
 }): void {
   const lastResetPageIdRef = React.useRef<string | null>(null);
+  const pendingLayoutRetryPageIdRef = React.useRef<string | null>(null);
+  const lastScrollOriginRef = React.useRef<
+    (WorkspaceScrollOrigin & { pageId: string }) | null
+  >(null);
 
   React.useLayoutEffect(() => {
-    if (!pageId) {
-      lastResetPageIdRef.current = null;
-      return;
-    }
-    if (renderedImagePageId !== pageId) {
-      return;
-    }
-    if (lastResetPageIdRef.current === pageId) {
-      return;
-    }
-    const panel = workspacePanelRef.current;
-    if (panel) {
-      panel.scrollTop = 0;
-      panel.scrollLeft = 0;
-    }
-    lastResetPageIdRef.current = pageId;
-  }, [pageId, renderedImagePageId, workspacePanelRef]);
+    syncWorkspaceScroll({
+      lastResetPageIdRef,
+      lastScrollOriginRef,
+      layoutReady,
+      pageId,
+      pendingLayoutRetryPageIdRef,
+      renderedImagePageId,
+      scrollOrigin,
+      workspacePanelRef,
+    });
+  }, [
+    layoutReady,
+    pageId,
+    renderedImagePageId,
+    scrollOrigin,
+    workspacePanelRef,
+  ]);
+}
+
+type MutableValueRef<T> = { current: T };
+
+type WorkspaceScrollSyncInput = {
+  lastResetPageIdRef: MutableValueRef<string | null>;
+  lastScrollOriginRef: MutableValueRef<
+    (WorkspaceScrollOrigin & { pageId: string }) | null
+  >;
+  layoutReady: boolean;
+  pageId: string | null;
+  pendingLayoutRetryPageIdRef: MutableValueRef<string | null>;
+  renderedImagePageId: string | null;
+  scrollOrigin: WorkspaceScrollOrigin | null;
+  workspacePanelRef: React.RefObject<HTMLElement | null>;
+};
+
+function syncWorkspaceScroll(input: WorkspaceScrollSyncInput): void {
+  if (!input.pageId) {
+    clearWorkspaceScrollSync(input);
+    return;
+  }
+  if (input.renderedImagePageId !== input.pageId) return;
+  if (!shouldSyncWorkspaceScroll(input, input.pageId)) return;
+  const panel = input.workspacePanelRef.current;
+  if (panel) {
+    panel.scrollTop = input.scrollOrigin?.y ?? 0;
+    panel.scrollLeft = input.scrollOrigin?.x ?? 0;
+  }
+  recordWorkspaceScrollSync(input, input.pageId);
+}
+
+function clearWorkspaceScrollSync(input: WorkspaceScrollSyncInput): void {
+  input.lastResetPageIdRef.current = null;
+  input.pendingLayoutRetryPageIdRef.current = null;
+  input.lastScrollOriginRef.current = null;
+}
+
+function shouldSyncWorkspaceScroll(
+  input: WorkspaceScrollSyncInput,
+  pageId: string,
+): boolean {
+  if (input.lastResetPageIdRef.current !== pageId) return true;
+  if (
+    input.layoutReady &&
+    input.pendingLayoutRetryPageIdRef.current === pageId
+  ) {
+    return true;
+  }
+  return didWorkspaceScrollOriginChange(input, pageId);
+}
+
+function didWorkspaceScrollOriginChange(
+  input: WorkspaceScrollSyncInput,
+  pageId: string,
+): boolean {
+  if (!input.layoutReady || !input.scrollOrigin) return false;
+  const previous = input.lastScrollOriginRef.current;
+  if (!previous || previous.pageId !== pageId) return false;
+  return (
+    previous.x !== input.scrollOrigin.x || previous.y !== input.scrollOrigin.y
+  );
+}
+
+function recordWorkspaceScrollSync(
+  input: WorkspaceScrollSyncInput,
+  pageId: string,
+): void {
+  input.lastResetPageIdRef.current = pageId;
+  input.pendingLayoutRetryPageIdRef.current = input.layoutReady ? null : pageId;
+  input.lastScrollOriginRef.current =
+    input.layoutReady && input.scrollOrigin
+      ? { ...input.scrollOrigin, pageId }
+      : null;
 }

--- a/src/renderer/src/components/LibraryTree.tsx
+++ b/src/renderer/src/components/LibraryTree.tsx
@@ -27,6 +27,8 @@ import { EditIcon } from "./ui/icons";
 import { SidebarSectionCollapseButton } from "./SidebarSectionCollapseButton";
 
 type LibraryTreeProps = {
+  collapsed: boolean;
+  otherPanelCollapsed: boolean;
   library: LibraryIndex;
   currentChapterId: string | null;
   jobActive: boolean;
@@ -38,6 +40,7 @@ type LibraryTreeProps = {
     sourceChapterId: string,
     targetChapterId: string,
   ) => void;
+  onToggleOtherPanel: () => void;
 };
 
 type ActiveChapterDrag = {
@@ -55,6 +58,8 @@ type ChapterDragController = {
 };
 
 function LibraryTreeView({
+  collapsed,
+  otherPanelCollapsed,
   library,
   currentChapterId,
   jobActive,
@@ -62,13 +67,13 @@ function LibraryTreeView({
   onRenameWork,
   onRenameChapter,
   onReorderChapter,
+  onToggleOtherPanel,
 }: LibraryTreeProps): React.JSX.Element {
   const { i18n } = useTranslation("components");
   const [searchQuery, setSearchQuery] = React.useState("");
   const contentId = React.useId();
   const deferredSearchQuery = React.useDeferredValue(searchQuery);
   const [sort, handleSortChange] = useStoredLibrarySort();
-  const [collapsed, setCollapsed] = React.useState(false);
   const filteredLibrary = React.useMemo(
     () => filterLibraryIndex(library, deferredSearchQuery),
     [deferredSearchQuery, library],
@@ -94,18 +99,18 @@ function LibraryTreeView({
     <section
       className={`library-panel ${collapsed ? "collapsed" : ""}`.trim()}
       data-collapsed={collapsed}
+      id="sidebar-library-panel"
     >
       <LibraryPanelHeader
         collapsed={collapsed}
-        contentId={contentId}
+        otherPanelCollapsed={otherPanelCollapsed}
         onSearchChange={setSearchQuery}
         onSortChange={handleSortChange}
-        onToggle={() => setCollapsed((current) => !current)}
+        onToggleOtherPanel={onToggleOtherPanel}
         searchQuery={searchQuery}
         sort={sort}
       />
-      {!collapsed ? (
-        <div className="library-panel-content" id={contentId}>
+      <div className="library-panel-content" id={contentId} hidden={collapsed}>
           <DndContext
             sensors={drag.sensors}
             collisionDetection={closestCenter}
@@ -129,8 +134,7 @@ function LibraryTreeView({
               currentChapterId={currentChapterId}
             />
           </DndContext>
-        </div>
-      ) : null}
+      </div>
     </section>
   );
 }
@@ -202,18 +206,18 @@ function useChapterDragController({
 
 function LibraryPanelHeader({
   collapsed,
-  contentId,
+  otherPanelCollapsed,
   onSearchChange,
   onSortChange,
-  onToggle,
+  onToggleOtherPanel,
   searchQuery,
   sort,
 }: {
   collapsed: boolean;
-  contentId: string;
+  otherPanelCollapsed: boolean;
   onSearchChange: (query: string) => void;
   onSortChange: (sort: LibrarySort) => void;
-  onToggle: () => void;
+  onToggleOtherPanel: () => void;
   searchQuery: string;
   sort: LibrarySort;
 }): React.JSX.Element {
@@ -242,10 +246,11 @@ function LibraryPanelHeader({
         </>
       ) : null}
       <SidebarSectionCollapseButton
-        collapsed={collapsed}
-        controls={contentId}
-        onToggle={onToggle}
-        sectionTitle={t("library.title")}
+        collapsed={otherPanelCollapsed}
+        controls="sidebar-page-panel"
+        direction={otherPanelCollapsed ? "up" : "down"}
+        onToggle={onToggleOtherPanel}
+        sectionTitle={t("common.pages")}
       />
     </div>
   );

--- a/src/renderer/src/components/LibraryTree.tsx
+++ b/src/renderer/src/components/LibraryTree.tsx
@@ -111,29 +111,29 @@ function LibraryTreeView({
         sort={sort}
       />
       <div className="library-panel-content" id={contentId} hidden={collapsed}>
-          <DndContext
-            sensors={drag.sensors}
-            collisionDetection={closestCenter}
-            onDragStart={drag.handleDragStart}
-            onDragCancel={drag.handleDragCancel}
-            onDragEnd={drag.handleDragEnd}
-          >
-            <LibraryWorksList
-              activeDrag={drag.activeDrag}
-              currentChapterId={currentChapterId}
-              dragEnabled={drag.dragEnabled}
-              jobActive={jobActive}
-              onOpenChapter={onOpenChapter}
-              onRenameChapter={onRenameChapter}
-              onRenameWork={onRenameWork}
-              searchActive={searchActive}
-              visibleLibrary={visibleLibrary}
-            />
-            <ChapterDragPortal
-              activeDrag={drag.activeDrag}
-              currentChapterId={currentChapterId}
-            />
-          </DndContext>
+        <DndContext
+          sensors={drag.sensors}
+          collisionDetection={closestCenter}
+          onDragStart={drag.handleDragStart}
+          onDragCancel={drag.handleDragCancel}
+          onDragEnd={drag.handleDragEnd}
+        >
+          <LibraryWorksList
+            activeDrag={drag.activeDrag}
+            currentChapterId={currentChapterId}
+            dragEnabled={drag.dragEnabled}
+            jobActive={jobActive}
+            onOpenChapter={onOpenChapter}
+            onRenameChapter={onRenameChapter}
+            onRenameWork={onRenameWork}
+            searchActive={searchActive}
+            visibleLibrary={visibleLibrary}
+          />
+          <ChapterDragPortal
+            activeDrag={drag.activeDrag}
+            currentChapterId={currentChapterId}
+          />
+        </DndContext>
       </div>
     </section>
   );

--- a/src/renderer/src/components/PageList.tsx
+++ b/src/renderer/src/components/PageList.tsx
@@ -29,6 +29,8 @@ import {
 } from "./pageList/pageListMemo";
 
 type PageListProps = {
+  collapsed: boolean;
+  otherPanelCollapsed: boolean;
   pages: MangaPage[];
   selectedPageId: string | null;
   jobActive: boolean;
@@ -38,9 +40,12 @@ type PageListProps = {
   onRetranslate: (pageId: string) => void;
   onRemove: (pageId: string) => void;
   onReorder: (sourcePageId: string, targetPageId: string) => void;
+  onToggleOtherPanel: () => void;
 };
 
 function PageListView({
+  collapsed,
+  otherPanelCollapsed,
   pages,
   selectedPageId,
   jobActive,
@@ -50,8 +55,8 @@ function PageListView({
   onRetranslate,
   onRemove,
   onReorder,
+  onToggleOtherPanel,
 }: PageListProps): React.JSX.Element {
-  const [collapsed, setCollapsed] = React.useState(false);
   const contentId = React.useId();
   const {
     activePage,
@@ -77,63 +82,62 @@ function PageListView({
     <section
       className={buildPageListClassName(pages.length > 0, collapsed)}
       data-collapsed={collapsed}
+      id="sidebar-page-panel"
     >
       <PageListHeader
         collapsed={collapsed}
-        contentId={contentId}
+        otherPanelCollapsed={otherPanelCollapsed}
         filter={filter}
         pages={pages}
         statusMode={statusMode}
         visibleCount={visiblePages.length}
         onFilterChange={setFilter}
-        onToggle={() => setCollapsed((current) => !current)}
+        onToggleOtherPanel={onToggleOtherPanel}
       />
-      {!collapsed ? (
-        <div className="page-list-content" id={contentId}>
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragStart={handleDragStart}
-            onDragCancel={() => setActivePageId(null)}
-            onDragEnd={handleDragEnd}
-          >
-            <PageSortableContent
-              activePage={activePage}
-              activePageId={activePageId}
-              allPageCount={pages.length}
-              disabled={jobActive}
-              lockedPageIds={lockedPageIds}
-              onRemove={onRemove}
-              onRetranslate={onRetranslate}
-              onSelect={onSelect}
-              pages={visiblePages}
-              registerPageItemRef={registerPageItemRef}
-              selectedPageId={selectedPageId}
-              statusMode={statusMode}
-              selectedPageHidden={selectedPageHidden}
-            />
-          </DndContext>
-        </div>
-      ) : null}
+      <div className="page-list-content" id={contentId} hidden={collapsed}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragCancel={() => setActivePageId(null)}
+          onDragEnd={handleDragEnd}
+        >
+          <PageSortableContent
+            activePage={activePage}
+            activePageId={activePageId}
+            allPageCount={pages.length}
+            disabled={jobActive}
+            lockedPageIds={lockedPageIds}
+            onRemove={onRemove}
+            onRetranslate={onRetranslate}
+            onSelect={onSelect}
+            pages={visiblePages}
+            registerPageItemRef={registerPageItemRef}
+            selectedPageId={selectedPageId}
+            statusMode={statusMode}
+            selectedPageHidden={selectedPageHidden}
+          />
+        </DndContext>
+      </div>
     </section>
   );
 }
 
 function PageListHeader({
   collapsed,
-  contentId,
+  otherPanelCollapsed,
   filter,
   onFilterChange,
-  onToggle,
+  onToggleOtherPanel,
   pages,
   statusMode,
   visibleCount,
 }: {
   collapsed: boolean;
-  contentId: string;
+  otherPanelCollapsed: boolean;
   filter: PageListFilter;
   onFilterChange: (filter: PageListFilter) => void;
-  onToggle: () => void;
+  onToggleOtherPanel: () => void;
   pages: MangaPage[];
   statusMode: PageStatusMode;
   visibleCount: number;
@@ -152,10 +156,11 @@ function PageListHeader({
           </span>
         ) : null}
         <SidebarSectionCollapseButton
-          collapsed={collapsed}
-          controls={contentId}
-          onToggle={onToggle}
-          sectionTitle={t("common.pages")}
+          collapsed={otherPanelCollapsed}
+          controls="sidebar-library-panel"
+          direction={otherPanelCollapsed ? "down" : "up"}
+          onToggle={onToggleOtherPanel}
+          sectionTitle={t("library.title")}
         />
       </div>
       {pages.length && !collapsed ? (

--- a/src/renderer/src/components/SidebarSectionCollapseButton.tsx
+++ b/src/renderer/src/components/SidebarSectionCollapseButton.tsx
@@ -6,11 +6,13 @@ import { ChevronDownIcon } from "./ui/icons";
 export function SidebarSectionCollapseButton({
   collapsed,
   controls,
+  direction,
   onToggle,
   sectionTitle,
 }: {
   collapsed: boolean;
   controls: string;
+  direction: "up" | "down";
   onToggle: () => void;
   sectionTitle: string;
 }): React.JSX.Element {
@@ -30,7 +32,9 @@ export function SidebarSectionCollapseButton({
     >
       <ChevronDownIcon
         size={16}
-        className={collapsed ? "" : "sidebar-section-collapse-chevron-open"}
+        className={
+          direction === "up" ? "sidebar-section-collapse-chevron-up" : ""
+        }
       />
     </IconButton>
   );

--- a/src/renderer/src/components/WorkspaceViewControls.tsx
+++ b/src/renderer/src/components/WorkspaceViewControls.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import {
   IconAdjustmentsHorizontal,
   IconAspectRatio,
-  IconChevronDown,
   IconMinus,
   IconPlus,
 } from "@tabler/icons-react";
@@ -15,7 +14,8 @@ import {
 import { ControlTooltip } from "./ui/ControlTooltip";
 import { Select } from "./ui/Select";
 
-type WorkspaceViewControlsProps = {
+export type WorkspaceViewControlsProps = {
+  effectiveScale: number;
   fitMode: WorkspaceFitMode;
   zoom: number;
   onChangeFitMode: (fitMode: WorkspaceFitMode) => void;
@@ -27,6 +27,7 @@ type WorkspaceViewControlsProps = {
 const FIT_MODES: WorkspaceFitMode[] = ["contain", "width", "height", "actual"];
 
 type WorkspaceViewLabels = {
+  adjusted: string;
   fitMode: string;
   fitModes: Record<WorkspaceFitMode, string>;
   hideControls: string;
@@ -42,101 +43,129 @@ export function WorkspaceViewControls(
   props: WorkspaceViewControlsProps,
 ): React.JSX.Element {
   const labels = useWorkspaceViewLabels();
-  const controls = useCollapsibleViewControls();
+  const { open, rootRef, toggle, triggerRef } = useWorkspaceViewPopup();
   const panelId = React.useId();
-  const zoomPercent = Math.round(props.zoom * 100);
+  const zoomPercent = Math.round(props.effectiveScale * 100);
   return (
     <div
-      className={`workspace-view-dock ${controls.collapsed ? "collapsed" : ""}`.trim()}
+      ref={rootRef}
+      className={`workspace-view-dock ${open ? "open" : ""}`.trim()}
     >
-      <CollapsedViewTrigger
-        buttonRef={controls.revealButtonRef}
-        hidden={!controls.collapsed}
+      <WorkspaceViewTrigger
+        buttonRef={triggerRef}
         labels={labels}
+        open={open}
         panelId={panelId}
         zoomPercent={zoomPercent}
-        onExpand={controls.expand}
+        onToggle={toggle}
       />
-      <WorkspaceViewPanel
-        {...props}
-        collapseButtonRef={controls.collapseButtonRef}
-        hidden={controls.collapsed}
-        labels={labels}
-        panelId={panelId}
-        zoomPercent={zoomPercent}
-        onCollapse={controls.collapse}
-      />
+      {open ? (
+        <WorkspaceViewPanel
+          {...props}
+          labels={labels}
+          panelId={panelId}
+          zoomPercent={zoomPercent}
+        />
+      ) : null}
     </div>
   );
 }
 
-function useCollapsibleViewControls(): {
-  collapse: () => void;
-  collapseButtonRef: React.RefObject<HTMLButtonElement | null>;
-  collapsed: boolean;
-  expand: () => void;
-  revealButtonRef: React.RefObject<HTMLButtonElement | null>;
+function useWorkspaceViewPopup(): {
+  open: boolean;
+  rootRef: React.RefObject<HTMLDivElement | null>;
+  toggle: () => void;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
 } {
-  const [collapsed, setCollapsed] = React.useState(true);
-  const collapseButtonRef = React.useRef<HTMLButtonElement>(null);
-  const revealButtonRef = React.useRef<HTMLButtonElement>(null);
-  const focusAfterToggleRef = React.useRef(false);
-  const setCollapsedFromControl = React.useCallback(
-    (nextCollapsed: boolean) => {
-      focusAfterToggleRef.current = true;
-      setCollapsed(nextCollapsed);
-    },
-    [],
-  );
-  const collapse = React.useCallback(() => {
-    setCollapsedFromControl(true);
-  }, [setCollapsedFromControl]);
-  const expand = React.useCallback(() => {
-    setCollapsedFromControl(false);
-  }, [setCollapsedFromControl]);
-  React.useLayoutEffect(() => {
-    if (!focusAfterToggleRef.current) return;
-    focusAfterToggleRef.current = false;
-    (collapsed ? revealButtonRef : collapseButtonRef).current?.focus();
-  }, [collapsed]);
+  const [open, setOpen] = React.useState(false);
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const close = (): void => setOpen(false);
+    const handlePointerDown = (event: PointerEvent): void => {
+      if (!isWorkspaceViewPopupTarget(rootRef.current, event.target)) close();
+    };
+    const handleFocusIn = (event: FocusEvent): void => {
+      if (!isWorkspaceViewPopupTarget(rootRef.current, event.target)) close();
+    };
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      event.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("focusin", handleFocusIn, true);
+    window.addEventListener("blur", close);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("focusin", handleFocusIn, true);
+      window.removeEventListener("blur", close);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
   return {
-    collapse,
-    collapseButtonRef,
-    collapsed,
-    expand,
-    revealButtonRef,
+    open,
+    rootRef,
+    toggle: React.useCallback(() => setOpen((current) => !current), []),
+    triggerRef,
   };
 }
 
-function CollapsedViewTrigger({
+function isWorkspaceViewPopupTarget(
+  root: HTMLDivElement | null,
+  target: EventTarget | null,
+): boolean {
+  if (!root || !(target instanceof Node)) return false;
+  if (root.contains(target)) return true;
+  const targetElement =
+    target instanceof Element ? target : target.parentElement;
+  const selectMenu = targetElement?.closest<HTMLElement>(
+    "[data-ui-select-menu]",
+  );
+  if (!selectMenu) return false;
+  const controlledListboxId = root
+    .querySelector<HTMLElement>("[data-ui-select-trigger][aria-controls]")
+    ?.getAttribute("aria-controls");
+  const controlledListbox = controlledListboxId
+    ? document.getElementById(controlledListboxId)
+    : null;
+  return Boolean(controlledListbox && selectMenu.contains(controlledListbox));
+}
+
+function WorkspaceViewTrigger({
   buttonRef,
-  hidden,
   labels,
+  open,
   panelId,
   zoomPercent,
-  onExpand,
+  onToggle,
 }: {
   buttonRef: React.RefObject<HTMLButtonElement | null>;
-  hidden: boolean;
   labels: WorkspaceViewLabels;
+  open: boolean;
   panelId: string;
   zoomPercent: number;
-  onExpand: () => void;
+  onToggle: () => void;
 }): React.JSX.Element {
   return (
-    <span className="workspace-view-reveal-slot" hidden={hidden}>
+    <span className="workspace-view-reveal-slot">
       <ControlTooltip
         className="workspace-view-reveal"
-        content={labels.showControls}
+        content={open ? labels.hideControls : labels.showControls}
         placement="left"
       >
         <button
           type="button"
           ref={buttonRef}
           aria-controls={panelId}
-          aria-expanded={false}
-          aria-label={labels.showControls}
-          onClick={onExpand}
+          aria-expanded={open}
+          aria-label={open ? labels.hideControls : labels.showControls}
+          onClick={onToggle}
         >
           <IconAdjustmentsHorizontal
             size={16}
@@ -151,26 +180,19 @@ function CollapsedViewTrigger({
 }
 
 function WorkspaceViewPanel({
-  collapseButtonRef,
-  hidden,
   labels,
   panelId,
   zoomPercent,
-  onCollapse,
   ...props
 }: WorkspaceViewControlsProps & {
-  collapseButtonRef: React.RefObject<HTMLButtonElement | null>;
-  hidden: boolean;
   labels: WorkspaceViewLabels;
   panelId: string;
   zoomPercent: number;
-  onCollapse: () => void;
 }): React.JSX.Element {
   return (
     <nav
       className="workspace-view-controls"
       aria-label={labels.label}
-      hidden={hidden}
       id={panelId}
     >
       <WorkspaceZoomRow
@@ -184,24 +206,10 @@ function WorkspaceViewPanel({
       <WorkspaceFitModeSelect
         fitMode={props.fitMode}
         labels={labels}
+        zoom={props.zoom}
+        zoomPercent={zoomPercent}
         onChangeFitMode={props.onChangeFitMode}
       />
-      <ControlTooltip
-        className="workspace-view-control workspace-view-collapse"
-        content={labels.hideControls}
-        placement="left"
-      >
-        <button
-          type="button"
-          ref={collapseButtonRef}
-          aria-controls={panelId}
-          aria-expanded={true}
-          aria-label={labels.hideControls}
-          onClick={onCollapse}
-        >
-          <IconChevronDown size={18} stroke={2.2} aria-hidden="true" />
-        </button>
-      </ControlTooltip>
     </nav>
   );
 }
@@ -225,7 +233,7 @@ function WorkspaceZoomRow({
       <ControlTooltip
         className="workspace-view-control"
         content={labels.zoomIn}
-        placement="left"
+        placement="bottom"
       >
         <button
           type="button"
@@ -239,7 +247,7 @@ function WorkspaceZoomRow({
       <ControlTooltip
         className="workspace-view-control workspace-zoom-percent"
         content={labels.resetZoom}
-        placement="left"
+        placement="bottom"
       >
         <button
           type="button"
@@ -252,7 +260,7 @@ function WorkspaceZoomRow({
       <ControlTooltip
         className="workspace-view-control"
         content={labels.zoomOut}
-        placement="left"
+        placement="bottom"
       >
         <button
           type="button"
@@ -270,16 +278,22 @@ function WorkspaceZoomRow({
 function WorkspaceFitModeSelect({
   fitMode,
   labels,
+  zoom,
+  zoomPercent,
   onChangeFitMode,
-}: Pick<WorkspaceViewControlsProps, "fitMode" | "onChangeFitMode"> & {
+}: Pick<WorkspaceViewControlsProps, "fitMode" | "zoom" | "onChangeFitMode"> & {
   labels: WorkspaceViewLabels;
+  zoomPercent: number;
 }): React.JSX.Element {
-  const selectedLabel = labels.fitModes[fitMode];
+  const adjusted = Math.abs(zoom - 1) > 0.001;
+  const selectedLabel = adjusted
+    ? `${labels.adjusted} (${zoomPercent}%)`
+    : labels.fitModes[fitMode];
   return (
     <ControlTooltip
       className="workspace-view-control workspace-fit-picker"
       content={`${labels.fitMode}: ${selectedLabel}`}
-      placement="left"
+      placement="bottom"
     >
       <span className="workspace-fit-picker-face" aria-hidden="true">
         <IconAspectRatio size={19} stroke={2} />
@@ -287,7 +301,8 @@ function WorkspaceFitModeSelect({
       <Select
         ariaLabel={labels.fitMode}
         className="workspace-fit-select"
-        value={fitMode}
+        placeholder={selectedLabel}
+        value={adjusted ? "__adjusted__" : fitMode}
         options={FIT_MODES.map((mode) => ({
           value: mode,
           label: labels.fitModes[mode],
@@ -304,6 +319,7 @@ function useWorkspaceViewLabels(): WorkspaceViewLabels {
   const { t } = useTranslation("components");
   return React.useMemo(
     () => ({
+      adjusted: t("workspace.view.adjusted"),
       fitMode: t("workspace.view.fitMode"),
       fitModes: {
         actual: t("workspace.view.actual"),

--- a/src/renderer/src/components/appWorkspaceTypes.ts
+++ b/src/renderer/src/components/appWorkspaceTypes.ts
@@ -44,6 +44,7 @@ export type AppWorkspaceProps = {
   onResetWorkspaceZoom: () => void;
   onZoomInWorkspace: () => void;
   onZoomOutWorkspace: () => void;
+  onEffectiveScaleChange?: (scale: number) => void;
   onStagePointerMove: ImageStageProps["onStagePointerMove"];
   onStagePointerUp: ImageStageProps["onStagePointerUp"];
   onStagePointerDown: ImageStageProps["onStagePointerDown"];

--- a/src/renderer/src/components/ui/ControlTooltip.tsx
+++ b/src/renderer/src/components/ui/ControlTooltip.tsx
@@ -4,7 +4,7 @@ type ControlTooltipProps = {
   children: React.ReactNode;
   className?: string;
   content: string;
-  placement?: "left" | "right" | "top";
+  placement?: "bottom" | "left" | "right" | "top";
 };
 
 /** App-rendered tooltip for compact icon controls; never uses native title UI. */

--- a/src/renderer/src/hooks/useWorkspaceZoomStyle.ts
+++ b/src/renderer/src/hooks/useWorkspaceZoomStyle.ts
@@ -5,14 +5,23 @@ import {
   type RefObject,
 } from "react";
 import {
+  computeWorkspaceOverscroll,
   computeWorkspaceImageSize,
+  computeWorkspaceScrollOrigin,
+  doesWorkspacePageFit,
   type ContainerSize,
   type PageAspect,
+  type WorkspaceOverscroll,
+  type WorkspaceScrollOrigin,
   type WorkspaceFitMode,
 } from "../lib/workspaceZoom";
 
 type WorkspaceZoomStyle = {
   className: string;
+  effectiveScale: number | null;
+  overscroll: WorkspaceOverscroll | null;
+  pageFits: boolean;
+  scrollOrigin: WorkspaceScrollOrigin | null;
   style: CSSProperties | undefined;
 };
 
@@ -42,54 +51,114 @@ export function useWorkspaceZoomStyle({
   page,
   zoom,
 }: WorkspaceZoomStyleInput): WorkspaceZoomStyle {
-  const [container, setContainer] = useState<ContainerSize | null>(null);
+  const container = useObservedContainerSize(containerRef);
   const observedImageSize = useObservedImageSize({
     imageRef,
     page,
     revision: imageRevision,
   });
+  const imageAspect =
+    observedImageSize?.revision === imageRevision ? observedImageSize : page;
+  return resolveWorkspaceZoomStyle({ container, fitMode, imageAspect, zoom });
+}
 
+function useObservedContainerSize(
+  containerRef: RefObject<HTMLElement | null>,
+): ContainerSize | null {
+  const [container, setContainer] = useState<ContainerSize | null>(null);
   useLayoutEffect(() => {
     const element = containerRef.current;
-    if (!element) {
-      return;
-    }
+    if (!element) return;
     const sync = (): void =>
-      setContainer((current) => {
-        const next = {
-          width: element.clientWidth,
-          height: element.clientHeight,
-        };
-        return current &&
-          Math.abs(current.width - next.width) < 0.5 &&
-          Math.abs(current.height - next.height) < 0.5
-          ? current
-          : next;
-      });
+      setContainer((current) => retainEqualContainerSize(current, element));
     sync();
     const observer = new ResizeObserver(sync);
     observer.observe(element);
     return () => observer.disconnect();
   }, [containerRef]);
+  return container;
+}
 
-  const imageAspect =
-    observedImageSize?.revision === imageRevision ? observedImageSize : page;
+function retainEqualContainerSize(
+  current: ContainerSize | null,
+  element: HTMLElement,
+): ContainerSize {
+  const next = { width: element.clientWidth, height: element.clientHeight };
+  const unchanged =
+    current &&
+    Math.abs(current.width - next.width) < 0.5 &&
+    Math.abs(current.height - next.height) < 0.5;
+  return unchanged ? current : next;
+}
+
+function resolveWorkspaceZoomStyle({
+  container,
+  fitMode,
+  imageAspect,
+  zoom,
+}: {
+  container: ContainerSize | null;
+  fitMode: WorkspaceFitMode;
+  imageAspect: PageAspect | null;
+  zoom: number;
+}): WorkspaceZoomStyle {
   const imageSize = computeWorkspaceImageSize(
     zoom,
     fitMode,
     imageAspect,
     container,
   );
-  if (!imageSize) {
-    return { className: "", style: undefined };
+  if (!imageSize || !imageAspect) {
+    return {
+      className: "",
+      effectiveScale: null,
+      overscroll: container ? { x: 0, y: 0 } : null,
+      pageFits: false,
+      scrollOrigin: null,
+      style: undefined,
+    };
   }
+  const pageFits = container
+    ? doesWorkspacePageFit(imageSize, container)
+    : false;
+  const overscroll = resolveWorkspaceOverscroll(container, pageFits);
   return {
     className: "is-zoomed",
+    effectiveScale: imageSize.width / imageAspect.width,
+    overscroll,
+    pageFits,
+    scrollOrigin: resolveWorkspaceScrollOrigin(
+      container,
+      imageSize,
+      overscroll,
+      pageFits,
+    ),
     style: {
       "--page-display-w": `${imageSize.width}px`,
       "--page-display-h": `${imageSize.height}px`,
+      "--workspace-overscroll-x": `${overscroll?.x ?? 0}px`,
+      "--workspace-overscroll-y": `${overscroll?.y ?? 0}px`,
     } as CSSProperties,
   };
+}
+
+function resolveWorkspaceOverscroll(
+  container: ContainerSize | null,
+  pageFits: boolean,
+): WorkspaceOverscroll | null {
+  if (!container) return null;
+  return pageFits ? { x: 0, y: 0 } : computeWorkspaceOverscroll(container);
+}
+
+function resolveWorkspaceScrollOrigin(
+  container: ContainerSize | null,
+  imageSize: PageAspect,
+  overscroll: WorkspaceOverscroll | null,
+  pageFits: boolean,
+): WorkspaceScrollOrigin | null {
+  if (pageFits) return { x: 0, y: 0 };
+  if (!container || !overscroll) return null;
+  return computeWorkspaceScrollOrigin(container, imageSize, overscroll);
 }
 
 function useObservedImageSize({

--- a/src/renderer/src/hooks/workspaceBlockDragModel.ts
+++ b/src/renderer/src/hooks/workspaceBlockDragModel.ts
@@ -149,8 +149,19 @@ export function resolveDragCursor(mode: DragMode): string {
   ) {
     return "crosshair";
   }
-  return "nwse-resize";
+  return RESIZE_CURSOR_BY_MODE[mode] ?? "nwse-resize";
 }
+
+const RESIZE_CURSOR_BY_MODE: Partial<Record<DragMode, string>> = {
+  "resize-n": "ns-resize",
+  "resize-s": "ns-resize",
+  "resize-e": "ew-resize",
+  "resize-w": "ew-resize",
+  "resize-ne": "nesw-resize",
+  "resize-sw": "nesw-resize",
+  "resize-nw": "nwse-resize",
+  "resize-se": "nwse-resize",
+};
 
 function resolveWarpDrag(
   drag: DragState,

--- a/src/renderer/src/lib/workspaceZoom.ts
+++ b/src/renderer/src/lib/workspaceZoom.ts
@@ -8,9 +8,6 @@ export const MIN_WORKSPACE_ZOOM = 0.5;
 export const MAX_WORKSPACE_ZOOM = 4;
 export const WORKSPACE_ZOOM_STEP = 0.25;
 
-/** Matches the recoverable editing gutter around `.workspace`. */
-const WORKSPACE_EDIT_GUTTER_PX = 96;
-
 export type WorkspaceFitMode = "contain" | "width" | "height" | "actual";
 
 export function clampWorkspaceZoom(value: number): number {
@@ -27,12 +24,59 @@ export function clampWorkspaceZoom(value: number): number {
 export type PageAspect = { width: number; height: number };
 export type ContainerSize = { width: number; height: number };
 export type ImageDisplaySize = { width: number; height: number };
+export type WorkspaceOverscroll = { x: number; y: number };
+export type WorkspaceScrollOrigin = { x: number; y: number };
+
+/**
+ * Give every page enough pasteboard to move an edge to the viewport centre.
+ * This follows the viewport instead of reserving an arbitrary fixed gutter.
+ */
+export function computeWorkspaceOverscroll(
+  container: ContainerSize,
+): WorkspaceOverscroll {
+  return {
+    x: Math.max(0, Math.round(container.width / 2)),
+    y: Math.max(0, Math.round(container.height / 2)),
+  };
+}
+
+/** Centre fitted page pixels while retaining pasteboard before every edge. */
+export function computeWorkspaceScrollOrigin(
+  container: ContainerSize,
+  image: ImageDisplaySize,
+  overscroll: WorkspaceOverscroll,
+): WorkspaceScrollOrigin {
+  return {
+    x: Math.max(
+      0,
+      Math.round(
+        overscroll.x - Math.max(0, container.width - image.width) / 2,
+      ),
+    ),
+    y: Math.max(
+      0,
+      Math.round(
+        overscroll.y - Math.max(0, container.height - image.height) / 2,
+      ),
+    ),
+  };
+}
+
+/** Native bars describe clipped page pixels, not invisible pasteboard space. */
+export function doesWorkspacePageFit(
+  image: ImageDisplaySize,
+  container: ContainerSize,
+): boolean {
+  return image.width <= container.width && image.height <= container.height;
+}
 
 /**
  * Compute the explicit pixel size the page image should render at. The fit
- * mode establishes the 100% base and zoom scales from there. Explicit sizing
- * keeps the page image, overlays, and pointer geometry on the same coordinate
- * system while allowing small source images to fill the workspace.
+ * mode establishes the zoom base and zoom scales from there. The pasteboard is
+ * scrollable space outside the page and must not make a fitted page smaller.
+ * Explicit sizing keeps the page image, overlays, and pointer geometry on the
+ * same coordinate system while allowing small source images to fill the
+ * workspace.
  */
 export function computeWorkspaceImageSize(
   zoom: number,
@@ -50,14 +94,8 @@ export function computeWorkspaceImageSize(
   ) {
     return null;
   }
-  const availWidth = Math.max(
-    1,
-    container.width - WORKSPACE_EDIT_GUTTER_PX * 2,
-  );
-  const availHeight = Math.max(
-    1,
-    container.height - WORKSPACE_EDIT_GUTTER_PX * 2,
-  );
+  const availWidth = Math.max(1, container.width);
+  const availHeight = Math.max(1, container.height);
   const widthScale = availWidth / page.width;
   const heightScale = availHeight / page.height;
   const fitScale = resolveFitScale(fitMode, widthScale, heightScale);

--- a/src/renderer/src/lib/workspaceZoom.ts
+++ b/src/renderer/src/lib/workspaceZoom.ts
@@ -49,9 +49,7 @@ export function computeWorkspaceScrollOrigin(
   return {
     x: Math.max(
       0,
-      Math.round(
-        overscroll.x - Math.max(0, container.width - image.width) / 2,
-      ),
+      Math.round(overscroll.x - Math.max(0, container.width - image.width) / 2),
     ),
     y: Math.max(
       0,

--- a/src/renderer/src/styles/shell-workspace.css
+++ b/src/renderer/src/styles/shell-workspace.css
@@ -1,8 +1,19 @@
 .app-shell {
   display: grid;
-  grid-template-columns: 400px minmax(0, 1fr) 44px 340px;
+  grid-template-columns: 400px minmax(0, 1fr) 400px;
   height: 100vh;
   background: #0e0f13;
+}
+
+.workspace-region {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+}
+
+.workspace-region > .workspace-shell {
+  width: 100%;
+  height: 100%;
 }
 
 .sidebar,
@@ -24,6 +35,11 @@
 .page-list.collapsed {
   flex: 0 0 auto;
   grid-template-rows: auto;
+}
+
+.library-panel-content[hidden],
+.page-list-content[hidden] {
+  display: none;
 }
 
 .library-panel-content,
@@ -49,7 +65,7 @@
   transition: transform var(--motion-fast) var(--ease-standard);
 }
 
-.sidebar-section-collapse-chevron-open {
+.sidebar-section-collapse-chevron-up {
   transform: rotate(180deg);
 }
 
@@ -88,23 +104,116 @@
 }
 
 .right-quick-rail {
+  position: absolute;
+  z-index: var(--layer-toolbar);
+  top: 0;
+  right: 10px;
+  bottom: 0;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
+  width: 42px;
   min-width: 0;
   min-height: 0;
   padding: 12px 0;
-  background: #0c0d10;
+  background: transparent;
+  pointer-events: none;
 }
 
-.chapter-quick-controls-frame {
+.right-quick-rail button,
+.right-quick-rail [role="combobox"],
+.right-quick-rail .status-popover {
+  pointer-events: auto;
+}
+
+.right-quick-rail-top,
+.right-quick-rail-bottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.right-quick-controls-frame {
   width: 42px;
   border: 1px solid var(--border-soft);
   border-radius: var(--r-md);
   background: #14161b;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
   overflow: visible;
+}
+
+.right-quick-rail-bottom-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 40px;
+}
+
+.right-quick-rail-toggle,
+.right-quick-rail-toggle > button {
+  width: 40px;
+  height: 32px;
+}
+
+.right-quick-rail-toggle > button {
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 0 0 calc(var(--r-md) - 1px) calc(var(--r-md) - 1px);
+  background: transparent;
+  color: #aeb8c5;
+  cursor: pointer;
+}
+
+.right-quick-controls-frame:not(.collapsed) > .right-quick-rail-toggle {
+  border-top: 1px solid var(--border-soft);
+}
+
+.right-quick-rail-toggle > button:hover,
+.right-quick-rail-toggle > button:focus-visible {
+  background: #20242b;
+  color: #f4f6f8;
+}
+
+.right-quick-rail-toggle > button:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.chapter-quick-controls-frame {
+  width: 42px;
+}
+
+.right-quick-bottom-frame .workspace-view-dock,
+.right-quick-bottom-frame .workspace-view-reveal-slot,
+.right-quick-bottom-frame .workspace-view-reveal,
+.right-quick-bottom-frame .status-dock,
+.right-quick-bottom-frame .status-dock-button {
+  width: 40px;
+}
+
+.right-quick-bottom-frame .workspace-view-reveal-slot,
+.right-quick-bottom-frame .workspace-view-reveal,
+.right-quick-bottom-frame .workspace-view-reveal > button,
+.right-quick-bottom-frame .workspace-view-dock,
+.right-quick-bottom-frame .status-dock,
+.right-quick-bottom-frame .status-dock-button {
+  height: 40px;
+}
+
+.right-quick-bottom-frame .workspace-view-reveal > button,
+.right-quick-bottom-frame .status-dock-button {
+  width: 40px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.right-quick-bottom-frame .status-dock {
+  border-top: 1px solid var(--border-soft);
 }
 
 .status-dock {
@@ -438,30 +547,39 @@
 }
 
 .workspace {
-  --workspace-edit-gutter: 96px;
+  --workspace-overscroll-x: 0px;
+  --workspace-overscroll-y: 0px;
   position: relative;
   display: grid;
   place-items: center;
   width: 100%;
   height: 100%;
   overflow: auto;
-  padding: var(--workspace-edit-gutter);
+  padding: var(--workspace-overscroll-y) var(--workspace-overscroll-x);
   background: #0c0d10;
   outline: none;
 }
 
+/* Screen-fit modes are centered and immovable. Scrolling is enabled only
+   after the rendered page itself grows beyond the viewport. */
+.workspace.is-fit-scroll-locked {
+  overflow: hidden;
+}
+
 .workspace-view-dock {
-  position: absolute;
-  z-index: var(--layer-drag);
-  right: 6px;
-  bottom: 10px;
+  position: relative;
   width: 42px;
+  height: 42px;
 }
 
 .workspace-view-controls {
+  position: absolute;
+  right: calc(100% + 8px);
+  bottom: 0;
   display: flex;
-  flex-direction: column;
-  width: 42px;
+  flex-direction: row;
+  width: max-content;
+  height: 42px;
   border: 1px solid var(--border-soft);
   border-radius: var(--r-md);
   background: rgba(20, 22, 27, 0.96);
@@ -470,27 +588,26 @@
   backdrop-filter: blur(8px);
 }
 
-.workspace-view-controls[hidden],
 .workspace-view-reveal-slot[hidden] {
   display: none;
 }
 
 .workspace-view-zoom-row {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
 }
 
 .workspace-view-control {
   width: 40px;
-  height: 38px;
+  height: 40px;
 }
 
 .workspace-view-control > button {
   display: grid;
   place-items: center;
   width: 40px;
-  height: 38px;
+  height: 40px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -524,8 +641,8 @@
 
 .workspace-view-control.workspace-zoom-percent {
   width: 40px;
-  border-top: 1px solid var(--border-soft);
-  border-bottom: 1px solid var(--border-soft);
+  border-right: 1px solid var(--border-soft);
+  border-left: 1px solid var(--border-soft);
 }
 
 .workspace-view-control.workspace-zoom-percent > button {
@@ -534,28 +651,20 @@
   font-variant-numeric: tabular-nums;
 }
 
-.workspace-view-collapse {
-  border-top: 1px solid var(--border-soft);
-}
-
 .workspace-view-zoom-row > .workspace-view-control:first-child > button {
-  border-radius: var(--r-md) var(--r-md) 0 0;
-}
-
-.workspace-view-collapse > button {
-  border-radius: 0 0 var(--r-md) var(--r-md);
+  border-radius: calc(var(--r-md) - 1px) 0 0 calc(var(--r-md) - 1px);
 }
 
 .workspace-fit-picker {
   position: relative;
-  border-top: 1px solid var(--border-soft);
+  border-left: 1px solid var(--border-soft);
 }
 
 .workspace-fit-picker-face {
   display: grid;
   place-items: center;
   width: 40px;
-  height: 38px;
+  height: 40px;
   color: #aeb8c5;
   pointer-events: none;
 }
@@ -564,17 +673,31 @@
   position: absolute;
   inset: 0;
   width: 40px;
-  height: 38px;
+  height: 40px;
 }
 
 .workspace-fit-select [data-ui-select-trigger] {
   width: 40px;
-  height: 38px;
-  min-height: 38px;
+  height: 40px;
+  min-height: 40px;
   padding: 0;
   border: 0;
   background: transparent;
   color: transparent;
+}
+
+.workspace-fit-picker,
+.workspace-fit-picker-face,
+.workspace-fit-select,
+.workspace-fit-select [data-ui-select-trigger] {
+  border-radius: 0 calc(var(--r-md) - 1px) calc(var(--r-md) - 1px) 0;
+}
+
+.workspace-fit-select [data-ui-select-trigger]:hover,
+.workspace-fit-select [data-ui-select-trigger]:focus-visible,
+.workspace-fit-select [data-ui-select-trigger][aria-expanded="true"] {
+  background: transparent;
+  box-shadow: none;
 }
 
 .workspace-fit-select [data-ui-select-trigger] > span,
@@ -611,6 +734,16 @@
   font-variant-numeric: tabular-nums;
   cursor: pointer;
   backdrop-filter: blur(8px);
+}
+
+.workspace-view-reveal > button[aria-expanded="true"] {
+  border-color: var(--accent-bd);
+  background: #20242b;
+  color: #f4f6f8;
+}
+
+.workspace-view-dock.open .workspace-view-reveal > .control-tooltip-bubble {
+  display: none;
 }
 
 .stage-toolbar {
@@ -839,6 +972,13 @@
   transform-origin: center bottom;
 }
 
+.control-tooltip-bottom .control-tooltip-bubble {
+  top: calc(100% + 9px);
+  left: 50%;
+  transform: translate(-50%, -4px) scale(0.97);
+  transform-origin: center top;
+}
+
 .control-tooltip:hover .control-tooltip-bubble,
 .control-tooltip:has(:focus-visible) .control-tooltip-bubble {
   visibility: visible;
@@ -856,6 +996,24 @@
 .control-tooltip-top:hover .control-tooltip-bubble,
 .control-tooltip-top:has(:focus-visible) .control-tooltip-bubble {
   transform: translate(-50%, 0) scale(1);
+}
+
+.control-tooltip-bottom:hover .control-tooltip-bubble,
+.control-tooltip-bottom:has(:focus-visible) .control-tooltip-bubble {
+  transform: translate(-50%, 0) scale(1);
+}
+
+.workspace-fit-picker.control-tooltip-bottom .control-tooltip-bubble {
+  right: 0;
+  left: auto;
+  transform: translateY(-4px) scale(0.97);
+  transform-origin: right top;
+}
+
+.workspace-fit-picker.control-tooltip-bottom:hover .control-tooltip-bubble,
+.workspace-fit-picker.control-tooltip-bottom:has(:focus-visible)
+  .control-tooltip-bubble {
+  transform: translateY(0) scale(1);
 }
 
 .stage-active-tool-badge {
@@ -919,8 +1077,9 @@
 
 @media (max-width: 1400px) {
   .app-shell {
-    grid-template-columns: 340px minmax(0, 1fr) 44px 300px;
+    grid-template-columns: 340px minmax(0, 1fr) 340px;
   }
+
 }
 
 @media (max-width: 1180px) {
@@ -929,7 +1088,7 @@
   }
 
   .app-shell {
-    grid-template-columns: minmax(0, 1fr) 44px;
+    grid-template-columns: minmax(0, 1fr);
     height: auto;
   }
 
@@ -943,8 +1102,9 @@
     grid-column: 1;
   }
 
-  .right-quick-rail {
-    grid-column: 2;
+  .workspace-region {
+    grid-column: 1;
+    min-height: 480px;
   }
 
   .workspace {

--- a/src/renderer/src/styles/shell-workspace.css
+++ b/src/renderer/src/styles/shell-workspace.css
@@ -1079,7 +1079,6 @@
   .app-shell {
     grid-template-columns: 340px minmax(0, 1fr) 340px;
   }
-
 }
 
 @media (max-width: 1180px) {

--- a/src/renderer/src/styles/stage-overlay.css
+++ b/src/renderer/src/styles/stage-overlay.css
@@ -195,11 +195,6 @@
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
 }
 
-.workspace .page-image,
-.workspace .page-image-placeholder {
-  max-height: calc(100vh - 192px);
-}
-
 .page-image-loading-overlay {
   position: absolute;
   inset: 0;
@@ -472,7 +467,6 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  padding-right: 48px;
   background: #0c0d10;
 }
 

--- a/src/shared/i18n/locales/en/components.json
+++ b/src/shared/i18n/locales/en/components.json
@@ -66,10 +66,17 @@
       "hideControls": "Collapse view controls",
       "showControls": "Expand view controls",
       "fitMode": "Image fit mode",
+      "adjusted": "Custom zoom",
       "contain": "Fit screen",
       "width": "Fit width",
       "height": "Fit height",
-      "actual": "100%"
+      "actual": "Actual size (100%)"
+    },
+    "quickRail": {
+      "hideTop": "Hide upper tools",
+      "showTop": "Show upper tools",
+      "hideBottom": "Hide zoom and notifications",
+      "showBottom": "Show zoom and notifications"
     },
     "empty": {
       "title": "Start translating manga",

--- a/src/shared/i18n/locales/ja/components.json
+++ b/src/shared/i18n/locales/ja/components.json
@@ -66,10 +66,17 @@
       "hideControls": "表示コントロールを折りたたむ",
       "showControls": "表示コントロールを展開",
       "fitMode": "画像の表示方法",
+      "adjusted": "カスタム倍率",
       "contain": "画面に合わせる",
       "width": "横幅に合わせる",
       "height": "高さに合わせる",
-      "actual": "100%"
+      "actual": "原寸 (100%)"
+    },
+    "quickRail": {
+      "hideTop": "上のツールを隠す",
+      "showTop": "上のツールを表示",
+      "hideBottom": "倍率と通知を隠す",
+      "showBottom": "倍率と通知を表示"
     },
     "empty": {
       "title": "マンガ翻訳を始めましょう",

--- a/src/shared/i18n/locales/ko/components.json
+++ b/src/shared/i18n/locales/ko/components.json
@@ -66,10 +66,17 @@
       "hideControls": "보기 조절 접기",
       "showControls": "보기 조절 펼치기",
       "fitMode": "이미지 맞춤 방식",
+      "adjusted": "사용자 배율",
       "contain": "화면 맞춤",
       "width": "가로 맞춤",
       "height": "세로 맞춤",
-      "actual": "100%"
+      "actual": "원본 크기 (100%)"
+    },
+    "quickRail": {
+      "hideTop": "위쪽 도구 숨기기",
+      "showTop": "위쪽 도구 보이기",
+      "hideBottom": "배율과 알림 숨기기",
+      "showBottom": "배율과 알림 보이기"
     },
     "empty": {
       "title": "망가 번역을 시작해요",

--- a/src/shared/i18n/locales/zh-Hans/components.json
+++ b/src/shared/i18n/locales/zh-Hans/components.json
@@ -66,10 +66,17 @@
       "hideControls": "收起视图控制",
       "showControls": "展开视图控制",
       "fitMode": "图像适配方式",
+      "adjusted": "自定义缩放",
       "contain": "适应窗口",
       "width": "适应宽度",
       "height": "适应高度",
-      "actual": "100%"
+      "actual": "原始大小 (100%)"
+    },
+    "quickRail": {
+      "hideTop": "隐藏上方工具",
+      "showTop": "显示上方工具",
+      "hideBottom": "隐藏缩放与通知",
+      "showBottom": "显示缩放与通知"
     },
     "empty": {
       "title": "开始翻译漫画",

--- a/src/shared/i18n/locales/zh-Hant/components.json
+++ b/src/shared/i18n/locales/zh-Hant/components.json
@@ -66,10 +66,17 @@
       "hideControls": "收合檢視控制",
       "showControls": "展開檢視控制",
       "fitMode": "影像適配方式",
+      "adjusted": "自訂縮放",
       "contain": "符合視窗",
       "width": "符合寬度",
       "height": "符合高度",
-      "actual": "100%"
+      "actual": "原始大小 (100%)"
+    },
+    "quickRail": {
+      "hideTop": "隱藏上方工具",
+      "showTop": "顯示上方工具",
+      "hideBottom": "隱藏縮放與通知",
+      "showBottom": "顯示縮放與通知"
     },
     "empty": {
       "title": "開始翻譯漫畫",

--- a/tests/appWorkspaceScrollReset.test.tsx
+++ b/tests/appWorkspaceScrollReset.test.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -33,6 +34,7 @@ const PAGE_2_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAA/////ywAAAAAAQABAAACAUwAOw==";
 
 beforeEach(() => {
+  ResizeObserverStub.reset();
   vi.stubGlobal("ResizeObserver", ResizeObserverStub);
   vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
 });
@@ -174,6 +176,56 @@ describe("AppWorkspace scroll reset", () => {
     );
 
     expect(workspace.scrollTop).toBe(400);
+  });
+
+  it("recomputes fit scrolling after layout and follows a changed scroll origin", () => {
+    const refs = makeWorkspaceRefs();
+    const onEffectiveScaleChange = vi.fn();
+    const narrowPage = {
+      ...makePage("page-1"),
+      width: 100,
+      height: 1600,
+    };
+    const props = {
+      ...makeWorkspaceProps({
+        refs,
+        selectedPage: narrowPage,
+        selectedPageImageDataUrl: PAGE_1_IMAGE,
+        selectedPageImagePageId: "page-1",
+      }),
+      onEffectiveScaleChange,
+      workspaceFitMode: "actual" as const,
+    };
+    const view = renderWorkspace(props);
+    const workspace = screen.getByLabelText("읽기 영역") as HTMLElement;
+    Object.defineProperties(workspace, {
+      clientHeight: { configurable: true, value: 500 },
+      clientWidth: { configurable: true, value: 400 },
+    });
+
+    act(() => ResizeObserverStub.emit());
+
+    expect(onEffectiveScaleChange).toHaveBeenLastCalledWith(1);
+    expect(workspace.classList.contains("is-fit-scroll-locked")).toBe(false);
+    expect(workspace.scrollLeft).toBe(50);
+    expect(workspace.scrollTop).toBe(250);
+
+    view.rerender(withFonts(<AppWorkspace {...props} workspaceZoom={2} />));
+
+    expect(onEffectiveScaleChange).toHaveBeenLastCalledWith(2);
+    expect(workspace.scrollLeft).toBe(100);
+    expect(workspace.scrollTop).toBe(250);
+
+    view.rerender(
+      withFonts(
+        <AppWorkspace
+          {...props}
+          selectedPage={null}
+          selectedPageImagePageId={null}
+        />,
+      ),
+    );
+    expect(view.container.querySelector(".stage-toolbar")).toBeNull();
   });
 
   it("does not rescan canvas blocks for job-progress-only root updates", () => {
@@ -411,11 +463,31 @@ describe("AppWorkspace scroll reset", () => {
 });
 
 class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+
+  static emit(): void {
+    for (const instance of ResizeObserverStub.instances) {
+      instance.callback([], instance);
+    }
+  }
+
+  static reset(): void {
+    ResizeObserverStub.instances = [];
+  }
+
   observe(): void {
     return undefined;
   }
 
   disconnect(): void {
+    return undefined;
+  }
+
+  unobserve(): void {
     return undefined;
   }
 }

--- a/tests/pageListStatus.test.tsx
+++ b/tests/pageListStatus.test.tsx
@@ -12,6 +12,8 @@ describe("page list workflow status", () => {
   it("distinguishes translation completion from full postprocess completion", () => {
     render(
       <PageList
+        collapsed={false}
+        otherPanelCollapsed={false}
         pages={PAGES}
         selectedPageId={null}
         jobActive={false}
@@ -19,6 +21,7 @@ describe("page list workflow status", () => {
         onRetranslate={vi.fn()}
         onRemove={vi.fn()}
         onReorder={vi.fn()}
+        onToggleOtherPanel={vi.fn()}
       />,
     );
 

--- a/tests/productionCleanupCoverageGate.test.ts
+++ b/tests/productionCleanupCoverageGate.test.ts
@@ -426,7 +426,7 @@ describe("production cleanup coverage floor gate", () => {
     expect(Object.keys(manifest.floors)).toEqual(scope.existing);
     expect(Object.keys(manifest.introducedFloors)).toEqual(scope.added);
     expect(manifest.deletedFiles).toEqual(scope.deleted);
-    expect(scope.existing).toHaveLength(114);
+    expect(scope.existing).toHaveLength(123);
     expect(scope.added).toHaveLength(22);
     expect(scope.deleted).toHaveLength(0);
   });

--- a/tests/sidebarPanelCollapse.test.tsx
+++ b/tests/sidebarPanelCollapse.test.tsx
@@ -12,8 +12,8 @@ import type {
 
 afterEach(cleanup);
 
-describe("sidebar list panel collapse", () => {
-  it("lets either list release its height to the other list", () => {
+describe("sidebar list panel switching", () => {
+  it("lets each header hide and restore the opposite panel", () => {
     const { container } = render(
       <AppSidebar
         currentChapter={CHAPTER}
@@ -44,21 +44,56 @@ describe("sidebar list panel collapse", () => {
     expect(libraryPanel?.getAttribute("data-collapsed")).toBe("false");
     expect(pagePanel?.getAttribute("data-collapsed")).toBe("false");
 
+    const search = screen.getByRole("textbox", { name: "보관함 검색" });
+    fireEvent.change(search, { target: { value: "테스트" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "페이지 접기" }));
+    expect(libraryPanel?.getAttribute("data-collapsed")).toBe("false");
+    expect(pagePanel?.getAttribute("data-collapsed")).toBe("true");
+    expect(pagePanel?.classList.contains("collapsed")).toBe(true);
+    expect(
+      pagePanel?.querySelector<HTMLElement>(".page-list-content")?.hidden,
+    ).toBe(true);
+    expect(screen.getByRole("heading", { name: "페이지" })).not.toBeNull();
+    expect(container.querySelector(".library-scroll")).not.toBeNull();
+    expect(container.querySelector(".page-list-scroll")).not.toBeNull();
+    const restorePages = screen.getByRole("button", { name: "페이지 펼치기" });
+    expect(restorePages.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      restorePages.querySelector("svg")?.classList.contains(
+        "sidebar-section-collapse-chevron-up",
+      ),
+    ).toBe(true);
+
+    fireEvent.click(restorePages);
+    expect(pagePanel?.getAttribute("data-collapsed")).toBe("false");
+    expect((search as HTMLInputElement).value).toBe("테스트");
+
     fireEvent.click(screen.getByRole("button", { name: "보관함 접기" }));
     expect(libraryPanel?.getAttribute("data-collapsed")).toBe("true");
-    expect(container.querySelector(".library-scroll")).toBeNull();
-    expect(container.querySelector(".page-list-scroll")).not.toBeNull();
+    expect(pagePanel?.getAttribute("data-collapsed")).toBe("false");
+    expect(libraryPanel?.classList.contains("collapsed")).toBe(true);
     expect(
-      screen
-        .getByRole("button", { name: "보관함 펼치기" })
-        .getAttribute("aria-expanded"),
-    ).toBe("false");
+      libraryPanel?.querySelector<HTMLElement>(".library-panel-content")
+        ?.hidden,
+    ).toBe(true);
+    expect(screen.getByRole("heading", { name: "보관함" })).not.toBeNull();
+    const restoreLibrary = screen.getByRole("button", {
+      name: "보관함 펼치기",
+    });
+    expect(restoreLibrary.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      restoreLibrary.querySelector("svg")?.classList.contains(
+        "sidebar-section-collapse-chevron-up",
+      ),
+    ).toBe(false);
 
-    fireEvent.click(screen.getByRole("button", { name: "보관함 펼치기" }));
-    fireEvent.click(screen.getByRole("button", { name: "페이지 접기" }));
-    expect(pagePanel?.getAttribute("data-collapsed")).toBe("true");
-    expect(container.querySelector(".page-list-scroll")).toBeNull();
-    expect(container.querySelector(".library-scroll")).not.toBeNull();
+    fireEvent.click(restoreLibrary);
+    expect(libraryPanel?.getAttribute("data-collapsed")).toBe("false");
+    expect(
+      (screen.getByRole("textbox", { name: "보관함 검색" }) as HTMLInputElement)
+        .value,
+    ).toBe("테스트");
   });
 });
 

--- a/tests/sidebarPanelCollapse.test.tsx
+++ b/tests/sidebarPanelCollapse.test.tsx
@@ -60,9 +60,9 @@ describe("sidebar list panel switching", () => {
     const restorePages = screen.getByRole("button", { name: "페이지 펼치기" });
     expect(restorePages.getAttribute("aria-expanded")).toBe("false");
     expect(
-      restorePages.querySelector("svg")?.classList.contains(
-        "sidebar-section-collapse-chevron-up",
-      ),
+      restorePages
+        .querySelector("svg")
+        ?.classList.contains("sidebar-section-collapse-chevron-up"),
     ).toBe(true);
 
     fireEvent.click(restorePages);
@@ -83,9 +83,9 @@ describe("sidebar list panel switching", () => {
     });
     expect(restoreLibrary.getAttribute("aria-expanded")).toBe("false");
     expect(
-      restoreLibrary.querySelector("svg")?.classList.contains(
-        "sidebar-section-collapse-chevron-up",
-      ),
+      restoreLibrary
+        .querySelector("svg")
+        ?.classList.contains("sidebar-section-collapse-chevron-up"),
     ).toBe(false);
 
     fireEvent.click(restoreLibrary);

--- a/tests/unifiedInpaintingUi.test.tsx
+++ b/tests/unifiedInpaintingUi.test.tsx
@@ -403,6 +403,41 @@ describe("unified right rail", () => {
     expect(container.querySelector('[role="menu"]')).toBeNull();
   });
 
+  it("hides the upper and lower quick-tool groups independently", () => {
+    const props = makeRightRailProps();
+    renderQuickRail(props);
+
+    expect(screen.getByRole("toolbar", { name: "캔버스 작업" })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "보기 조절 펼치기" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "작업 센터 열기" }),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "위쪽 도구 숨기기" }));
+    expect(screen.queryByRole("toolbar", { name: "캔버스 작업" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "보기 조절 펼치기" }),
+    ).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "배율과 알림 숨기기" }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "보기 조절 펼치기" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "작업 센터 열기" }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "위쪽 도구 보이기" }));
+    expect(screen.getByRole("toolbar", { name: "캔버스 작업" })).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "보기 조절 펼치기" }),
+    ).toBeNull();
+  });
+
   it("offers current, whole-chapter, and selected-page erase scopes", () => {
     const props = makeRightRailProps();
     renderRightRail(props);
@@ -708,6 +743,7 @@ describe("unified right rail", () => {
     view.rerender(
       <AppRightQuickRail
         {...props}
+        {...makeQuickRailChromeProps()}
         jobState={{
           id: "job-ocr-failed",
           kind: "gemma-analysis",
@@ -790,9 +826,29 @@ function renderRightRail(props: RightRailProps) {
 }
 
 function renderQuickRail(props: RightRailProps) {
-  return render(<AppRightQuickRail {...props} />, {
+  return render(
+    <AppRightQuickRail {...props} {...makeQuickRailChromeProps()} />,
+    {
     wrapper: RightRailTestProviders,
-  });
+    },
+  );
+}
+
+function makeQuickRailChromeProps(): Pick<
+  React.ComponentProps<typeof AppRightQuickRail>,
+  "workspaceViewControls"
+> {
+  return {
+    workspaceViewControls: {
+      effectiveScale: 1,
+      fitMode: "contain",
+      zoom: 1,
+      onChangeFitMode: () => undefined,
+      onResetZoom: () => undefined,
+      onZoomIn: () => undefined,
+      onZoomOut: () => undefined,
+    },
+  };
 }
 
 function RightRailTestProviders({

--- a/tests/unifiedInpaintingUi.test.tsx
+++ b/tests/unifiedInpaintingUi.test.tsx
@@ -421,15 +421,11 @@ describe("unified right rail", () => {
       screen.getByRole("button", { name: "보기 조절 펼치기" }),
     ).not.toBeNull();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "배율과 알림 숨기기" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "배율과 알림 숨기기" }));
     expect(
       screen.queryByRole("button", { name: "보기 조절 펼치기" }),
     ).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "작업 센터 열기" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "작업 센터 열기" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "위쪽 도구 보이기" }));
     expect(screen.getByRole("toolbar", { name: "캔버스 작업" })).not.toBeNull();
@@ -829,7 +825,7 @@ function renderQuickRail(props: RightRailProps) {
   return render(
     <AppRightQuickRail {...props} {...makeQuickRailChromeProps()} />,
     {
-    wrapper: RightRailTestProviders,
+      wrapper: RightRailTestProviders,
     },
   );
 }

--- a/tests/workspaceBlockDragModel.test.ts
+++ b/tests/workspaceBlockDragModel.test.ts
@@ -18,6 +18,18 @@ describe("workspace block drag model", () => {
     expect(rotationCursor).toMatch(/^url\(".+"\) 12 12, crosshair$/);
   });
 
+  it("keeps the grabbed resize handle cursor throughout a resize drag", () => {
+    expect(resolveDragCursor("resize-n")).toBe("ns-resize");
+    expect(resolveDragCursor("resize-s")).toBe("ns-resize");
+    expect(resolveDragCursor("resize-e")).toBe("ew-resize");
+    expect(resolveDragCursor("resize-w")).toBe("ew-resize");
+    expect(resolveDragCursor("resize-ne")).toBe("nesw-resize");
+    expect(resolveDragCursor("resize-sw")).toBe("nesw-resize");
+    expect(resolveDragCursor("resize-nw")).toBe("nwse-resize");
+    expect(resolveDragCursor("resize-se")).toBe("nwse-resize");
+    expect(resolveDragCursor("resize")).toBe("nwse-resize");
+  });
+
   it("rejects a perspective edge that crosses the opposite edge", () => {
     const { page, drag } = makeFixture("perspective-top");
     const result = resolveBlockDrag(

--- a/tests/workspaceChromeCss.test.ts
+++ b/tests/workspaceChromeCss.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("workspace chrome CSS", () => {
+  const shellCss = fs.readFileSync(
+    path.join(ROOT, "src/renderer/src/styles/shell-workspace.css"),
+    "utf8",
+  );
+  const stageCss = fs.readFileSync(
+    path.join(ROOT, "src/renderer/src/styles/stage-overlay.css"),
+    "utf8",
+  );
+
+  it("locks fitted pages instead of creating an invisible scroll area", () => {
+    expect(rule(shellCss, ".workspace.is-fit-scroll-locked")).toContain(
+      "overflow: hidden",
+    );
+    expect(rule(stageCss, ".workspace-canvas-viewport")).not.toContain(
+      "padding-right",
+    );
+    expect(stageCss).not.toContain("192px");
+  });
+
+  it("keeps the fit-mode icon visible through hover and focus states", () => {
+    const interactiveRule = rule(
+      shellCss,
+      ".workspace-fit-select [data-ui-select-trigger]:hover,",
+    );
+    expect(interactiveRule).toContain("background: transparent");
+    expect(interactiveRule).toContain("box-shadow: none");
+    const fitTooltip = rule(
+      shellCss,
+      ".workspace-fit-picker.control-tooltip-bottom .control-tooltip-bubble",
+    );
+    expect(fitTooltip).toContain("right: 0");
+    expect(fitTooltip).toContain("left: auto");
+  });
+
+  it("opens zoom controls as a horizontal flyout on the left", () => {
+    const controls = rule(shellCss, ".workspace-view-controls");
+    expect(controls).toContain("right: calc(100% + 8px)");
+    expect(controls).toContain("flex-direction: row");
+    expect(controls).toContain("width: max-content");
+    expect(
+      rule(
+        shellCss,
+        ".workspace-view-dock.open .workspace-view-reveal > .control-tooltip-bubble",
+      ),
+    ).toContain("display: none");
+  });
+
+  it("collapses sidebar contents while retaining both panel headers", () => {
+    const collapsedPanels = rule(shellCss, ".library-panel.collapsed,");
+    expect(collapsedPanels).toContain("flex: 0 0 auto");
+    expect(collapsedPanels).not.toContain("display: none");
+    expect(rule(shellCss, ".library-panel-content[hidden],")).toContain(
+      "display: none",
+    );
+  });
+
+  it("uses one framed surface for each right quick-tool group", () => {
+    const frame = rule(shellCss, ".right-quick-controls-frame");
+    expect(frame).toContain("border: 1px solid var(--border-soft)");
+    expect(frame).toContain("border-radius: var(--r-md)");
+    expect(
+      rule(
+        shellCss,
+        ".right-quick-controls-frame:not(.collapsed) > .right-quick-rail-toggle",
+      ),
+    ).toContain("border-top: 1px solid var(--border-soft)");
+  });
+
+  it("overlays both toolbars symmetrically without reserving a right column", () => {
+    const shell = rule(shellCss, ".app-shell");
+    expect(shell).toContain(
+      "grid-template-columns: 400px minmax(0, 1fr) 400px",
+    );
+    expect(shell).not.toContain("44px");
+    const rightToolbar = rule(shellCss, ".right-quick-rail");
+    expect(rightToolbar).toContain("right: 10px");
+    expect(rightToolbar).toContain("position: absolute");
+  });
+});
+
+function rule(css: string, selector: string): string {
+  const start = css.indexOf(selector);
+  if (start < 0) throw new Error(`Missing CSS selector: ${selector}`);
+  const open = css.indexOf("{", start);
+  const close = css.indexOf("}", open);
+  if (open < 0 || close < 0) {
+    throw new Error(`Invalid CSS declaration block: ${selector}`);
+  }
+  return css.slice(open + 1, close);
+}

--- a/tests/workspaceViewControls.test.tsx
+++ b/tests/workspaceViewControls.test.tsx
@@ -1,12 +1,19 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceViewControls } from "../src/renderer/src/components/WorkspaceViewControls";
 import {
   chooseCustomSelectOption,
   customSelectOptionValues,
+  openCustomSelect,
 } from "./testUtils/customSelect";
 
 afterEach(cleanup);
@@ -16,6 +23,7 @@ describe("WorkspaceViewControls", () => {
     const onChangeFitMode = vi.fn();
     render(
       <WorkspaceViewControls
+        effectiveScale={0.625}
         fitMode="contain"
         zoom={1}
         onChangeFitMode={onChangeFitMode}
@@ -32,6 +40,10 @@ describe("WorkspaceViewControls", () => {
       "height",
       "actual",
     ]);
+    expect(
+      within(screen.getByRole("listbox", { name: "이미지 맞춤 방식" }))
+        .getByRole("option", { name: "원본 크기 (100%)", hidden: true }),
+    ).not.toBeNull();
     fireEvent.keyDown(
       screen.getByRole("combobox", { name: "이미지 맞춤 방식" }),
       { key: "Escape" },
@@ -45,6 +57,7 @@ describe("WorkspaceViewControls", () => {
     const onZoomIn = vi.fn();
     render(
       <WorkspaceViewControls
+        effectiveScale={4}
         fitMode="actual"
         zoom={4}
         onChangeFitMode={() => undefined}
@@ -67,9 +80,34 @@ describe("WorkspaceViewControls", () => {
     expect(resetButton.textContent).toBe("400%");
   });
 
-  it("collapses to an accessible reveal control without losing zoom or fit controls", () => {
+  it("marks manual zoom as custom and reapplies the current fit preset", () => {
+    const onChangeFitMode = vi.fn();
     render(
       <WorkspaceViewControls
+        effectiveScale={1.14}
+        fitMode="contain"
+        zoom={1.25}
+        onChangeFitMode={onChangeFitMode}
+        onResetZoom={() => undefined}
+        onZoomIn={() => undefined}
+        onZoomOut={() => undefined}
+      />,
+    );
+    expandViewControls();
+
+    expect(
+      screen.getByRole("tooltip", {
+        name: "이미지 맞춤 방식: 사용자 배율 (114%)",
+      }),
+    ).not.toBeNull();
+    chooseCustomSelectOption("이미지 맞춤 방식", "화면 맞춤");
+    expect(onChangeFitMode).toHaveBeenCalledWith("contain");
+  });
+
+  it("opens leftward controls and dismisses them on focus loss, outside pointer, or Escape", () => {
+    render(
+      <WorkspaceViewControls
+        effectiveScale={0.625}
         fitMode="contain"
         zoom={1}
         onChangeFitMode={() => undefined}
@@ -82,50 +120,86 @@ describe("WorkspaceViewControls", () => {
     const revealButton = screen.getByRole("button", {
       name: "보기 조절 펼치기",
     });
+    expect(revealButton.textContent).toContain("63%");
     expect(revealButton.getAttribute("aria-expanded")).toBe("false");
     fireEvent.click(revealButton);
 
-    const collapseButton = screen.getByRole("button", {
+    const openTrigger = screen.getByRole("button", {
       name: "보기 조절 접기",
     });
+    expect(openTrigger).toBe(revealButton);
+    expect(openTrigger.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByRole("button", { name: "축소" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "확대" })).not.toBeNull();
     expect(screen.getByLabelText("이미지 맞춤 방식")).not.toBeNull();
 
-    fireEvent.click(collapseButton);
+    const outsideButton = document.createElement("button");
+    outsideButton.textContent = "외부 버튼";
+    document.body.append(outsideButton);
+    outsideButton.focus();
+    fireEvent.focusIn(outsideButton);
 
     const restoredRevealButton = screen.getByRole("button", {
       name: "보기 조절 펼치기",
     });
     expect(restoredRevealButton.getAttribute("aria-expanded")).toBe("false");
-    expect(document.activeElement).toBe(restoredRevealButton);
-    expect(
-      document.getElementById(
-        restoredRevealButton.getAttribute("aria-controls") ?? "",
-      ),
-    ).not.toBeNull();
     expect(screen.queryByRole("button", { name: "축소" })).toBeNull();
     expect(screen.queryByRole("button", { name: "확대" })).toBeNull();
-    expect(
-      screen
-        .getByLabelText("이미지 맞춤 방식")
-        .closest("nav")
-        ?.hasAttribute("hidden"),
-    ).toBe(true);
 
     fireEvent.click(restoredRevealButton);
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("button", { name: "축소" })).toBeNull();
 
-    const restoredCollapseButton = screen.getByRole("button", {
-      name: "보기 조절 접기",
+    fireEvent.click(
+      screen.getByRole("button", { name: "보기 조절 펼치기" }),
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    const escapedTrigger = screen.getByRole("button", {
+      name: "보기 조절 펼치기",
     });
-    expect(restoredCollapseButton.getAttribute("aria-expanded")).toBe("true");
-    expect(document.activeElement).toBe(restoredCollapseButton);
+    expect(document.activeElement).toBe(escapedTrigger);
+
+    fireEvent.click(escapedTrigger);
     expect(
       screen.getByRole("button", { name: "배율 초기화" }).textContent,
-    ).toBe("100%");
+    ).toBe("63%");
     expect(
       (screen.getByLabelText("이미지 맞춤 방식") as HTMLButtonElement).value,
     ).toBe("contain");
+    outsideButton.remove();
+  });
+
+  it("keeps portal fit choices interactive and closes the flyout on window blur", () => {
+    render(
+      <WorkspaceViewControls
+        effectiveScale={0.79}
+        fitMode="contain"
+        zoom={1}
+        onChangeFitMode={() => undefined}
+        onResetZoom={() => undefined}
+        onZoomIn={() => undefined}
+        onZoomOut={() => undefined}
+      />,
+    );
+    expandViewControls();
+
+    const listbox = openCustomSelect("이미지 맞춤 방식");
+    fireEvent.pointerDown(
+      within(listbox).getByRole("option", { name: "화면 맞춤", hidden: true }),
+    );
+    expect(
+      screen.getByRole("button", { name: "보기 조절 접기" }),
+    ).not.toBeNull();
+
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(
+      screen.getByRole("button", { name: "보기 조절 접기" }),
+    ).not.toBeNull();
+
+    fireEvent.blur(window);
+    expect(
+      screen.getByRole("button", { name: "보기 조절 펼치기" }),
+    ).not.toBeNull();
   });
 });
 

--- a/tests/workspaceViewControls.test.tsx
+++ b/tests/workspaceViewControls.test.tsx
@@ -41,8 +41,9 @@ describe("WorkspaceViewControls", () => {
       "actual",
     ]);
     expect(
-      within(screen.getByRole("listbox", { name: "이미지 맞춤 방식" }))
-        .getByRole("option", { name: "원본 크기 (100%)", hidden: true }),
+      within(
+        screen.getByRole("listbox", { name: "이미지 맞춤 방식" }),
+      ).getByRole("option", { name: "원본 크기 (100%)", hidden: true }),
     ).not.toBeNull();
     fireEvent.keyDown(
       screen.getByRole("combobox", { name: "이미지 맞춤 방식" }),
@@ -150,9 +151,7 @@ describe("WorkspaceViewControls", () => {
     fireEvent.pointerDown(document.body);
     expect(screen.queryByRole("button", { name: "축소" })).toBeNull();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "보기 조절 펼치기" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "보기 조절 펼치기" }));
     fireEvent.keyDown(window, { key: "Escape" });
     const escapedTrigger = screen.getByRole("button", {
       name: "보기 조절 펼치기",

--- a/tests/workspaceZoom.test.ts
+++ b/tests/workspaceZoom.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   clampWorkspaceZoom,
+  computeWorkspaceOverscroll,
   computeWorkspaceImageSize,
+  computeWorkspaceScrollOrigin,
+  doesWorkspacePageFit,
   MAX_WORKSPACE_ZOOM,
   MIN_WORKSPACE_ZOOM,
 } from "../src/renderer/src/lib/workspaceZoom";
@@ -15,14 +18,52 @@ describe("clampWorkspaceZoom", () => {
   });
 });
 
+describe("workspace overscroll", () => {
+  it("follows half the current viewport instead of a fixed pixel gutter", () => {
+    expect(computeWorkspaceOverscroll({ width: 1000, height: 760 })).toEqual({
+      x: 500,
+      y: 380,
+    });
+  });
+
+  it("centres fitted page pixels instead of pinning them to the left edge", () => {
+    const container = { width: 1000, height: 760 };
+    const overscroll = computeWorkspaceOverscroll(container);
+    expect(
+      computeWorkspaceScrollOrigin(
+        container,
+        { width: 500, height: 760 },
+        overscroll,
+      ),
+    ).toEqual({ x: 250, y: 380 });
+    expect(
+      computeWorkspaceScrollOrigin(
+        container,
+        { width: 1200, height: 900 },
+        overscroll,
+      ),
+    ).toEqual(overscroll);
+  });
+
+  it("shows native bars only when page pixels are clipped", () => {
+    const viewport = { width: 1000, height: 760 };
+    expect(
+      doesWorkspacePageFit({ width: 500, height: 760 }, viewport),
+    ).toBe(true);
+    expect(
+      doesWorkspacePageFit({ width: 1001, height: 760 }, viewport),
+    ).toBe(false);
+  });
+});
+
 describe("computeWorkspaceImageSize", () => {
   const page = { width: 800, height: 1200 };
   const container = { width: 1000, height: 2000 };
 
   it("fits the whole image to the workspace and upscales small pages", () => {
     expect(computeWorkspaceImageSize(1, "contain", page, container)).toEqual({
-      width: 808,
-      height: 1212,
+      width: 1000,
+      height: 1500,
     });
   });
 
@@ -34,9 +75,9 @@ describe("computeWorkspaceImageSize", () => {
   it("scales the fitted size by the zoom factor", () => {
     const base = computeWorkspaceImageSize(2, "contain", page, container);
     expect(base).not.toBeNull();
-    // Width-bound fit: 1000-192 = 808; height = 808 * 1200/800.
-    expect(base?.width).toBe(Math.round(808 * 2));
-    expect(base?.height).toBe(Math.round((808 / (800 / 1200)) * 2));
+    // The editing pasteboard remains scrollable outside the fitted page.
+    expect(base?.width).toBe(2000);
+    expect(base?.height).toBe(3000);
   });
 
   it("keeps the whole image within the available height when tall", () => {
@@ -45,8 +86,8 @@ describe("computeWorkspaceImageSize", () => {
       width: 1000,
       height: 600,
     });
-    // Height-bound: availHeight 600-192 = 408, then * zoom.
-    expect(result?.height).toBe(Math.round(408 * 1.5));
+    // Height-bound against the viewport itself, then scaled by zoom.
+    expect(result?.height).toBe(900);
   });
 
   it("supports width, height, and actual-pixel bases", () => {
@@ -54,14 +95,14 @@ describe("computeWorkspaceImageSize", () => {
     expect(
       computeWorkspaceImageSize(1, "width", page, compactContainer),
     ).toEqual({
-      width: 808,
-      height: 1212,
+      width: 1000,
+      height: 1500,
     });
     expect(
       computeWorkspaceImageSize(1, "height", page, compactContainer),
     ).toEqual({
-      width: 405,
-      height: 608,
+      width: 533,
+      height: 800,
     });
     expect(
       computeWorkspaceImageSize(1, "actual", page, compactContainer),

--- a/tests/workspaceZoom.test.ts
+++ b/tests/workspaceZoom.test.ts
@@ -47,12 +47,12 @@ describe("workspace overscroll", () => {
 
   it("shows native bars only when page pixels are clipped", () => {
     const viewport = { width: 1000, height: 760 };
-    expect(
-      doesWorkspacePageFit({ width: 500, height: 760 }, viewport),
-    ).toBe(true);
-    expect(
-      doesWorkspacePageFit({ width: 1001, height: 760 }, viewport),
-    ).toBe(false);
+    expect(doesWorkspacePageFit({ width: 500, height: 760 }, viewport)).toBe(
+      true,
+    );
+    expect(doesWorkspacePageFit({ width: 1001, height: 760 }, viewport)).toBe(
+      false,
+    );
   });
 });
 

--- a/tests/workspaceZoomNaturalImage.test.tsx
+++ b/tests/workspaceZoomNaturalImage.test.tsx
@@ -7,6 +7,7 @@ import { useWorkspaceZoomStyle } from "../src/renderer/src/hooks/useWorkspaceZoo
 import type { WorkspaceFitMode } from "../src/renderer/src/lib/workspaceZoom";
 
 beforeEach(() => {
+  ResizeObserverStub.reset();
   vi.stubGlobal("ResizeObserver", ResizeObserverStub);
 });
 
@@ -27,9 +28,15 @@ describe("workspace zoom natural image dimensions", () => {
 
     expect(result.current).toEqual({
       className: "is-zoomed",
+      effectiveScale: 1,
+      overscroll: { x: 0, y: 0 },
+      pageFits: true,
+      scrollOrigin: { x: 0, y: 0 },
       style: {
         "--page-display-h": "1200px",
         "--page-display-w": "836px",
+        "--workspace-overscroll-x": "0px",
+        "--workspace-overscroll-y": "0px",
       },
     });
   });
@@ -44,12 +51,56 @@ describe("workspace zoom natural image dimensions", () => {
       harness.useStyle("contain", harness.source),
     );
 
-    expect(result.current).toEqual({
-      className: "is-zoomed",
-      style: {
-        "--page-display-h": "808px",
-        "--page-display-w": "563px",
-      },
+    expect(result.current.style).toEqual({
+      "--page-display-h": "1000px",
+      "--page-display-w": "697px",
+      "--workspace-overscroll-x": "0px",
+      "--workspace-overscroll-y": "0px",
+    });
+    expect(result.current.effectiveScale).toBeCloseTo(697 / 836);
+    expect(result.current.pageFits).toBe(true);
+    expect(result.current.scrollOrigin).toEqual({ x: 0, y: 0 });
+  });
+
+  it("recomputes screen fit immediately when the workspace is resized", () => {
+    const harness = makeHarness({
+      container: { width: 800, height: 900 },
+      metadata: { width: 800, height: 1200 },
+      natural: { width: 800, height: 1200 },
+    });
+    const { result } = renderHook(() =>
+      harness.useStyle("contain", harness.source),
+    );
+
+    expect(result.current.style).toMatchObject({
+      "--page-display-h": "900px",
+      "--page-display-w": "600px",
+    });
+    harness.resize({ width: 1200, height: 1500 });
+    expect(result.current.style).toMatchObject({
+      "--page-display-h": "1500px",
+      "--page-display-w": "1000px",
+    });
+    expect(result.current.pageFits).toBe(true);
+    expect(result.current.scrollOrigin).toEqual({ x: 0, y: 0 });
+  });
+
+  it("adds viewport-relative pasteboard only after page pixels overflow", () => {
+    const harness = makeHarness({
+      container: { width: 400, height: 500 },
+      metadata: { width: 100, height: 1600 },
+      natural: { width: 100, height: 1600 },
+    });
+    const { result } = renderHook(() =>
+      harness.useStyle("actual", harness.source),
+    );
+
+    expect(result.current.pageFits).toBe(false);
+    expect(result.current.overscroll).toEqual({ x: 200, y: 250 });
+    expect(result.current.scrollOrigin).toEqual({ x: 50, y: 250 });
+    expect(result.current.style).toMatchObject({
+      "--workspace-overscroll-x": "200px",
+      "--workspace-overscroll-y": "250px",
     });
   });
 
@@ -95,11 +146,31 @@ describe("workspace zoom natural image dimensions", () => {
 });
 
 class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+
+  static emit(): void {
+    for (const instance of ResizeObserverStub.instances) {
+      instance.callback([], instance);
+    }
+  }
+
+  static reset(): void {
+    ResizeObserverStub.instances = [];
+  }
+
   observe(): void {
     return undefined;
   }
 
   disconnect(): void {
+    return undefined;
+  }
+
+  unobserve(): void {
     return undefined;
   }
 }
@@ -138,15 +209,21 @@ function makeHarness({
   const imageRef = React.createRef<HTMLImageElement>();
   imageRef.current = image;
   const containerElement = document.createElement("section");
+  const containerSize = { ...container };
   Object.defineProperties(containerElement, {
-    clientHeight: { configurable: true, value: container.height },
-    clientWidth: { configurable: true, value: container.width },
+    clientHeight: { configurable: true, get: () => containerSize.height },
+    clientWidth: { configurable: true, get: () => containerSize.width },
   });
   const containerRef = React.createRef<HTMLElement>();
   containerRef.current = containerElement;
 
   return {
     image,
+    resize(next: { height: number; width: number }): void {
+      containerSize.height = next.height;
+      containerSize.width = next.width;
+      act(() => ResizeObserverStub.emit());
+    },
     replaceImage(
       revision: string,
       next: { complete: boolean; height: number; width: number },


### PR DESCRIPTION
## Summary
- make screen-fit zoom use the real workspace viewport, stay centered, and suppress scroll until the page actually overflows
- align the right quick rail with the left toolbar, add independent icon-group collapse controls, and move zoom controls into a non-obscuring horizontal flyout
- make sidebar section chevrons control the adjacent section consistently
- preserve the active resize-handle cursor throughout a drag

## Verification
- `npm run check` (481 files; 3,557 passed, 2 skipped)
- production build passed
- page artwork parity: 0 mismatched pixels on both fixtures
- real production-component UI QA at 1440×1000 and 1000×760