### PR TITLE
Fix nested ROCm runtime library validation

### DIFF
--- a/docs/production-cleanup-scenario-ledger.md
+++ b/docs/production-cleanup-scenario-ledger.md
@@ -85,7 +85,7 @@ editing the totals by hand.
   introduced floors has SHA-256
   `5c694dc7b0c2636bc36e1d72461ba6289569db926fed512b8ea3ee85e6f7bec4`.
 - The manifest pins the exact Windows covered/total counts and the diagnostic
-  percentage for lines/statements/functions/branches in all 123 existing
+  percentage for lines/statements/functions/branches in all 124 existing
   coverage-eligible `src/**` files changed since cleanup start. The 22 new
   eligible source files have their accepted post-refactor Windows ratios sealed
   as `introducedFloors`; they cannot regress to a merely present 0% record.

--- a/scripts/production-cleanup-coverage-floors.json
+++ b/scripts/production-cleanup-coverage-floors.json
@@ -109,6 +109,12 @@
       "functions": { "covered": 9, "total": 28, "pct": 32.14 },
       "branches": { "covered": 12, "total": 58, "pct": 20.68 }
     },
+    "src/main/runtime/model/runtime-files.cjs": {
+      "lines": { "covered": 40, "total": 52, "pct": 76.92 },
+      "statements": { "covered": 41, "total": 54, "pct": 75.92 },
+      "functions": { "covered": 16, "total": 20, "pct": 80 },
+      "branches": { "covered": 26, "total": 41, "pct": 63.41 }
+    },
     "src/main/runtime/model/runtime-locations.cjs": {
       "lines": { "covered": 13, "total": 32, "pct": 40.62 },
       "statements": { "covered": 14, "total": 37, "pct": 37.83 },

--- a/src/main/runtime/model/runtime-files.cjs
+++ b/src/main/runtime/model/runtime-files.cjs
@@ -2,6 +2,8 @@
 const { existsSync, readdirSync } = require("node:fs");
 const path = require("node:path");
 
+const MAX_RUNTIME_LIBRARY_SCAN_DIRECTORIES = 4096;
+
 /** @typedef {{ backend?: string; dir: string; id?: string; kind?: string; requiredFiles?: Array<string | string[]> }} LlamaRuntimeDescriptor */
 
 function serverBinaryName() {
@@ -61,13 +63,35 @@ function hasAnyNamedFile(dir, names) {
 
 /** @param {string} dir */
 function hasAnyRuntimeLibraryFile(dir) {
+  const pending = [dir];
+  let scannedDirectories = 0;
   try {
-    return readdirSync(dir, { withFileTypes: true }).some(
-      (entry) => entry.isFile() && /\.(?:dat|co|hsaco)$/i.test(entry.name),
-    );
+    while (pending.length > 0) {
+      if (scannedDirectories >= MAX_RUNTIME_LIBRARY_SCAN_DIRECTORIES) {
+        return false;
+      }
+      const current = pending.pop();
+      if (!current) break;
+      scannedDirectories += 1;
+      if (scanRuntimeLibraryDirectory(current, pending)) return true;
+    }
   } catch (_error) {
     return false;
   }
+  return false;
+}
+
+/** @param {string} dir @param {string[]} pending */
+function scanRuntimeLibraryDirectory(dir, pending) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile() && /\.(?:dat|co|hsaco)$/i.test(entry.name)) return true;
+    // Runtime ZIP extraction owns this tree. Still avoid following links if an
+    // installed directory is replaced or modified before validation.
+    if (!entry.isSymbolicLink() && entry.isDirectory()) {
+      pending.push(path.join(dir, entry.name));
+    }
+  }
+  return false;
 }
 
 /** @param {string} runtimeDir */

--- a/tests/llamaRuntimeArchiveOwnership.test.ts
+++ b/tests/llamaRuntimeArchiveOwnership.test.ts
@@ -66,6 +66,14 @@ const TEST_RUNTIME: RuntimeDescriptor = {
   requiredFiles: ["llama-server.exe", "ggml-vulkan.dll"],
 };
 
+const TEST_ROCM_RUNTIME: RuntimeDescriptor = {
+  id: "test-rocm-runtime",
+  kind: "test",
+  backend: "rocm",
+  dir: "test-rocm-runtime",
+  requiredFiles: ["llama-server.exe", "ggml-hip.dll"],
+};
+
 describe("llama runtime archive ownership", () => {
   it("publishes only the claimed archive when the public cache path is swapped", async () => {
     const root = await mkdtemp(join(tmpdir(), "mgt-llama-owned-"));
@@ -140,6 +148,55 @@ describe("llama runtime archive ownership", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("publishes ROCm archives with kernel libraries in architecture subdirectories", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mgt-llama-nested-rocm-"));
+    const archivePath = join(root, "runtime.zip");
+    const runtimeDir = join(root, "installed-runtime");
+    await writeNestedRocmRuntimeZip(archivePath);
+    const archive = await describeRuntimeArchive(archivePath);
+    const ownership = await claimRuntimeArchivePaths([archivePath]);
+
+    try {
+      const verified = await verifyRuntimeArchiveChecksums(
+        ownership.archivePaths,
+        [archive],
+      );
+      await extractRuntimeArchives(
+        runtimeDir,
+        verified,
+        TEST_ROCM_RUNTIME,
+        {},
+        ownership.restore,
+      );
+
+      await expect(
+        access(
+          join(
+            runtimeDir,
+            "rocblas",
+            "library",
+            "gfx908",
+            "TensileLibrary_gfx908.dat",
+          ),
+        ),
+      ).resolves.toBeUndefined();
+      await expect(
+        access(
+          join(
+            runtimeDir,
+            "hipblaslt",
+            "library",
+            "gfx908",
+            "Kernels-gfx908.hsaco",
+          ),
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      await ownership.restore();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 async function describeRuntimeArchive(
@@ -159,6 +216,22 @@ async function writeRuntimeZip(
   const zip = new yazl.ZipFile();
   zip.addBuffer(Buffer.from(`${content}-server`), "llama-server.exe");
   zip.addBuffer(Buffer.from(`${content}-backend`), "ggml-vulkan.dll");
+  zip.end();
+  await pipeline(zip.outputStream, createWriteStream(archivePath));
+}
+
+async function writeNestedRocmRuntimeZip(archivePath: string): Promise<void> {
+  const zip = new yazl.ZipFile();
+  zip.addBuffer(Buffer.from("trusted-server"), "llama-server.exe");
+  zip.addBuffer(Buffer.from("trusted-backend"), "ggml-hip.dll");
+  zip.addBuffer(
+    Buffer.from("trusted-rocblas-kernel"),
+    "rocblas/library/gfx908/TensileLibrary_gfx908.dat",
+  );
+  zip.addBuffer(
+    Buffer.from("trusted-hipblaslt-kernel"),
+    "hipblaslt/library/gfx908/Kernels-gfx908.hsaco",
+  );
   zip.end();
   await pipeline(zip.outputStream, createWriteStream(archivePath));
 }

--- a/tests/llamaRuntimePaths.test.ts
+++ b/tests/llamaRuntimePaths.test.ts
@@ -776,6 +776,93 @@ describe("llama runtime path selection", () => {
     }
   });
 
+  it("accepts the audited kernel directory layouts from all pinned ROCm archives", () => {
+    const layouts = [
+      {
+        target: "gfx103X",
+        rocblasDirectories: [""],
+        hipblasltDirectories: ["gfx1100"],
+      },
+      {
+        target: "gfx110X",
+        rocblasDirectories: [""],
+        hipblasltDirectories: [""],
+      },
+      {
+        target: "gfx1150",
+        rocblasDirectories: ["gfx1150"],
+        hipblasltDirectories: ["", "gfx1150"],
+      },
+      {
+        target: "gfx1151",
+        rocblasDirectories: ["gfx1151"],
+        hipblasltDirectories: ["", "gfx1151"],
+      },
+      {
+        target: "gfx120X",
+        rocblasDirectories: [""],
+        hipblasltDirectories: [""],
+      },
+      {
+        target: "gfx908",
+        rocblasDirectories: ["gfx908"],
+        hipblasltDirectories: ["", "gfx908"],
+      },
+      {
+        target: "gfx90a",
+        rocblasDirectories: ["gfx90a"],
+        hipblasltDirectories: ["", "gfx90a"],
+      },
+    ] as const;
+
+    for (const layout of layouts) {
+      const runtime = resolvePreferredLlamaRuntime({
+        llamaRuntimeProfile: "rocm",
+        llamaRocmTarget: layout.target,
+        modelRepo: GEMMA_26B_MODEL_REPO,
+        modelFile: GEMMA_26B_MODEL_FILE_IQ3_S,
+      });
+      const runtimeDir = mkdtempSync(
+        join(tmpdir(), `mgt-rocm-${layout.target.toLowerCase()}-`),
+      );
+      try {
+        for (const requirement of runtime.requiredFiles) {
+          const fileName = Array.isArray(requirement)
+            ? requirement[0]
+            : requirement;
+          writeFileSync(join(runtimeDir, fileName), "");
+        }
+        for (const [library, directories, extension] of [
+          ["rocblas", layout.rocblasDirectories, "dat"],
+          ["hipblaslt", layout.hipblasltDirectories, "hsaco"],
+        ] as const) {
+          directories.forEach((directory, index) => {
+            const libraryDir = join(runtimeDir, library, "library", directory);
+            mkdirSync(libraryDir, { recursive: true });
+            writeFileSync(
+              join(
+                libraryDir,
+                `${library}-${layout.target}-${index}.${extension}`,
+              ),
+              "",
+            );
+          });
+        }
+
+        expect(
+          missingRequiredLlamaRuntimeFiles(runtimeDir, runtime),
+          layout.target,
+        ).toEqual([]);
+        expect(
+          hasRequiredLlamaRuntimeFiles(runtimeDir, runtime),
+          layout.target,
+        ).toBe(true);
+      } finally {
+        rmSync(runtimeDir, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("rejects ROCm runtimes that are missing extracted kernel libraries", () => {
     const runtime = resolvePreferredLlamaRuntime({
       llamaRuntimeProfile: "rocm",
@@ -787,6 +874,9 @@ describe("llama runtime path selection", () => {
       join(tmpdir(), "mgt-rocm-runtime-missing-kernels-"),
     );
     try {
+      const nonKernelDir = join(runtimeDir, "rocblas", "library", "gfx-test");
+      mkdirSync(nonKernelDir, { recursive: true });
+      writeFileSync(join(nonKernelDir, "README.txt"), "not a kernel");
       for (const fileName of [
         "llama-server.exe",
         "llama-server-impl.dll",

--- a/tests/productionCleanupCoverageGate.test.ts
+++ b/tests/productionCleanupCoverageGate.test.ts
@@ -426,7 +426,7 @@ describe("production cleanup coverage floor gate", () => {
     expect(Object.keys(manifest.floors)).toEqual(scope.existing);
     expect(Object.keys(manifest.introducedFloors)).toEqual(scope.added);
     expect(manifest.deletedFiles).toEqual(scope.deleted);
-    expect(scope.existing).toHaveLength(123);
+    expect(scope.existing).toHaveLength(124);
     expect(scope.added).toHaveLength(22);
     expect(scope.deleted).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

- validate ROCm kernel libraries recursively below `rocblas/library` and `hipblaslt/library`
- keep validation fail-closed with a 4,096-directory scan bound and no symbolic-link traversal
- add extraction/install regression coverage plus the audited layouts of all seven pinned Windows ROCm archives

## Pinned archive audit

The old direct-child-only validator rejected five current assets:

| Target | rocBLAS layout | hipBLASLt layout | Old result |
| --- | --- | --- | --- |
| gfx103X | direct | nested `gfx1100/` | fail |
| gfx110X | direct | direct | pass |
| gfx1150 | nested `gfx1150/` | direct + nested | fail |
| gfx1151 | nested `gfx1151/` | direct + nested | fail |
| gfx120X | direct | direct | pass |
| gfx908 | nested `gfx908/` | direct + nested | fail |
| gfx90a | nested `gfx90a/` | direct + nested | fail |

## Verification

- `npm run check`: 481 test files; 3,559 passed, 2 skipped
- production build, renderer/preload bundle guards, image-protocol smoke, and page-artwork pixel parity passed (0 mismatched pixels)
- downloaded the exact pinned `llama-b1291-windows-rocm-gfx103X-x64.zip`
  - 160,723,690 bytes
  - SHA-256 `3692a765ca0d5616284cbfe71c0a8a925824a538e9fe0efeb8710620612ecf77`
- installed it through the production extraction path: 406 rocBLAS kernels, 98 nested hipBLASLt kernels, zero missing files

Closes #67